### PR TITLE
Improvements related to lpgta/processing.py.

### DIFF
--- a/experiments/lpgta/processing.py
+++ b/experiments/lpgta/processing.py
@@ -31,8 +31,8 @@ def main():
 
     # declare datagroup
     arg('--dg', action=st, help='load datagroup')
-    arg('--q', type=str, help='datagroup query')
-    arg('--date', type=str, help='date query')
+    arg('--q', type=str, help='datagroup query (AND-ed with the date query)')
+    arg('--date', type=str, help='date query (AND-ed with the datagroup query)')
 
     # routines
     arg('--d2r', action=st, help='run daq_to_raw')
@@ -47,6 +47,10 @@ def main():
     arg('-c', '--cwd', action=st, help="save output to current directory")
     args = par.parse_args()
 
+    # print out the arguments for log files
+    if args.verbose:
+        print('Arguments:', args)
+
     # -- set options --
     nwfs = args.nwfs if args.nwfs is not None else np.inf
 
@@ -58,7 +62,9 @@ def main():
 
     # -- run routines --
     query = "YYYYmmdd == '" + args.date + "'" if args.date else args.q
-    if args.dg: dg = load_datagroup(query)
+    if args.date and args.q:
+        query += ' and ' + args.q
+    if args.dg or args.d2r or args.r2d: dg = load_datagroup(query)
     if args.d2r: d2r(dg, args.over, nwfs, args.verbose, args.cwd)
     if args.r2d: r2d(dg, args.over, nwfs, args.verbose, args.cwd, args.bl, args.bw)
 

--- a/pygama/io/daq_to_raw.py
+++ b/pygama/io/daq_to_raw.py
@@ -13,13 +13,13 @@ from ..io.compassdaq import *
 from ..io.fcdaq import *
 
 
