### PR TITLE
fix 3302 timestamp bug

### DIFF
--- a/experiments/oppi/processing.py
+++ b/experiments/oppi/processing.py
@@ -52,11 +52,12 @@ def main():
 
     if args.d2r: d2r(dg, args.over, nwfs, args.verbose)
     if args.r2d: r2d(dg, args.over, nwfs, args.verbose)
+    
     if args.r2d_file:
         f_raw, f_dsp = args.r2d_file
         r2d_file(f_raw, f_dsp, args.over, nwfs, args.verbose)
-
-
+        
+    
 def load_datagroup():
     """
     """
@@ -66,10 +67,10 @@ def load_datagroup():
     # various filters can go here
 
     # que = 'run==0'
-    # que = 'cycle == 2158'
-    # dg.file_keys.query(que, inplace=True)
+    que = 'cycle == 2180'
+    dg.file_keys.query(que, inplace=True)
     # dg.file_keys = dg.file_keys[:1]
-
+    
     print('files to process:')
     print(dg.file_keys)
 
@@ -92,7 +93,8 @@ def d2r(dg, overwrite=False, nwfs=None, vrb=False):
     for i, row in dg.file_keys.iterrows():
 
         f_daq = f"{dg.daq_dir}/{row['daq_dir']}/{row['daq_file']}"
-        f_raw = f"{dg.lh5_dir}/{row['raw_path']}/{row['raw_file']}"
+        # f_raw = f"{dg.lh5_dir}/{row['raw_path']}/{row['raw_file']}"
+        f_raw = 'test.lh5'
         subrun = row['cycle'] if 'cycle' in row else None
 
         if not overwrite and os.path.exists(f_raw):

--- a/experiments/oppi/ts_wrap.py
+++ b/experiments/oppi/ts_wrap.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+import numpy as np
+import pygama.io.lh5 as lh5
+import matplotlib.pyplot as plt
+
+# show how to correct for timestamp rollover with the struck 3302,
+# and how to calculate the run duration using the dsp file (fastest).
+
+f_dsp = '/Users/wisecg/Data/OPPI/dsp/oppi_run9_cyc2180_dsp.lh5'
+# f_raw = '/data/eliza1/LEGEND/LH5/oppi/raw/oppi_run9_cyc2180_raw.lh5'
+f_raw = 'test.lh5'
+
+sto = lh5.Store()
+# groups = sto.ls(f_dsp)
+# data = sto.read_object('ORSIS3302DecoderForEnergy/raw', f_dsp)
+# print(data.keys())
+
+# groups = sto.ls(f_raw, 'ORSIS3302DecoderForEnergy/raw/')
+data = sto.read_object('ORSIS3302DecoderForEnergy/raw/timestamp', f_raw)
+ts = data.nda
+
+# exit()
+# wtfffff
+# hitE = data['trapEmax'].nda
+# ts = data['timestamp'].nda
+# ts = np.sort(ts)
+# print(hitE[:10])
+for i in range(10000):
+    print(i, ts[i])
+
+# plt.semilogy(np.arange(len(ts)), ts, '.')
+# plt.show()

--- a/pygama/io/orca_digitizers.py
+++ b/pygama/io/orca_digitizers.py
@@ -27,7 +27,7 @@ class ORCAStruck3302(OrcaDecoder):
               'dtype': 'uint32',
             },
             'timestamp': {
-              'dtype': 'uint64',
+              'dtype': 'uint32',
               'units': 'clock_ticks',
             },
             'crate': {
@@ -116,7 +116,7 @@ class ORCAStruck3302(OrcaDecoder):
         wf_length32 = p32[1]
         ene_wf_length32 = p32[2]
         evt_header_id = p32[3] & 0xFF
-        tb['timestamp'].nda[ii] = ((p32[3] >> 16) & 0xFFFF) << 32 + p32[4]
+        tb['timestamp'].nda[ii] = p32[4] + ((p32[3] >> 16) & 0xFFFF)
         last_word = p32[-1]
 
         # get the footer


### PR DESCRIPTION
@jasondet I had to change the 3302 timestamp dtype to uint32, and the timestamp line from:
`tb['timestamp'].nda[ii] = ((p32[3] >> 16) & 0xFFFF) << 32 + p32[4]`

to this:
`tb['timestamp'].nda[ii] = p32[4] + ((p32[3] >> 16) & 0xFFFF)`
