### PR TITLE
Updated testDB.json to make LNGS tutorial work. Changed string splitting in calculators.py

### DIFF
--- a/experiments/example/testDB.json
+++ b/experiments/example/testDB.json
@@ -36,7 +36,7 @@
         "current" : {"wfin":"wf_blsub", "wfout":"wf_current", "sigma":5},
         "get_max" : [
             {"wfin":"wf_etrap"}, {"wfin":"wf_atrap"}, {"wfin":"wf_current"},
-            {"wfin":"wf_savgol"}
+            {"wfin":"wf_savgol"},{"wfin":"wf_blsub"}
         ],
         "ftp" : {},
         "timepoint" : {"wfin":"wf_blsub", "pct":[5,10,50,100]},

--- a/pygama/dsp/calculators.py
+++ b/pygama/dsp/calculators.py
@@ -141,7 +141,7 @@ def get_max(waves, calcs, wfin="wf_trap", calc="trap_max", test=False):
 
     maxes = np.amax(wfs, axis=1)
     imaxes = np.argmax(wfs, axis=1)
-
+    
     cname = wfin.split("_")[-1]
     calcs["{}_max".format(cname)] = maxes
     calcs["{}_imax".format(cname)] = imaxes
@@ -181,7 +181,7 @@ def timepoint(waves, calcs, pct, wfin="wf_savgol", calc="tp", test=False):
     for an estimate of where the wf tail starts, just use pct = 100 + (delta).
     """
     wfs = waves[wfin]
-    max = wfin.split('_')[1] + "_max"
+    max = wfin.split('_')[-1] + "_max"
     smax = calcs[max].values
 
     for p in pct:

--- a/pygama/dsp/calculators.py
+++ b/pygama/dsp/calculators.py
@@ -253,7 +253,7 @@ def ftp(waves, calcs, wf1="wf_etrap", wf2="wf_atrap", test=False):
     # this is less dependent on the trap's baseline noise.
     # Majorana uses a threshold of 2 ADC, hardcoded.
     thresh = 2
-    short = wf2.split("_")[1]
+    short = wf2.split("_")[-1]
     t0 = np.zeros(wfshort.shape[0], dtype=int)
 
     # print("WFSHAPE",wfshort.shape, short)


### PR DESCRIPTION
Changed the testDB.json to make the LNGS tutorial work (blsub_max was not generated).
In calculator.py I unified the string splitting in the get_max(), timepoint() and ftp() functions. If there would be more than one underscore the created tag in get_max() would differ from the requested ones.