### PR TITLE
Speedup in store.read_object

### DIFF
--- a/pygama/lh5/store.py
+++ b/pygama/lh5/store.py
@@ -458,7 +458,7 @@ class Store:
                 if n_rows == 0: 
                     tmp_shape = (0,) + h5f[name].shape[1:]
                     nda = np.empty(tmp_shape, h5f[name].dtype)
-                else: nda = h5f[name][source_sel]
+                else: nda = h5f[name][:][source_sel]
 
             # special handling for bools
             if elements == 'bool': nda = nda.astype(np.bool)


### PR DESCRIPTION
Sam Borden recently found that the `read_object` function can be much slower to read in a dataset as compared to when using h5py directly.  I found that the slowdown occurs on line 461:
https://github.com/legend-exp/pygama/blob/c8e9640b1632fd149d2df1cb0681c3cb56674e04/pygama/lh5/store.py#L461
when the `idx` argument passed into `read_object` is not `None`.  This slowdown goes away when `h5f[name][source_sel]` is changed to `h5f[name][:][source_sel]`.

Here's a minimal example that illustrates the slowdown.  The first method reads in a dataset directly using h5py and selects the waveforms that are from channel 21.  The second method uses `read_object` to read in the entire dataset and, afterward, selects the waveforms from channel 21.  The third method uses `read_object` with its optional `idx` argument to read in only those waveforms from channel 21.

```python
# import python modules
import h5py
import numpy as np
import time
import pygama.lh5 as lh5

# the file to analyze
file_raw = '/global/project/projectdirs/legend/data/lngs/pgt/raw/spms/LPGTA_r0028_20200706T130148Z_phys_spms_raw.lh5'

#
# method 1
# 
start = time.perf_counter()
f = h5py.File(file_raw, 'r')
channel = f['spms/raw/channel'][:]
waveform = f['spms/raw/waveform/values'][:]
channel_waveform = waveform[channel == 21]
print(channel_waveform[0])
stop = time.perf_counter() 
print(f'time to run (in seconds) using method 1: {stop - start}\n')

#
# method 2
# 
start = time.perf_counter()
store = lh5.Store()
channel, _ = store.read_object(f'spms/raw/channel', file_raw)
idx = np.where(channel.nda == 21)[0]
waveform, _ = store.read_object(f'spms/raw/waveform/values', file_raw)
channel_waveform = waveform.nda[idx]
print(channel_waveform[0])
stop = time.perf_counter()
print(f'time to run (in seconds) using method 2: {stop - start}\n')

#
# method 3
# 
start = time.perf_counter()
store = lh5.Store()
channel, _ = store.read_object(f'spms/raw/channel', file_raw)
idx = np.where(channel.nda == 21)[0]
waveform, _ = store.read_object(f'spms/raw/waveform/values', file_raw, idx=idx)
channel_waveform = waveform.nda
print(channel_waveform[0])
stop = time.perf_counter()
print(f'time to run (in seconds) using method 3: {stop - start}\n')
```

With `nda = h5f[name][source_sel]`, the output is:
```
$ python example.py 
[10045 10045 10039 ... 10042 10034 10045]
time to run (in seconds) using method 1: 3.080850976984948

[10045 10045 10039 ... 10042 10034 10045]
time to run (in seconds) using method 2: 3.1202140897512436

[10045 10045 10039 ... 10042 10034 10045]
time to run (in seconds) using method 3: 572.9645688659512

```

With `nda = h5f[name][:][source_sel]`, the output is:
```
$ python example.py 
[10045 10045 10039 ... 10042 10034 10045]
time to run (in seconds) using method 1: 3.1797321611084044

[10045 10045 10039 ... 10042 10034 10045]
time to run (in seconds) using method 2: 3.2095718439668417

[10045 10045 10039 ... 10042 10034 10045]
time to run (in seconds) using method 3: 2.994779756758362

```

As you can see, this fix makes the processing time for the third method consistent with that for the other two methods.  Further, the waveforms that are read in from all three methods appear to be the same.  In the above output, for instance, the first waveform read in is printed out and is the same for all of the methods.  This speed up is also found when reading in germanium PGT data using the analysis code on the "exp-lpgta" branch.