### PR TITLE
Fixed bug when using h5py._hl.files.File in read_object

### DIFF
--- a/pygama/lh5/store.py
+++ b/pygama/lh5/store.py
@@ -141,7 +141,7 @@ class Store:
         #          proc.execute()
 
         # Handle list-of-files recursively
-        if not isinstance(lh5_file, str):
+        if not isinstance(lh5_file, (str, h5py._hl.files.File)):
             lh5_file = list(lh5_file)
             n_rows_read = 0
             for i, h5f in enumerate(lh5_file):


### PR DESCRIPTION
This change fixes a bug introduced in commit https://github.com/legend-exp/pygama/commit/96eb1602ca53255ef7c8c54a68fe415792abf90d.

In store.py, when a `h5py._hl.files.File` object is passed into the `read_object` function as the `lh5_file` argument, it will pass the if-statement modified in the aforementioned commit.  As a result, `lh5_file = list(lh5_file)` is executed, which turns `lh5_file` into a list of its keys.  For example:

```
>>> import sys
>>> sys.version
'3.8.5 (default, Sep  4 2020, 07:30:14) \n[GCC 7.3.0]'
>>> import h5py
>>> h5py.__version__
'3.3.0'
>>> f = h5py.File('LPGTA_r0033_20200819T184210Z_calib_geds_raw.lh5', 'r')
>>> type(f)
<class 'h5py._hl.files.File'>
>>> list(f)
['g024', 'g025', 'g026', 'g028', 'g029', 'g030', 'g031', 'g032', 'g033', 'g034', 'g035', 'g037', 'g038', 'g039', 'g040']
```

The code will then proceed to look for a file called "g024" and subsequently throw an error because it, of course, does not exist.  My fix adds an exception for `h5py._hl.files.File` objects as is already done for `str` objects.  This should preserve the point of the aforementioned commit.

Note that this situation occurs when, for instance, the `datatype` attribute of the group is a `table`.  For a more concrete example, without this fix, the following command will fail:

```
waveform, _ = store.read_object('g024/raw/waveform', lh5_file)
```
