### PR TITLE
Updated the dtype of the dead-region variables in fcdaq.py.

### DIFF
--- a/pygama/io/fcdaq.py
+++ b/pygama/io/fcdaq.py
@@ -80,22 +80,22 @@ class FlashCamEventDecoder(DataDecoder):
               'dtype': 'int32',
             },
             'dr_start_pps': { # start pps of the next dead window
-              'dtype': 'float32',
+              'dtype': 'int32',
             },
             'dr_start_ticks': { # start ticks of the next dead window
-              'dtype': 'float32',
+              'dtype': 'int32',
             },
             'dr_stop_pps': { # stop pps of the next dead window
-              'dtype': 'float32',
+              'dtype': 'int32',
             },
             'dr_stop_ticks': { # stop ticks of the next dead window
-              'dtype': 'float32',
+              'dtype': 'int32',
             },
             'dr_maxticks': { # maxticks of the dead window
-              'dtype': 'float32',
+              'dtype': 'int32',
             },
             'deadtime': { # current dead time calculated from deadregion (dr) fields. Give the total dead time if summed up.
-              'dtype': 'float32',
+              'dtype': 'float64',
             },
             'wf_max': { # ultra-simple np.max energy estimation
               'dtype': 'uint16',


### PR DESCRIPTION
The dtypes have been updated in fcdaq.py for the dead-region variables:
- `dr_start_pps`
- `dr_stop_ticks`
- `dr_stop_pps`
- `dr_stop_ticks`
- `dr_maxticks`
- `deadtime`

These dtypes now reflect those of the time-stamp variables.  I see no reason why the dead-region should differ from the time-stamp variables.  In particular, the pps, ticks, and maxticks variables' dtypes are now int's, which is also what they are in pyfcutils.  The deadtime variable's dtype is now float64.

@Kermaidy, could you please confirm that these updates are reasonable?