-def daq_to_raw(daq_filename, raw_file_pattern=None, subrun=None, systems=None, 
+def daq_to_raw(daq_filename, raw_file_pattern=None, subrun=None, systems=None,
                n_max=np.inf, verbose=False, out_dir=None, chans=None,
                overwrite=True, config={}):
     """
-    Convert DAQ files into LEGEND-HDF5 `raw` format.  
+    Convert DAQ files into LEGEND-HDF5 `raw` format.
     Takes an input file (daq_filename) and an output file (raw_file_pattern).
-    
+
     If the list `systems` is supplied, the raw_file_pattern should be a string
     containing `{sysn}`, which is used to create a list of output files for
     each data taker.
@@ -32,7 +32,7 @@ def daq_to_raw(daq_filename, raw_file_pattern=None, subrun=None, systems=None,
     # convert any environment variables
     daq_filename = os.path.expandvars(daq_filename)
     raw_file_pattern = os.path.expandvars(raw_file_pattern)
-    
+
     # load options from config (can be dict or JSON filename)
     if isinstance(config, str):
         with open(os.path.expandvars(config)) as f:
@@ -56,15 +56,15 @@ def daq_to_raw(daq_filename, raw_file_pattern=None, subrun=None, systems=None,
         raw_files = {sysn: raw_file_pattern.replace('{sysn}', sysn) for sysn in systems}
     else:
         raw_files = {'default': raw_file_pattern}
-        
+
     # clear existing output files
     if overwrite:
         for sysn, file in raw_files.items():
             if os.path.isfile(file):
                 if verbose:
-                    print('Overwriting existing file :', file)
+                    print('Overwriting existing file:', file)
                 os.remove(file)
-    
+
     # if verbose:
     print('Starting daq_to_raw processing.'
           f'\n  Buffer size: {buffer_size}'
@@ -72,14 +72,14 @@ def daq_to_raw(daq_filename, raw_file_pattern=None, subrun=None, systems=None,
           f'\n  Cycle (subrun) num: {subrun}'
           f'\n  Input: {daq_filename}\n  Output:')
     pprint(raw_files)
-    
+
     t_start = time.time()
     bytes_processed = None
 
 
     ch_groups_dict = None
     if 'ch_groups' in d2r_conf: ch_groups_dict = d2r_conf['ch_groups']
-    
+
     # get the DAQ mode
     if config['daq'] == 'ORCA':
         print('note, remove decoder input option')
@@ -112,5 +112,5 @@ def daq_to_raw(daq_filename, raw_file_pattern=None, subrun=None, systems=None,
     else:
         print('Total converted: {}'.format(sizeof_fmt(bytes_processed)))
         print('Conversion speed: {}ps'.format(sizeof_fmt(bytes_processed/elapsed)))
-    
+
     print('Done.\n')

--- a/pygama/io/raw_to_dsp.py
+++ b/pygama/io/raw_to_dsp.py
@@ -19,7 +19,7 @@ import pygama.git as git
 from pygama.dsp.build_processing_chain import *
 
 def raw_to_dsp(f_raw, f_dsp, dsp_config, lh5_tables=None, database=None,
-               outputs=None, n_max=np.inf, overwrite=True, buffer_len=3200, 
+               outputs=None, n_max=np.inf, overwrite=True, buffer_len=3200,
                block_width=16, verbose=1):
     """
     Uses the ProcessingChain class.
@@ -30,7 +30,7 @@ def raw_to_dsp(f_raw, f_dsp, dsp_config, lh5_tables=None, database=None,
     if isinstance(dsp_config, str):
         with open(dsp_config, 'r') as config_file:
             dsp_config = json.load(config_file, object_pairs_hook=OrderedDict)
-    
+
     if not isinstance(dsp_config, dict):
         raise Exception('Error, dsp_config must be an dict')
 
@@ -53,7 +53,7 @@ def raw_to_dsp(f_raw, f_dsp, dsp_config, lh5_tables=None, database=None,
                 if "raw" in tbname:
                     tb = tb +'/'+ tbname # g024 + /raw
             lh5_tables.append(tb)
-    
+
     # make sure every group points to waveforms, if not, remove the group
     for tb in lh5_tables:
         if 'raw' not in tb:
@@ -71,14 +71,14 @@ def raw_to_dsp(f_raw, f_dsp, dsp_config, lh5_tables=None, database=None,
     if database and not isinstance(database, dict):
         database = None
         print('database is not a valid json file or dict. Using default db values.')
-    
-    # delete the old file. TODO: ONCE BUGS ARE FIXED IN LH5 MODULE, DO THIS ONLY IF OVERWRITE IS TRUE!
-    try:
-        os.remove(f_dsp)
-        print("Deleted", f_dsp)
-    except:
-        pass
-    
+
+    # clear existing output files
+    if overwrite:
+        if os.path.isfile(f_dsp):
+            if verbose:
+                print('Overwriting existing file:', f_dsp)
+            os.remove(f_dsp)
+
     for tb in lh5_tables:
         # load primary table and build processing chain and output table
         tot_n_rows = raw_store.read_n_rows(tb, f_raw)
@@ -88,7 +88,7 @@ def raw_to_dsp(f_raw, f_dsp, dsp_config, lh5_tables=None, database=None,
         db_dict = database.get(chan_name) if database else None
         lh5_in, n_rows_read = raw_store.read_object(tb, f_raw, start_row=0, n_rows=buffer_len)
         pc, tb_out = build_processing_chain(lh5_in, dsp_config, db_dict, outputs, verbose, block_width)
-        
+
         print(f'Processing table: {tb} ...')
         for start_row in range(0, tot_n_rows, buffer_len):
             if verbose > 0:
@@ -97,7 +97,7 @@ def raw_to_dsp(f_raw, f_dsp, dsp_config, lh5_tables=None, database=None,
             n_rows = min(tot_n_rows-start_row, n_rows)
             pc.execute(0, n_rows)
             raw_store.write_object(tb_out, tb.replace('/raw', '/dsp'), f_dsp, n_rows=n_rows)
-            
+
         if verbose > 0:
             update_progress(1)
         print(f'Done.  Writing to file {f_dsp}')
@@ -125,18 +125,18 @@ if __name__=="__main__":
     parser = argparse.ArgumentParser(description=
 """Process a single tier 1 LH5 file and produce a tier 2 LH5 file using a
 json config file and raw_to_dsp.""")
-    
+
     arg = parser.add_argument
     arg('file', help="Input (tier 1) LH5 file.")
     arg('-o', '--output',
         help="Name of output file. By default, output to ./t2_[input file name].")
-    
+
     arg('-v', '--verbose', default=1, type=int,
         help="Verbosity level: 0=silent, 1=basic warnings, 2=verbose output, 3=debug. Default is 2.")
-    
+
     arg('-b', '--block', default=16, type=int,
         help="Number of waveforms to process simultaneously. Default is 8")
-    
+
     arg('-c', '--chunk', default=3200, type=int,
         help="Number of waveforms to read from disk at a time. Default is 256. THIS IS NOT IMPLEMENTED YET!")
     arg('-n', '--nevents', default=None, type=int,


### PR DESCRIPTION
I made some general improvements related to lpgta/processing.py:

- The `overwrite` argument in raw_to_dsp.py now controls whether or not to delete the dsp file before processing the raw file.  Previously, this argument was unused.
- The --date option in lpgta/processing.py is now AND-ed with the --q option in order to come up with the query that is passed to the `load_datagroup` function.  Previously, the --date option would override the --q option.
- The `load_datagroup` function is now run whenever the --d2r and/or --r2d option is used even when the --dg option is not used.  Previously, this was an implicit requirement.  The --dg option is retained because it is useful for testing out different queries and seeing what files would be processed without actually processing them.
- The arguments used in processing.py is now printed out when `verbose` is True.  This will allow us to record the exact configuration used to a log file when processing the data.