### PR TITLE
GitHub actions: do not build documentation in pull request builds

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,34 @@
+name: pygama
+
+on:
+  push:
+    branches:
+      - master
+      - dev
+      - 'releases/**'
+    tags: '*'
+  release:
+
+jobs:
+
+  deploy-docs:
+    name: Deploy documentation on legend-exp.github.io/pygama
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      - name: Build with Sphinx
+        run: |
+          .github/workflows/get-dependencies.sh
+          pip install .
+          pip install sphinx sphinx-rtd-theme
+          cd docs
+          make clean
+          make html
+      - name: Deploy to GitHub pages
+        uses: JamesIves/github-pages-deploy-action@4.1.0
+        with:
+          branch: gh-pages
+          folder: docs/build/html

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,11 +2,13 @@ name: pygama
 
 on:
   push:
-    paths-ignore:
-      - '**.md'
+    branches:
+      - master
+      - dev
+      - 'releases/**'
+    tags: '*'
   pull_request:
-    paths-ignore:
-      - '**.md'
+  release:
 
 jobs:
 
@@ -41,25 +43,3 @@ jobs:
     - uses: actions/checkout@v2
     - name: Run unit tests
       run: pip install .
-
-  deploy-docs:
-    name: Deploy documentation on legend-exp.github.io/pygama
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
-      - name: Build with Sphinx
-        run: |
-          .github/workflows/get-dependencies.sh
-          pip install .
-          pip install sphinx sphinx-rtd-theme
-          cd docs
-          make clean
-          make html
-      - name: Deploy to GitHub pages
-        uses: JamesIves/github-pages-deploy-action@4.1.0
-        with:
-          branch: gh-pages
-          folder: docs/build/html


### PR DESCRIPTION
I realized that the GitHub bot tries to push docs to the website even for not-yet-merged PRs, which does not make sense and fails for unprivileged users (see #164 and #165). This PR should do the job. I also moved the docs stuff to a separate config file for convenience.