### PR TITLE
Removed checks of negative pole-zero inputs

### DIFF
--- a/pygama/dsp/_processors/pole_zero.py
+++ b/pygama/dsp/_processors/pole_zero.py
@@ -36,9 +36,6 @@ def pole_zero(w_in, t_tau, w_out):
     if (np.isnan(w_in).any() or np.isnan(t_tau)):
         return
 
-    if (not t_tau > 0):
-        raise DSPFatal('t_tau is out of range, must be >= 0')
-
     const = np.exp(-1/t_tau)
     w_out[0] = w_in[0]
     for i in range(1, len(w_in)):
@@ -83,13 +80,6 @@ def double_pole_zero(w_in, t_tau1, t_tau2, frac, w_out):
 
     if (np.isnan(w_in).any() or np.isnan(t_tau1) or np.isnan(t_tau2) or np.isnan(frac)):
         return
-
-    if (not t_tau1 > 0):
-        raise DSPFatal('t_tau1 is out of range, must be >= 0')
-    if (not t_tau2 > 0):
-        raise DSPFatal('t_tau2 is out of range, must be >= 0')
-    if (not frac >= 0):
-        raise DSPFatal('frac is out of range, must be >= 0')
 
     const1 = 1/t_tau1 #np.exp(-1/t_tau1)
     const2 = 1/t_tau2 #np.exp(-1/t_tau2)


### PR DESCRIPTION
This change removes the checks of negative input arguments in the `pole_zero` and `double_pole_zero` functions, which were introduced in commit https://github.com/legend-exp/pygama/commit/c265422d0d236f0a7773a9faf54249ef8ae70ef0.

In the aforementioned commit, a negative input time constant—or, in the case of the double pole-zero function, fraction—is treated as a fatal error, stopping the processing.  While a negative time constant may not make much sense for our waveforms, it is not a fatal error in the sense that the functions will successfully execute with such negative input.

In addition, a user may want to optimize the pole-zero input parameters using a minimizer such as that in `iminuit`—as I have been doing.  In this case, the minimizer may naturally want to sample some negative parameter values as it finds its way down to the minimum (assuming no parameter bounds are used).

A warning may be more appropriate if the original idea was to alert the user to a possible problem in the DSP routine.  However, it would be good to control such output with a verbosity flag, which creates an added—and possibly unnecessary—complication to setting up the arguments via the `ProcessingChain` class.