### PR TITLE
Fixed the signature for time_point_thresh

### DIFF
--- a/pygama/dsp/_processors/time_point_thresh.py
+++ b/pygama/dsp/_processors/time_point_thresh.py
@@ -3,8 +3,8 @@ from numba import guvectorize
 import math
 from pygama.dsp.errors import DSPFatal
 
-@guvectorize(["void(float32[:], float32, float32, int32 ,float32[:])",
-              "void(float64[:], float64, float32, int32 ,float32[:])"],
+@guvectorize(["void(float32[:], float32, int32, int32 ,float32[:])",
+              "void(float64[:], float64, int32, int32 ,float32[:])"],
              "(n),(),(),()->()", nopython=True, cache=True)
 
 def time_point_thresh(w_in, a_threshold, t_start, walk_forward, t_out):


### PR DESCRIPTION
This change fixes a bug in time_point_thresh.py—which was introduced in commit 47e6dbe49afd301cdfe4ad504ffff9fcd6cd331e—so that an integer can now be passed in as the `t_start` argument.

`float32` is changed to `int32` for the `t_start` argument in the signature—as it was before the aforementioned commit.  Otherwise, if an integer—say, the output variable from a processor running `numpy.argmax`—is passed in, it throws a `pygama.dsp.errors.ProcessingChainError` similar to:

```
pygama.dsp.errors.ProcessingChainError: Could not find a type signature matching the types of the variables given for time_point_thresh('wf_af', '0', 'tp_max', '0', 'tp_00')
wf_af: float32
tp_max: int32
```

This assumption that `t_start` is an integer is clear by its enforcement through checks and type casting already in the body of the function.  Nonetheless, if someone is indeed trying to input a float (with an integer value) as `t_start` in their processing chain, it seems to be better for them to type cast it in their JSON configuration, such as in

```
"tp_00": {
    "function": "time_point_thresh",
    "module": "pygama.dsp.processors",
    "args": ["wf_af", "0", "int(tp_max)", "0", "tp_00"],
    "unit": "ns",
    "prereqs": ["wf_af", "tp_max"]
}
```

than the other way around with `float(tp_max)`.  This is because the latter would be simply increasing the memory of the variable just to ignore it in the function.