### PR TITLE
Processor cleanup

### DIFF
--- a/pygama/dsp/_processors/bl_subtract.py
+++ b/pygama/dsp/_processors/bl_subtract.py
@@ -2,39 +2,35 @@ import numpy as np
 from numba import guvectorize
 from pygama.dsp.errors import DSPFatal
 
-@guvectorize(["void(float32[:], uint16, float32[:])",
-              "void(float64[:], uint16, float64[:])"],
+@guvectorize(["void(float32[:], float32, float32[:])",
+              "void(float64[:], float64, float64[:])"],
              "(n),()->(n)", nopython=True, cache=True)
-
 def bl_subtract(w_in, a_baseline, w_out):
     """
-    Processor to subtract the fpga baseline from all waveform values. If any
-    input values are nan will return array of nan of w_out.
+    Subtract the constant baseline from the entire waveform.
+
     Parameters
     ----------
     w_in : array-like
-           wf to baseline subtract
-    a_in : uint
-           The baseline values to subtract, these are stored as uints in the raw files
-    w_out : array-like
-            The output waveform from the processor
+           The input waveform
+    a_in : float
+           The baseline value to subtract
+    w_out: array-like
+           The output waveform with the baseline subtracted
+
     Processing Chain Example
     ------------------------
-    "wf_blsub":{
+    "wf_bl": {
         "function": "bl_subtract",
         "module": "pygama.dsp.processors",
-        "args": ["waveform", "baseline", "wf_blsub"],
-        "prereqs": ["waveform", "baseline"],
-        "unit": "ADC"
-        },
+        "args": ["waveform", "baseline", "wf_bl"],
+        "unit": "ADC",
+        "prereqs": ["waveform", "baseline"]
+    }
     """
-
     w_out[:] = np.nan
 
-    if (np.isnan(w_in).any() or np.isnan(a_baseline)):
+    if np.isnan(w_in).any() or np.isnan(a_baseline):
         return
-
-    if (not a_baseline >= 0):
-        raise DSPFatal('a_baseline is out of range')
 
     w_out[:] = w_in[:] - a_baseline

--- a/pygama/dsp/_processors/convolutions.py
+++ b/pygama/dsp/_processors/convolutions.py
@@ -1,217 +1,232 @@
 import numpy as np
 from numba import guvectorize
-import math
-from math import pow
 from pygama.dsp.errors import DSPFatal
 
 def cusp_filter(length, sigma, flat, decay):
-    
     """
-    This processor applies a CUSP filter to the waveform for use in energy estimation. 
-    It is composed of a factory function that is called using the init_args argument and the function the waveforms are passed to using args
-    Initialisation Parameters
-    ------------------------
-    length : int 
-             The length of the filter to be convolved with the waveforms generally specified as len(wf)-some number
-    sigma : int, float
-             Parameter determining the curvature of the rising and faling part of the kernel
-    flat : int
-            Size of the flat section of the CUSP filter 
+    Apply a CUSP filter to the waveform.  Note that it is composed of a
+    factory function that is called using the init_args argument and that
+    the function the waveforms are passed to using args.
+
+    Initialization Parameters
+    -------------------------
+    length: int
+            The length of the filter to be convolved
+    sigma : float
+            The curvature of the rising and falling part of the kernel
+    flat  : int
+            The length of the flat section
     decay : int
-            Decay constant of the exponential to be convolved with the CUSP kernel
+            The decay constant of the exponential to be convolved
+
     Parameters
     ----------
     w_in : array-like
-            waveform to be convolved with CUSP filter
-    w_out : array-like
-        waveform convolved with CUSP filter
+           The input waveform
+    w_out: array-like
+           The filtered waveform
+
     Processing Chain Example
     ------------------------
     "wf_cusp": {
         "function": "cusp_filter",
         "module": "pygama.dsp.processors",
-        "args": [ "wf_blsub", "wf_cusp(101,f)" ],
-        "init_args" : ["len(wf_blsub)-100", "40*us", "3*us", "45*us"],
-        "prereqs": [ "wf_blsub" ],
-        "unit": "ADC"
-        },
+        "args": ["wf_bl", "wf_cusp(101,f)"],
+        "unit": "ADC",
+        "prereqs": ["wf_bl"],
+        "init_args": ["len(wf_bl)-100", "40*us", "3*us", "45*us"]
+    }
     """
+    if length <= 0:
+        raise DSPFatal('The length of the filter must be positive')
 
-    if (not length > 0):
-        raise DSPFatal('length out of range, must be greater than 0')
-    if (not sigma >= 0):
-        raise DSPFatal('sigma out of range, must be >= 0')
+    if sigma < 0:
+        raise DSPFatal('The curvature parameter must be positive')
 
-    if (not flat >= 0):
-        raise DSPFatal('flat out of range, must be >= 0')
-    if (not decay >= 0):
-        raise DSPFatal('decay out of range, must be >= 0')
+    if flat < 0:
+        raise DSPFatal('The length of the flat section must be positive')
 
-    lt = int((length-flat)/2)
+    if decay < 0:
+        raise DSPFatal('The decay constant must be positive')
+
+    lt       = int((length - flat) / 2)
     flat_int = int(flat)
-    cusp = np.zeros(length)
-    for ind in range(lt):
-        cusp[ind] = float(math.sinh(ind/sigma)/math.sinh(lt/sigma))
-    for ind in range(lt, lt+flat_int+1, 1):
+    cusp     = np.zeros(length)
+    for ind in range(0, lt, 1):
+        cusp[ind] = float(np.sinh(ind / sigma) / np.sinh(lt / sigma))
+    for ind in range(lt, lt + flat_int + 1, 1):
         cusp[ind] = 1
-    for ind in range(lt+flat_int+1, length,1):
-        cusp[ind] = float(math.sinh((length-ind)/sigma)/math.sinh(lt/sigma))
+    for ind in range(lt + flat_int + 1, length, 1):
+        cusp[ind] = float(np.sinh((length - ind) / sigma) / np.sinh(lt / sigma))
 
-
-    den = [1, -np.exp(-1/decay)]
+    den   = [1, -np.exp(-1 / decay)]
     cuspd = np.convolve(cusp, den, 'same')
     
     @guvectorize(["void(float32[:], float32[:])",
                   "void(float64[:], float64[:])"],
                  "(n),(m)", forceobj=True)
-    def cusp_out(w_in,w_out):
+    def cusp_out(w_in, w_out):
+        w_out[:] = np.nan
 
-        w_out[:]= np.nan
-
-        if (np.isnan(w_in).any()):
+        if np.isnan(w_in).any():
             return
 
-        if (len(cuspd)> len(w_in)):
-            raise DSPFatal('Filter longer than input waveform')
+        if len(cuspd) > len(w_in):
+            raise DSPFatal('The filter is longer than the input waveform')
 
         w_out[:] = np.convolve(w_in, cuspd, 'valid')
+
     return cusp_out
 
 def zac_filter(length, sigma, flat, decay):
-    
     """
-    This processor applies a ZAC (Zero Area Cusp) filter to the waveform for use in energy estimation. 
-    It is composed of a factory function that is called using the init_args argument and the function the waveforms are passed to using args
-    Initialisation Parameters
-    ------------------------
-    length : int 
-             The length of the filter to be convolved with the waveforms generally specified as len(wf)-some number
-    sigma : int, float
-             Parameter determining the curvature of the rising and faling part of the kernel
-    flat : int
-            Size of the flat section of the ZAC filter 
+    Apply a ZAC (Zero Area CUSP) filter to the waveform.  Note that it is
+    composed of a factory function that is called using the init_args
+    argument and that the function the waveforms are passed to using args.
+
+    Initialization Parameters
+    -------------------------
+    length: int
+            The length of the filter to be convolved
+    sigma : float
+            The curvature of the rising and falling part of the kernel
+    flat  : int
+            The length of the flat section
     decay : int
-            Decay constant of the exponential to be convolved with the ZAC kernel
+            The decay constant of the exponential to be convolved
+
     Parameters
     ----------
     w_in : array-like
-            waveform to be convolved with ZAC filter
-    w_out : array-like
-        waveform convolved with ZAC filter
+           The input waveform
+    w_out: array-like
+           The filtered waveform
+
     Processing Chain Example
     ------------------------
     "wf_zac": {
         "function": "zac_filter",
         "module": "pygama.dsp.processors",
-        "args": [ "wf_blsub", "wf_zac(101,f)" ],
-        "init_args" : ["len(wf_blsub)-100", "40*us", "3*us", "45*us"],
-        "prereqs": [ "wf_blsub" ],
-        "unit": "ADC"
-        },
+        "args": ["wf_bl", "wf_zac(101,f)"],
+        "unit": "ADC",
+        "prereqs": ["wf_bl"],
+        "init_args": ["len(wf_bl)-100", "40*us", "3*us", "45*us"],
+    }
     """
+    if length <= 0:
+        raise DSPFatal('The length of the filter must be positive')
 
-    if (not length > 0):
-        raise DSPFatal('length out of range, must be greater than 0')
-    if (not sigma >= 0):
-        raise DSPFatal('sigma out of range, must be >= 0')
+    if sigma < 0:
+        raise DSPFatal('The curvature parameter must be positive')
 
-    if (not flat >= 0):
-        raise DSPFatal('flat out of range, must be >= 0')
-    if (not decay >= 0):
-        raise DSPFatal('decay out of range, must be >= 0')
+    if flat < 0:
+        raise DSPFatal('The length of the flat section must be positive')
 
-    lt = int((length-flat)/2)
+    if decay < 0:
+        raise DSPFatal('The decay constant must be positive')
+
+    lt       = int((length - flat) / 2)
     flat_int = int(flat)
+
     # calculate cusp filter and negative parables
     cusp = np.zeros(length)
-    par = np.zeros(length)
-    for ind in range(lt):
-        cusp[ind] = float(math.sinh(ind/sigma)/math.sinh(lt/sigma))
-        par[ind] = pow(ind-lt/2,2)-pow(lt/2,2)
-    for ind in range(lt, lt+flat_int+1, 1):
+    par  = np.zeros(length)
+    for ind in range(0, lt, 1):
+        cusp[ind] = float(np.sinh(ind / sigma) / np.sinh(lt / sigma))
+        par [ind] = np.power(ind - lt / 2, 2) - np.power(lt / 2, 2)
+    for ind in range(lt, lt + flat_int + 1, 1):
         cusp[ind] = 1
-    for ind in range(lt+flat_int+1, length,1):
-        cusp[ind] = float(math.sinh((length-ind)/sigma)/math.sinh(lt/sigma))
-        par[ind] = pow(length-ind-lt/2,2)-pow(lt/2,2)
+    for ind in range(lt + flat_int + 1, length, 1):
+        cusp[ind] = float(np.sinh((length - ind) / sigma) / np.sinh(lt / sigma))
+        par [ind] = np.power(length - ind - lt / 2, 2) - np.power(lt / 2, 2)
 
     # calculate area of cusp and parables
     areapar, areacusp = 0, 0
-    for i in range(length):
-        areapar += par[i]
+    for i in range(0, length, 1):
+        areapar  += par [i]
         areacusp += cusp[i]
-    #normalize parables area
-    par = -par/areapar*areacusp
-    #create zac filter
+
+    # normalize parables area
+    par = -par / areapar * areacusp
+
+    # create zac filter
     zac = cusp + par
-    #deconvolve zac filter
-    den = [1, -np.exp(-1/decay)]
+
+    # deconvolve zac filter
+    den  = [1, -np.exp(-1 / decay)]
     zacd = np.convolve(zac, den, 'same')
 
     @guvectorize(["void(float32[:], float32[:])",
                   "void(float64[:], float64[:])"],
                  "(n),(m)", forceobj=True)
-    def zac_out(w_in,w_out):
-
+    def zac_out(w_in, w_out):
         w_out[:] = np.nan
 
-        if (np.isnan(w_in).any()):
+        if np.isnan(w_in).any():
             return
 
-        if (len(zacd) > len(w_in)):
-            raise DSPFatal('Filter longer than input waveform')
+        if len(zacd) > len(w_in):
+            raise DSPFatal('The filter is longer than the input waveform')
 
         w_out[:] = np.convolve(w_in, zacd, 'valid')
+
     return zac_out
 
-def t0_filter(rise,fall):
+def t0_filter(rise, fall):
 
     """
-    This processor applies modified assymetric trap filter to the waveform for use in t0 estimation. 
-    It is composed of a factory function that is called using the init_args argument and the function the waveforms are passed to using args.
-    Initialisation Parameters
-    ------------------------
-    rise : int 
-            Specifies length of rise section. This is the linearly increasing section of the filter that performs a weighted average.
-    fall : int
-            Specifies length of fall section. This is the simple averaging part of the filter.
+    Apply a modified, asymmetric trapezoidal filter to the waveform.  Note
+    that it is composed of a factory function that is called using the init_args
+    argument and that the function the waveforms are passed to using args.
+
+    Initialization Parameters
+    -------------------------
+    rise: int
+          The length of the rise section.  This is the linearly increasing
+          section of the filter that performs a weighted average.
+    fall: int
+          The length of the fall section.  This is the simple averaging part
+          of the filter.
+
     Parameters
     ----------
     w_in : array-like
-            waveform to be convolved with t0 filter
-    w_out : array-like
-        waveform convolved with t0 filter
+           The input waveform
+    w_out: array-like
+           The filtered waveform
+
     Processing Chain Example
     ------------------------
     "wf_t0_filter": {
         "function": "t0_filter",
         "module": "pygama.dsp.processors",
-        "args": [ "wf_pz", "wf_t0_filter(3748,f)" ],
-        "init_args" : ["128*ns", "2*us"],
+        "args": ["wf_pz", "wf_t0_filter(3748,f)"],
+        "unit": "ADC",
         "prereqs": ["wf_pz"],
-        "unit": "ADC"
-        },
+        "init_args": ["128*ns", "2*us"]
+    }
     """
+    if rise < 0:
+        raise DSPFatal('The length of the rise section must be positive')
 
-    if (not rise >= 0):
-        raise DSPFatal('rise out of range, must be >= 0')
-    if (not fall >= 0):
-        raise DSPFatal('fall out of range, must be >= 0')
+    if fall < 0:
+        raise DSPFatal('The length of the fall section must be positive')
 
-    t0_kern = np.arange(2/float(rise),0, -2/(float(rise)**2))
-    t0_kern = np.append(t0_kern, np.zeros(int(fall))-(1/float(fall)))
+    t0_kern = np.arange(2 / float(rise), 0, -2 / (float(rise)**2))
+    t0_kern = np.append(t0_kern, np.zeros(int(fall)) - (1 / float(fall)))
 
     @guvectorize(["void(float32[:], float32[:])",
                   "void(float64[:], float64[:])"],
                  "(n),(m)", forceobj=True)
-    def t0_filter_out(w_in,w_out):
-
+    def t0_filter_out(w_in, w_out):
         w_out[:] = np.nan
 
-        if (np.isnan(w_in).any()):
+        if np.isnan(w_in).any():
             return
 
-        if (len(t0_kern)> len(w_in)):
-            raise DSPFatal('Filter longer than input waveform')
+        if len(t0_kern) > len(w_in):
+            raise DSPFatal('The filter is longer than the input waveform')
 
         w_out[:] = np.convolve(w_in, t0_kern)[:len(w_in)]
+
     return t0_filter_out

--- a/pygama/dsp/_processors/fftw.py
+++ b/pygama/dsp/_processors/fftw.py
@@ -1,30 +1,29 @@
+import numpy as np
 from numba import guvectorize
 from pyfftw import FFTW
-import numpy as np
 
 def dft(buf_in, buf_out):
     """
-    Perform discrete fourier transforms using the FFTW library. FFTW optimizes
-    the fft algorithm based on the size of the arrays, with SIMD parallelized
-    commands. This optimization requires initialization, so this is a factory
-    function that returns a numba gufunc that performs the FFT. FFTW works on
+    Perform discrete Fourier transforms using the FFTW library.  FFTW optimizes
+    the FFT algorithm based on the size of the arrays, with SIMD parallelized
+    commands.  This optimization requires initialization, so this is a factory
+    function that returns a Numba gufunc that performs the FFT.  FFTW works on
     fixed memory buffers, so you must tell it what memory to use ahead of time.
-    When using this with ProcessingChain, to ensure the correct buffers are used
+    When using this with ProcessingChain, to ensure the correct buffers are used,
     call ProcessingChain.get_variable('var_name') to give it the internal memory
-    buffer directly (with raw_to_dsp, you can just give it the name and it will
-    automatically happen!). The possible dtypes for the input/outputs are:
-    - float32/float (size n) -> complex64 (size n/2+1)
-    - float64/double (size n) -> complex128 (size n/2+1)
-    - float128/longdouble (size n) -> complex256/clongdouble (size n/2+1)
-    - complex64 (size n) -> complex64 (size n)
-    - complex128 (size n) -> complex128 (size n)
-    - complex256/clongdouble (size n) -> complex256/clongdouble (size n)
+    buffer directly---with raw_to_dsp, you can just give it the name, and it will
+    automatically happen.  The possible dtypes for the input/outputs are:
+    - float32/float          (size n) -> complex64              (size n/2+1)
+    - float64/double         (size n) -> complex128             (size n/2+1)
+    - float128/longdouble    (size n) -> complex256/clongdouble (size n/2+1)
+    - complex64              (size n) -> complex64              (size n    )
+    - complex128             (size n) -> complex128             (size n    )
+    - complex256/clongdouble (size n) -> complex256/clongdouble (size n    )
     """
-
     try:
         dft_fun = FFTW(buf_in, buf_out, axes=(-1,), direction='FFTW_FORWARD')
     except ValueError:
-        raise ValueError("""Incompatible array types/shapes. Allowed:
+        raise ValueError("""Incompatible array types/shapes.  Allowed:
     - float32/float (size n) -> complex64 (size n/2+1)
     - float64/double (size n) -> complex128 (size n/2+1)
     - float128/longdouble (size n) -> complex256/clongdouble (size n/2+1)
@@ -43,27 +42,26 @@ def dft(buf_in, buf_out):
 
 def inv_dft(buf_in, buf_out):
     """
-    Perform inverse discrete fourier transforms using FFTW. FFTW optimizes
-    the fft algorithm based on the size of the arrays, with SIMD parallelized
-    commands. This optimization requires initialization, so this is a factory
-    function that returns a numba gufunc that performs the FFT. FFTW works on
+    Perform inverse discrete Fourier transforms using the FFTW library.  FFTW
+    optimizes the FFT algorithm based on the size of the arrays, with SIMD parallelized
+    commands.  This optimization requires initialization, so this is a factory
+    function that returns a Numba gufunc that performs the FFT.  FFTW works on
     fixed memory buffers, so you must tell it what memory to use ahead of time.
-    When using this with ProcessingChain, to ensure the correct buffers are used
+    When using this with ProcessingChain, to ensure the correct buffers are used,
     call ProcessingChain.get_variable('var_name') to give it the internal memory
-    buffer directly (with raw_to_dsp, you can just give it the name and it will
-    automatically happen!). The possible dtypes for the input/outputs are:
-    - complex64 (size n/2+1) -> float32/float (size n) 
-    - complex128 (size n/2+1) -> float64/double (size n)
-    - complex256/clongdouble (size n/2+1) -> float128/longdouble (size n)
-    - complex64 (size n) -> complex64 (size n)
-    - complex128 (size n) -> complex128 (size n)
-    - complex256/clongdouble (size n) -> complex256/clongdouble (size n)
+    buffer directly---with raw_to_dsp, you can just give it the name, and it will
+    automatically happen.  The possible dtypes for the input/outputs are:
+    - complex64              (size n/2+1) -> float32/float          (size n)
+    - complex128             (size n/2+1) -> float64/double         (size n)
+    - complex256/clongdouble (size n/2+1) -> float128/longdouble    (size n)
+    - complex64              (size n    ) -> complex64              (size n)
+    - complex128             (size n    ) -> complex128             (size n)
+    - complex256/clongdouble (size n    ) -> complex256/clongdouble (size n)
     """
-
     try:
         idft_fun = FFTW(buf_in, buf_out, axes=(-1,), direction='FFTW_BACKWARD')
     except ValueError:
-        raise ValueError("""Incompatible array types/shapes. Allowed:
+        raise ValueError("""Incompatible array types/shapes.  Allowed:
         - complex64 (size n/2+1) -> float32/float (size n) 
         - complex128 (size n/2+1) -> float64/double (size n)
         - complex256/clongdouble (size n/2+1) -> float128/longdouble (size n)
@@ -80,34 +78,32 @@ def inv_dft(buf_in, buf_out):
 
     return inv_dft
 
-
-
 def psd(buf_in, buf_out):
     """
-    Perform discrete fourier transforms using the FFTW library and use it to
-    get the power spectral density. FFTW optimizes
-    the fft algorithm based on the size of the arrays, with SIMD parallelized
-    commands. This optimization requires initialization, so this is a factory
-    function that returns a numba gufunc that performs the FFT. FFTW works on
-    fixed memory buffers, so you must tell it what memory to use ahead of time.
-    When using this with ProcessingChain, to ensure the correct buffers are used
-    call ProcessingChain.get_variable('var_name') to give it the internal memory
-    buffer directly (with raw_to_dsp, you can just give it the name and it will
-    automatically happen!). The possible dtypes for the input/outputs are:
-    - complex64 (size n) -> float32/float (size n) 
-    - complex128 (size n) -> float64/double (size n)
-    - complex256/clongdouble (size n) -> float128/longdouble (size n)
-    - float32/float (size n) -> float32/float (size n/2+1)
-    - float64/double (size n) -> float64/double (size n/2+1)
-    - float128/longdouble (size n) -> float128/longdouble (size n/2+1)
+    Perform discrete Fourier transforms using the FFTW library, and use it to get
+    the power spectral density.  FFTW optimizes the FFT algorithm based on the
+    size of the arrays, with SIMD parallelized commands.  This optimization
+    requires initialization, so this is a factory function that returns a Numba gufunc
+    that performs the FFT.  FFTW works on fixed memory buffers, so you must
+    tell it what memory to use ahead of time.  When using this with ProcessingChain,
+    to ensure the correct buffers are used, call ProcessingChain.get_variable('var_name')
+    to give it the internal memory buffer directly---with raw_to_dsp, you can just
+    give it the name, and it will automatically happen.  The possible dtypes for the
+    input/outputs are:
+    - complex64              (size n) -> float32/float       (size n    )
+    - complex128             (size n) -> float64/double      (size n    )
+    - complex256/clongdouble (size n) -> float128/longdouble (size n    )
+    - float32/float          (size n) -> float32/float       (size n/2+1)
+    - float64/double         (size n) -> float64/double      (size n/2+1)
+    - float128/longdouble    (size n) -> float128/longdouble (size n/2+1)
     """
 
     # build intermediate array for the dft, which will be abs'd to get the PSD
-    buf_dft = np.ndarray(buf_out.shape, np.dtype('complex'+str(buf_out.dtype.itemsize*16)))
+    buf_dft = np.ndarray(buf_out.shape, np.dtype('complex' + str(buf_out.dtype.itemsize * 16)))
     try:
         dft_fun = FFTW(buf_in, buf_dft, axes=(-1,), direction='FFTW_FORWARD')
     except ValueError:
-        raise ValueError("""Incompatible array types/shapes. Allowed:
+        raise ValueError("""Incompatible array types/shapes.  Allowed:
         - complex64 (size n) -> float32/float (size n) 
         - complex128 (size n) -> float64/double (size n)
         - complex256/clongdouble (size n) -> float128/longdouble (size n)

--- a/pygama/dsp/_processors/fixed_time_pickoff.py
+++ b/pygama/dsp/_processors/fixed_time_pickoff.py
@@ -1,41 +1,39 @@
 import numpy as np
 from numba import guvectorize
-import math
 from pygama.dsp.errors import DSPFatal
 
-
 @guvectorize(["void(float32[:], float32, float32[:])",
-              "void(float64[:], float32, float64[:])"],
+              "void(float64[:], float64, float64[:])"],
              "(n),()->()", nopython=True, cache=True)
-
 def fixed_time_pickoff(w_in, t_in, a_out):
     """
-    Fixed time pickoff -- gives the waveform value at a fixed time
+    Pick off the waveform value at the provided index.
+
     Parameters
     ----------
     w_in : array-like
-            Input waveform
-    t_in : float
-            Time point to find value
-    a_out : float
-            Output value
+           The input waveform
+    t_in : int
+           The waveform index to pick off
+    a_out: float
+           The output pick-off value
+
     Processing Chain Example
     ------------------------
     "trapEftp": {
         "function": "fixed_time_pickoff",
         "module": "pygama.dsp.processors",
-        "args": ["wf_trap", "tp_0 + (10*us+2.5*us)", "trapEftp"],
+        "args": ["wf_trap", "tp_0+10*us", "trapEftp"],
         "unit": "ADC",
         "prereqs": ["wf_trap", "tp_0"]
-        },
+    }
     """
-    
     a_out[0] = np.nan
 
-    if (np.isnan(w_in).any() or np.isnan(t_in)):
+    if np.isnan(w_in).any() or np.isnan(t_in):
         return
     
-    if (not int(t_in) in range(len(w_in))):
-        return
+    if int(t_in) < 0 or int(t_in) >= len(w_in):
+        raise DSPFatal('The pick-off index is out of range')
   
     a_out[0] = w_in[int(t_in)]

--- a/pygama/dsp/_processors/fixed_time_pickoff.py
+++ b/pygama/dsp/_processors/fixed_time_pickoff.py
@@ -7,7 +7,8 @@ from pygama.dsp.errors import DSPFatal
              "(n),()->()", nopython=True, cache=True)
 def fixed_time_pickoff(w_in, t_in, a_out):
     """
-    Pick off the waveform value at the provided index.
+    Pick off the waveform value at the provided index.  If the
+    provided index is out of range, return NaN.
 
     Parameters
     ----------
@@ -32,8 +33,11 @@ def fixed_time_pickoff(w_in, t_in, a_out):
 
     if np.isnan(w_in).any() or np.isnan(t_in):
         return
-    
+
+    if np.floor(t_in) != t_in:
+        raise DSPFatal('The pick-off index must be an integer')
+
     if int(t_in) < 0 or int(t_in) >= len(w_in):
-        raise DSPFatal('The pick-off index is out of range')
+        return
   
     a_out[0] = w_in[int(t_in)]

--- a/pygama/dsp/_processors/gaussian_filter1d.py
+++ b/pygama/dsp/_processors/gaussian_filter1d.py
@@ -28,15 +28,14 @@
 # NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-
-# All this code belongs to the team that coded Scipy, found at this link: https://github.com/scipy/scipy/blob/v1.6.0/scipy/ndimage/filters.py#L210-L260 
-# The only thing changed was the calculation of the convulution which originally called a function from a C library
-# In this code the convolution is performed with numpy's built in convolution function
-
+# All this code belongs to the team that coded Scipy, found at this link:
+#     https://github.com/scipy/scipy/blob/v1.6.0/scipy/ndimage/filters.py#L210-L260
+# The only thing changed was the calculation of the convulution, which
+# originally called a function from a C library.  In this code, the convolution is
+# performed with NumPy's built in convolution function.
 
 import numpy 
 from numba import guvectorize
-
 
 def gaussian_filter1d(sigma, truncate):
     """1-D Gaussian filter.
@@ -57,14 +56,14 @@ def gaussian_filter1d(sigma, truncate):
         Computes a 1-D Gaussian convolution kernel.
         """
         sigma2 = sigma * sigma
-        x = numpy.arange(-radius, radius+1)
+        x = numpy.arange(-radius, radius + 1)
         phi_x = numpy.exp(-0.5 / sigma2 * x ** 2)
         phi_x = phi_x / phi_x.sum()
         return phi_x
 
     sd = float(sigma)
     
-    # make the radius of the filter equal to truncate standard deviations
+    # Make the radius of the filter equal to truncate standard deviations
     
     lw = int(truncate * sd + 0.5)
     
@@ -73,9 +72,9 @@ def gaussian_filter1d(sigma, truncate):
     weights = _gaussian_kernel1d(sigma, lw)[::-1]
     weights = numpy.asarray(weights, dtype=numpy.float64)
 
-    # find the length of the kernel so we can reflect the signal an appropriate amount
+    # Find the length of the kernel so we can reflect the signal an appropriate amount
     
-    extension_length = int(len(weights)/2)+1
+    extension_length = int(len(weights) / 2) + 1
 
     """Calculate a 1-D correlation along the given axis.
     The lines of the array along the given axis are correlated with the
@@ -92,7 +91,7 @@ def gaussian_filter1d(sigma, truncate):
                   "void(int32[:], int32[:])",
                   "void(int64[:], int64[:])"],
                  "(n),(m)", forceobj=True)
-    def gaussian_filter1d_out(wf_in,wf_out):
+    def gaussian_filter1d_out(wf_in, wf_out):
 
         # Have to create an array to enable the reflect mode
         # Extend the signal on the left and right by at least half of the length of the kernel
@@ -101,28 +100,27 @@ def gaussian_filter1d(sigma, truncate):
         
         # Short warning message if kernel is larger than signal, in which case signal can't be convolved
         
-        if len(wf_in)<extension_length: 
-            print("Kernel calculated was larger than signal, try again with smaller parameters")
+        if len(wf_in) < extension_length:
+            print('Kernel calculated was larger than signal, try again with smaller parameters')
             return 0
         
-
-        # This mode extends as a reflection 
-        #‘reflect’ (d c b a | a b c d | d c b a)
-        #The input is extended by reflecting about the edge of the last pixel. This mode is also sometimes referred to as half-sample symmetric.
+        # This mode extends as a reflection
+        # ‘reflect’ (d c b a | a b c d | d c b a)
+        # The input is extended by reflecting about the edge of the last pixel. This mode is also
+        # sometimes referred to as half-sample symmetric.
        
         reflected_front = numpy.flip(wf_in[0:extension_length])
-        reflected_end = numpy.flip(wf_in[-extension_length:])
+        reflected_end   = numpy.flip(wf_in[-extension_length:])
         
-        # extend the signal
+        # Extend the signal
         
         extended_signal = wf_in
-        extended_signal= numpy.concatenate((extended_signal,reflected_end),axis=None)
-        extended_signal = numpy.concatenate((reflected_front,extended_signal),axis=None)
-        output = numpy.correlate(extended_signal,weights,mode="same")
+        extended_signal = numpy.concatenate((extended_signal, reflected_end  ), axis=None)
+        extended_signal = numpy.concatenate((reflected_front, extended_signal), axis=None)
+        output = numpy.correlate(extended_signal, weights, mode='same')
         
-        #now extract the original signal length
+        # Now extract the original signal length
         
         wf_out[:] = output[extension_length:-extension_length]
         
     return gaussian_filter1d_out
-

--- a/pygama/dsp/_processors/linear_slope_fit.py
+++ b/pygama/dsp/_processors/linear_slope_fit.py
@@ -5,54 +5,60 @@ from pygama.dsp.errors import DSPFatal
 @guvectorize(["void(float32[:], float32[:], float32[:], float32[:], float32[:])",
               "void(float64[:], float64[:], float64[:], float64[:], float64[:])"],
              "(n)->(),(),(),()", nopython=True, cache=True)
-
 def linear_slope_fit(w_in, mean, stdev, slope, intercept):   
     """
-    Calculate mean and standard deviation using Welford's method. In addition, it performs a linear regression and return best fit values for slope and intercept. Note: mean and stdev are computes assuming a flat slope.
+    Calculate the mean and standard deviation of the waveform using
+    Welford's method as well as the slope an intercept of the waveform
+    using linear regression.
     
     Parameters
     ----------
-    w_in : array-like
-            Input waveform 
-    
-    a_mean : float
-    stdev : float
-    slope : float
-    intercept : float
+    w_in     : array-like
+               The input waveform
+    a_mean   : float
+               The mean of the waveform
+    stdev    : float
+               The standard deviation of the waveform
+    slope    : float
+               The slope of the linear fit
+    intercept: float
+               The intercept of the linear fit
+
     Processing Chain Example
     ------------------------
-    
-    "bl_mean , bl_std, bl_slope, bl_intercept":{
+    "bl_mean, bl_std, bl_slope, bl_intercept": {
         "function": "linear_slope_fit",
         "module": "pygama.dsp.processors",
-        "args" : ["wf_blsub[0: 1650]", "bl_mean","bl_std", "bl_slope","bl_intercept"],
-        "prereqs": ["wf_blsub"],
-        "unit": ["ADC","ADC","ADC","ADC"]
-        },
+        "args": ["wf_blsub[0:1650]", "bl_mean", "bl_std", "bl_slope", "bl_intercept"],
+        "unit": ["ADC", "ADC", "ADC", "ADC"],
+        "prereqs": ["wf_blsub"]
+    }
     """
+    mean     [0] = np.nan
+    stdev    [0] = np.nan
+    slope    [0] = np.nan
+    intercept[0] = np.nan
 
-    mean[0] = stdev[0] = slope[0] = intercept[0] = np.nan
-
-    if (np.isnan(w_in).any()):
+    if np.isnan(w_in).any():
         return
 
     sum_x = sum_x2 = sum_xy = sum_y = mean[0] = stdev[0] = 0
     isum = len(w_in)
 
-    for i in range(len(w_in)):
-        # mean and stdev
-        tmp = w_in[i]-mean
-        mean += tmp / (i+1)
-        stdev += tmp*(w_in[i]-mean)
+    for i in range(0, len(w_in), 1):
+        # the mean and standard deviation
+        temp   = w_in[i] - mean
+        mean  += temp / (i + 1)
+        stdev += temp * (w_in[i] - mean)
 
         # linear regression
-        sum_x += i 
-        sum_x2 += i*i
+        sum_x  += i
+        sum_x2 += i * i
         sum_xy += (w_in[i] * i)
-        sum_y += w_in[i]
+        sum_y  += w_in[i]
 
     stdev /= (isum - 1)
     np.sqrt(stdev, stdev)
 
-    slope[0] = (isum * sum_xy - sum_x * sum_y) / (isum * sum_x2 - sum_x * sum_x)
-    intercept[0] = (sum_y - sum_x * slope[0])/isum
+    slope    [0] = (isum * sum_xy - sum_x * sum_y) / (isum * sum_x2 - sum_x * sum_x)
+    intercept[0] = (sum_y - sum_x * slope[0]) / isum

--- a/pygama/dsp/_processors/log_check.py
+++ b/pygama/dsp/_processors/log_check.py
@@ -1,35 +1,38 @@
 import numpy as np
 from numba import guvectorize
+from pygama.dsp.errors import DSPFatal
 
 @guvectorize(["void(float32[:], float32[:])",
               "void(float64[:], float64[:])"],
              "(n)->(n)", nopython=True, cache=True)
-
 def log_check(w_in, w_log):
     """
-    This processor takes in a waveform slice and outputs its logarithm if all the values are positive otherwise returns nan.
-    Typically used to log the decay tail before applying a linear fit to find the pole zero constant.
+    Calculate the logarithm of the waveform if all its values
+    are positive; otherwise, return NaN.
+
     Parameters
     ----------
     w_in : array-like
-           input waveform slice or whole waveform
-    
-    w_log : array-like
-            the output of the processor the logged waveform
+           The input waveform
+    w_log: array-like
+           The output waveform with logged values
+
     Processing Chain Example
     ------------------------
-    "wf_logged":{
+    "wf_logged": {
         "function": "log_check",
         "module": "pygama.dsp.processors",
         "args": ["wf_blsub[2100:]", "wf_logged"],
-        "prereqs": ["wf_blsub"],
-        "unit": "ADC"
-        },
+        "unit": "ADC",
+        "prereqs": ["wf_blsub"]
+    }
     """
-    
     w_log[:] = np.nan
     
-    if (np.isnan(w_in).any() or np.any(w_in<=0)):
+    if np.isnan(w_in).any():
+        return
+
+    if np.any(w_in <= 0):
         return
         
     w_log[:] = np.log(w_in[:])

--- a/pygama/dsp/_processors/min_max.py
+++ b/pygama/dsp/_processors/min_max.py
@@ -1,50 +1,51 @@
 import numpy as np
 from numba import guvectorize
+from pygama.dsp.errors import DSPFatal
 
 @guvectorize(["void(float32[:], float32[:], float32[:], float32[:], float32[:])",
-              "void(float64[:], float32[:], float32[:], float64[:], float64[:])"],
+              "void(float64[:], float64[:], float64[:], float64[:], float64[:])"],
              "(n)->(),(),(),()", nopython=True, cache=True)
-
 def min_max(w_in, t_min, t_max, a_min, a_max):
     """
-    Finds the min, max and their time position for a waveform.  If there are
-    multiple samples with the same min/max value, the first one is returned
+    Find the value and index of the minimum and maximum values
+    in the waveform.  Note that the first instance of each extremum
+    in the waveform will be returned.
+
     Parameters
     ----------
     w_in : array-like
-           input waveform
-    
-    t_min : float
-            Output time when waveform is at minimum
-    
-    t_max : float
-            Output time when waveform is at maximum
-    a_min : float
-            Output value when waveform is at minimum
-    
-    a_max : float
-            Output value when waveform is at maximum
+           The input waveform
+    t_min: int
+           The index of the minimum value
+    t_max: int
+           The index of the maximum value
+    a_min: float
+           The minimum value
+    a_max: float
+           The maximum value
+
     Processing Chain Example
     ------------------------
-    
-    "tp_min, tp_max, wf_min, wf_max":{
+    "tp_min, tp_max, wf_min, wf_max": {
         "function": "min_max",
         "module": "pygama.dsp.processors",
         "args": ["waveform", "tp_min", "tp_max", "wf_min", "wf_max"],
-        "unit": ["ns","ns","ADC", "ADC"],
-        "prereqs":["waveform"]
-        },
+        "unit": ["ns", "ns", "ADC", "ADC"],
+        "prereqs": ["waveform"]
+    }
     """
+    a_min[0] = np.nan
+    a_max[0] = np.nan
+    t_min[0] = np.nan
+    t_max[0] = np.nan
 
-    a_min[0] = a_max[0] = t_min[0] = t_max[0] = np.nan
-
-    if (np.isnan(w_in).any()):
+    if np.isnan(w_in).any():
         return
 
     min_index = 0
     max_index = 0
 
-    for i in range(len(w_in)):
+    for i in range(0, len(w_in), 1):
         if w_in[i] < w_in[min_index]:
             min_index = i
         if w_in[i] > w_in[max_index]:

--- a/pygama/dsp/_processors/moving_windows.py
+++ b/pygama/dsp/_processors/moving_windows.py
@@ -2,171 +2,171 @@ import numpy as np
 from numba import guvectorize
 from pygama.dsp.errors import DSPFatal
 
-
 @guvectorize(["void(float32[:], float32, float32[:])",
               "void(float64[:], float64, float64[:])"],
              "(n),()->(n)", nopython=True, cache=True)
-
 def moving_window_left(w_in, length, w_out):
+    """
+    Apply a moving-average window to the waveform from the left.
 
-    '''
-    Applies a moving average window to the waveform from the left, assumes that the baseline is at 0. 
     Parameters
     ----------
-    w_in : array-like
+    w_in  : array-like
             The input waveform
-    length : float
-              Length of the moving window to be applied
+    length: int
+            The length of the moving window
     w_out : array-like
-            Output waveform after moving window applied
+            The windowed waveform
+
     Processing Chain Example
     ------------------------
-    "wf_mw":{
+    "wf_mw": {
         "function": "moving_window_left",
         "module": "pygama.dsp.processors",
-        "args" : ["wf_pz", "96*ns","wf_mw"],
-        "prereqs": ["wf_pz"],
-        "unit":"ADC"
-        },
-    '''
-    
+        "args": ["wf_pz", "96*ns", "wf_mw"],
+        "unit": "ADC",
+        "prereqs": ["wf_pz"]
+    }
+    """
     w_out[:] = np.nan
 
-    if (np.isnan(w_in).any()):
+    if np.isnan(w_in).any():
         return
 
-    if (not length >= 0 or not length< len(w_in)):
-        raise DSPFatal('length is out of range, must be between 0 and the length of the waveform')
+    if np.floor(length) != length:
+        raise DSPFatal('The length of the moving window must be an integer')
 
-    w_out[0]= w_in[0]/length
+    if int(length) < 0 or int(length) >= len(w_in):
+        raise DSPFatal('The length of the moving window is out of range')
+
+    w_out[0] = w_in[0] / length
     for i in range(1, int(length)):
-        w_out[i] = w_out[i-1] + w_in[i]/length
+        w_out[i] = w_out[i-1] + w_in[i] / length
     for i in range(int(length), len(w_in)):
-        w_out[i] = w_out[i-1] + (w_in[i] - w_in[i-int(length)])/length
-
+        w_out[i] = w_out[i-1] + (w_in[i] - w_in[i-int(length)]) / length
 
 @guvectorize(["void(float32[:], float32, float32[:])",
               "void(float64[:], float64, float64[:])"],
              "(n),()->(n)", nopython=True, cache=True)
-
 def moving_window_right(w_in, length, w_out):
+    """
+    Apply a moving-average window to the waveform from the left.
 
-    '''
-    Applies a moving average window to the waveform from the right. 
     Parameters
     ----------
-    w_in : array-like
+    w_in  : array-like
             The input waveform
-    length : float
-              Length of the moving window to be applied
+    length: int
+            The length of the moving window
     w_out : array-like
-            Output waveform after moving window applied
+            The windowed waveform
+
     Processing Chain Example
     ------------------------
-    "wf_mw":{
+    "wf_mw": {
         "function": "moving_window_right",
         "module": "pygama.dsp.processors",
-        "args" : ["wf_pz", "96*ns","wf_mw"],
-        "prereqs": ["wf_pz"],
-        "unit":"ADC"
-        },
-    '''
-
+        "args": ["wf_pz", "96*ns", "wf_mw"],
+        "unit": "ADC",
+        "prereqs": ["wf_pz"]
+    }
+    """
     w_out[:] = np.nan
 
-    if (np.isnan(w_in).any()):
+    if np.isnan(w_in).any():
         return
 
-    if (not length >= 0 or not length< len(w_in)):
-        raise DSPFatal('length is out of range, must be between 0 and the length of the waveform')
+    if np.floor(length) != length:
+        raise DSPFatal('The length of the moving window must be an integer')
 
+    if int(length) < 0 or int(length) >= len(w_in):
+        raise DSPFatal('The length of the moving window is out of range')
 
-    w_out[-1]= w_in[-1] 
-    for i in range(len(w_in)-2, len(w_in)-int(length)-1,-1):
-        w_out[i] = w_out[i+1] + (w_in[i]-w_out[-1])/length
-    for i in range(len(w_in)-int(length)-1, -1, -1):
-        w_out[i] = w_out[i+1] + (w_in[i] - w_in[i+int(length)])/length
-
+    w_out[-1] = w_in[-1]
+    for i in range(len(w_in) - 2, len(w_in) - int(length) - 1, -1):
+        w_out[i] = w_out[i+1] + (w_in[i] - w_out[-1]) / length
+    for i in range(len(w_in) - int(length) - 1, -1, -1):
+        w_out[i] = w_out[i+1] + (w_in[i] - w_in[i+int(length)]) / length
 
 @guvectorize(["void(float32[:], float32, float32, float32[:])",
               "void(float64[:], float64, float64, float64[:])"],
              "(n),(),()->(n)", nopython=True, cache=True)
-
 def moving_window_multi(w_in, length, num_mw, w_out):
+    """
+    Apply a series of moving-average windows to the waveform, alternating
+    its application between the left and the right.
 
-    '''
-    Applies a series of moving average window to the waveform alternating between applying form the left and right. 
     Parameters
     ----------
-    w_in : array-like
+    w_in  : array-like
             The input waveform
-    length : float
-              Length of the moving window to be applied
-    num_mw : float
-              Number of moving windows to be applied
+    length: int
+            The length of the moving window
+    num_mw: int
+            The number of moving windows
     w_out : array-like
-            Output waveform after moving window applied
+            The windowed waveform
+
     Processing Chain Example
-    ------------------------   
-    
-    "curr_av":{
+    ------------------------
+    "curr_av": {
         "function": "moving_window_multi",
         "module": "pygama.dsp.processors",
-        "args" : ["curr", "96*ns", 3,"curr_av"],
-        "prereqs": ["curr"],
-        "unit":"ADC/sample"
-        },
-    '''
-
+        "args": ["curr", "96*ns", "3", "curr_av"],
+        "unit": "ADC/sample",
+        "prereqs": ["curr"]
+    }
+    """
     w_out[:] = np.nan
 
-    if (np.isnan(w_in).any()):
+    if np.isnan(w_in).any():
         return
 
-    if (not length >= 0 or not length< len(w_in)):
-        raise DSPFatal('length is out of range, must be between 0 and the length of the waveform')
-    
-    if (not num_mw >= 0) :
-        raise DSPFatal('num_mw is out of range, must be >= 0')
+    if np.floor(length) != length:
+        raise DSPFatal('The length of the moving window must be an integer')
 
+    if np.floor(num_mw) != num_mw:
+        raise DSPFatal('The number of moving windows must be an integer')
+
+    if int(length) < 0 or int(length) >= len(w_in):
+        raise DSPFatal('The length of the moving window is out of range')
+
+    if int(num_mw) < 0:
+        raise DSPFatal('The number of moving windows much be positive')
 
     wf_buf = w_in.copy()
-    for i in range(num_mw):
-        
+    for i in range(0, int(num_mw), 1):
         if i % 2 == 1:
-            w_out[-1]= w_in[-1] 
-            for i in range(len(w_in)-2, len(w_in)-int(length)-1,-1):
-                w_out[i] = w_out[i+1] + (w_in[i]-w_out[-1])/length
-            for i in range(len(wf_buf)-(int(length)+1), -1,-1):
-                w_out[i] = w_out[i+1] + (wf_buf[i] - wf_buf[i+int(length)])/length
+            w_out[-1] = w_in[-1]
+            for i in range(len(w_in) - 2, len(w_in) - int(length) - 1, -1):
+                w_out[i] = w_out[i+1] + (w_in[i] - w_out[-1]) / length
+            for i in range(len(wf_buf) - int(length) - 1, -1, -1):
+                w_out[i] = w_out[i+1] + (wf_buf[i] - wf_buf[i+int(length)]) / length
         else:
-            w_out[0]= wf_buf[0]/length
-            for i in range(1, int(length)):
-                w_out[i] = w_out[i-1] + wf_buf[i]/length
-            for i in range(int(length), len(w_in)):
-                w_out[i] = w_out[i-1] + (wf_buf[i] - wf_buf[i-int(length)])/length
+            w_out[0] = wf_buf[0] / length
+            for i in range(1, int(length), 1):
+                w_out[i] = w_out[i-1] + wf_buf[i] / length
+            for i in range(int(length), len(w_in), 1):
+                w_out[i] = w_out[i-1] + (wf_buf[i] - wf_buf[i-int(length)]) / length
         wf_buf[:] = w_out[:]
-
-
 
 @guvectorize(["void(float32[:], float32, float32[:])",
               "void(float64[:], float64, float64[:])"],
              "(n),(),(m)", nopython=True, cache=True)
-
-
-
 def avg_current(w_in, length, w_out):
     """
-    Calculate the derivative of a WF, averaged across n samples. Dimension of
-    deriv should be len(wf) - n
+    Calculate the derivative of the waveform, averaged across the specified
+    number of samples.
+
     Parameters
     ----------
-    w_in : array-like
+    w_in  : array-like
             The input waveform
-    length : float
-              Length of the moving window derivative to be applied
+    length: int
+            The length of the moving window
     w_out : array-like
-            Output waveform after derivation
+            The output derivative
+
     Processing Chain Example
     ------------------------
     "curr": {
@@ -175,17 +175,18 @@ def avg_current(w_in, length, w_out):
         "args": ["wf_pz", 1, "curr(len(wf_pz)-1, f)"],
         "unit": "ADC/sample",
         "prereqs": ["wf_pz"]
-        }, 
+    }
     """
-
     w_out[:] = np.nan
 
-    if (np.isnan(w_in).any()):
+    if np.isnan(w_in).any():
         return
 
-    if (not length >= 0 or not length< len(w_in)):
-        raise DSPFatal('length is out of range, must be between 0 and the length of the waveform')
-    
+    if np.floor(length) != length:
+        raise DSPFatal('The length of the moving window must be an integer')
+
+    if int(length) < 0 or int(length) >= len(w_in):
+        raise DSPFatal('The length of the moving window is out of range')
 
     w_out[:] = w_in[int(length):] - w_in[:-int(length)]
-    w_out/=length
+    w_out /= length

--- a/pygama/dsp/_processors/param_lookup.py
+++ b/pygama/dsp/_processors/param_lookup.py
@@ -3,20 +3,23 @@ from numba import guvectorize, types, from_dtype
 
 def param_lookup(param_dict, default_val, dtype):
     """
-    Generate the ufunc lookup(channel, val), which returns a numpy array of
+    Generate the ufunc lookup(channel, val), which returns a NumPy array of
     values corresponding to various channels that are looked up in the provided
-    param_dict. If there is no key, use default_val instead.
+    param_dict.  If there is no key, use default_val instead.
     """
     out_type = from_dtype(np.dtype(dtype))
-    #convert types to avoid any necessity of casting...
-    param_dict = { types.uint32(k):out_type(v) for k, v in param_dict.items() }
+
+    # convert types to avoid any necessity of casting
+    param_dict  = {types.uint32(k): out_type(v) for k, v in param_dict.items()}
     default_val = out_type(default_val)
     
-    @guvectorize(["void(uint32, "+out_type.name+"[:])"],
-                 "()->()", forceobj = True)
+    @guvectorize(["void(uint32, " + out_type.name + "[:])"],
+                 "()->()", forceobj=True)
     def lookup(channel, val):
-        """Look up a value for the provided channel from a dictionary provided
-        at compile time"""
+        """
+        Look up a value for the provided channel from a dictionary provided at
+        compile time.
+        """
         val[0] = param_dict.get(channel, default_val)
 
     return lookup

--- a/pygama/dsp/_processors/pole_zero.py
+++ b/pygama/dsp/_processors/pole_zero.py
@@ -5,90 +5,84 @@ from pygama.dsp.errors import DSPFatal
 @guvectorize(["void(float32[:], float32, float32[:])",
               "void(float64[:], float64, float64[:])"],
              "(n),()->(n)", nopython=True, cache=True)
-
 def pole_zero(w_in, t_tau, w_out):
     """
-    Applies a Pole-zero correction using time constant tau
+    Apply a pole-zero cancellation using the provided time
+    constant to the waveform.
+
     Parameters
     ----------
     w_in : array-like
-           waveform to apply pole zero correction to. Needs to be baseline subtracted
-    
-    t_tau : float
-            Time constant of exponential decay to be deconvolved
-    
-    w_out : array-like
-            Output array for pole zero corrected waveform 
+           The input waveform
+    t_tau: float
+           The time constant of the exponential to be deconvolved
+    w_out: array-like
+           The pole-zero cancelled waveform
+
     Processing Chain Example
     ------------------------
     "wf_pz": {
         "function": "pole_zero",
         "module": "pygama.dsp.processors",
-        "args": ["wf_blsub", "db.pz.tau", "wf_pz"],
-        "prereqs": ["wf_blsub"],
+        "args": ["wf_bl", "400*us", "wf_pz"],
         "unit": "ADC",
-        "defaults": { "db.pz.tau":"74*us" }
-        },
+        "prereqs": ["wf_bl"]
+    }
     """
-
     w_out[:] = np.nan 
 
-    if (np.isnan(w_in).any() or np.isnan(t_tau)):
+    if np.isnan(w_in).any() or np.isnan(t_tau):
         return
 
-    const = np.exp(-1/t_tau)
+    const = np.exp(-1 / t_tau)
     w_out[0] = w_in[0]
-    for i in range(1, len(w_in)):
+    for i in range(1, len(w_in), 1):
         w_out[i] = w_out[i-1] + w_in[i] - w_in[i-1] * const
-
 
 @guvectorize(["void(float32[:], float32, float32, float32, float32[:])",
               "void(float64[:], float64, float64, float64, float64[:])"],
              "(n),(),(),()->(n)", nopython=True, cache=True)
-
 def double_pole_zero(w_in, t_tau1, t_tau2, frac, w_out):
     """
-    Pole-zero correction using two time constants: one main (long) time constant
-    tau1, and a shorter time constant tau2 that contributes a fraction frac
+    Apply a double pole-zero cancellation using the provided time
+    constant to the waveform.
+
     Parameters
     ----------
-    w_in : array-like
-           waveform to apply pole zero correction to. Needs to be baseline subtracted
-    
-    t_tau1 : float
-             Time constant of first exponential decay to be deconvolved
-    t_tau2 : float
-             Time constant of second exponential decay to be deconvolved
-    frac : float
-           Fraction which tau2 contributes to decay
-    
+    w_in  : array-like
+            The input waveform
+    t_tau1: float
+            The time constant of the first exponential to be deconvolved
+    t_tau2: float
+            The time constant of the second exponential to be deconvolved
+    frac  : float
+            The fraction which the second exponential contributes
     w_out : array-like
-            Output array for pole zero corrected waveform 
+            The pole-zero cancelled waveform
+
     Processing Chain Example
     ------------------------
-    "wf_pz2": {
+    "wf_pz": {
         "function": "double_pole_zero",
         "module": "pygama.dsp.processors",
-        "args": ["wf_blsub", "db.pz2.tau1", "db.pz2.tau2",  "db.pz2.frac", "wf_pz2"],
-        "prereqs": ["wf_blsub"],
+        "args": ["wf_bl", "400*us", "20*us", "0.02", "wf_pz"],
         "unit": "ADC",
-        "defaults": { "db.pz2.tau1":"74*us", "db.pz2.tau2":"3*us", "db.pz2.frac":"0.013" }
-        },
+        "prereqs": ["wf_bl"]
+    }
     """
-    
     w_out[:] = np.nan 
 
-    if (np.isnan(w_in).any() or np.isnan(t_tau1) or np.isnan(t_tau2) or np.isnan(frac)):
+    if np.isnan(w_in).any() or np.isnan(t_tau1) or np.isnan(t_tau2) or np.isnan(frac):
         return
 
-    const1 = 1/t_tau1 #np.exp(-1/t_tau1)
-    const2 = 1/t_tau2 #np.exp(-1/t_tau2)
+    const1 = 1 / t_tau1
+    const2 = 1 / t_tau2
     w_out[0] = w_in[0]
     e1 = w_in[0]
     e2 = w_in[0]
     e3 = 0
-    for i in range(1, len(w_in)):
-        e1 += w_in[i] - e2 + e2*const1
-        e3 += w_in[i] - e2 - e3*const2
-        e2 = w_in[i]
-        w_out[i] = e1 - frac*e3
+    for i in range(1, len(w_in), 1):
+        e1 += w_in[i] - e2 + e2 * const1
+        e3 += w_in[i] - e2 - e3 * const2
+        e2  = w_in[i]
+        w_out[i] = e1 - frac * e3

--- a/pygama/dsp/_processors/presum.py
+++ b/pygama/dsp/_processors/presum.py
@@ -1,17 +1,31 @@
+import numpy as np
 from numba import guvectorize
+from pygama.dsp.errors import DSPFatal
 
 @guvectorize(["void(float32[:], float32[:])",
-              "void(float64[:], float64[:])",
-              "void(int32[:], int32[:])",
-              "void(int64[:], int64[:])"],
+              "void(float64[:], float64[:])"],
              "(n),(m)", nopython=True, cache=True)
-def presum(wf_in, wf_out):
-    """Presum the waveform. Combine bins in chunks of len(wf_in)/len(wf_out),
-    which is hopefully an integer. If it isn't, then some samples at the end
-    will be omitted"""
-    ps_fact = len(wf_in)//len(wf_out)
-    for i in range(0, len(wf_out)):
-        j0 = i*ps_fact
-        wf_out[i] = wf_in[j0]
-        for j in range(j0+1, j0+ps_fact):
-            wf_out[i] += wf_in[j]
+def presum(w_in, w_out):
+    """
+    Presum the waveform.  Combine bins in chunks of len(w_in) / len(w_out),
+    which is hopefully an integer.  If it isn't, then some samples at the end
+    will be omitted.
+
+    Parameters
+    ----------
+    w_in : array-like
+           The input waveform
+    w_out: array-like
+           The output waveform
+    """
+    w_out[:] = np.nan
+
+    if np.isnan(w_in).any():
+        return
+
+    ps_fact = len(w_in) // len(w_out)
+    for i in range(0, len(w_out), 1):
+        j0 = i * ps_fact
+        w_out[i] = w_in[j0]
+        for j in range(j0 + 1, j0 + ps_fact, 1):
+            w_out[i] += w_in[j]

--- a/pygama/dsp/_processors/template.py
+++ b/pygama/dsp/_processors/template.py
@@ -1,19 +1,19 @@
-# 1) Import python modules
+# 1) Import Python modules
 #
 import numpy as np
 from numba import guvectorize
 from pygama.dsp.errors import DSPFatal
 
-# 2) Provide instructions to numba
+# 2) Provide instructions to Numba
 # 
-# Documentation about numba guvectorize decorator:
+# Documentation about Numba guvectorize decorator:
 # https://numba.pydata.org/numba-doc/latest/user/vectorize.html#the-guvectorize-decorator
 #
 # Notes:
-# - use `nopython=True` and `cache=True`
-# - use two declarations, one for 32-bit variables and one for 64-bit variables
-# - do not use ints as they do not support NaN values.
-# - use [:] for all output parameters
+# - Use "nopython=True, cache=True"
+# - Use two declarations, one for 32-bit variables and one for 64-bit variables
+# - Do not use "int" as it does not support an NaN value
+# - Use [:] for all output parameters
 #
 @guvectorize(["void(float32[:], float32, float32, float32[:])",
               "void(float64[:], float64, float64, float64[:])"],
@@ -21,11 +21,11 @@ from pygama.dsp.errors import DSPFatal
 
 # 3) Define the processor interface
 #
-# Notes: (@all, this is up for discussion)
-# - add the `_in`/`_out` suffix to the name of the input/output variables
-# - use w_ for waveforms, t_ for indexes, a_ for amplitudes 
-# - use underscore casing for the name of the processor and variables, e.g.
-#   a_trap_energy_in or t_trigger_in
+# Notes:
+# - Add the "_in"/"_out" suffix to the name of the input/output variables
+# - Use "w_" for waveforms, "t_" for indexes, "a_" for amplitudes
+# - Use underscore casing for the name of the processor and variables, e.g.,
+#   "a_trap_energy_in" or "t_trigger_in"
 #
 def the_processor_template(w_in, t_in, a_in, w_out, t_out):
 
@@ -36,45 +36,45 @@ def the_processor_template(w_in, t_in, a_in, w_out, t_out):
     meaning of input and output variables
     """
 
-    # 5) Initialize output parameters (@iann, will this be done automatically by the processing chain?)
+    # 5) Initialize output parameters
     #
     # Notes:
-    # - all output parameters should be initializes to a not-a-number. If a
-    #   processor fails, its output parameters should have the default nan value
-    # - use np.nan for both variables and arrays
+    # - All output parameters should be initializes to a NaN.  If a processor
+    #   fails, its output parameters should have the default NaN value
+    # - Use np.nan for both variables and arrays
     #
     w_out[:] = np.nan # use [:] for arrays
     t_out[0] = np.nan # use [0] for scalar parameters
 
-    # 6) Check inputs. 
+    # 6) Check inputs
     #
     # There are two kinds of checks:
-    # - NaN checks. A processor might depend on others, i.e. its input
-    #   parameters are the output parameters of an other processors. When a
+    # - NaN checks.  A processor might depend on others, i.e., its input
+    #   parameters are the output parameters of an other processors.  When a
     #   processor fails, all processors depending on its output should not run.
     #   Thus, skip this processor if a NaN value is detected and return NaN
     #   output parameters to propagate the failure throughout the processing chain.
-    # - in range checks. Check if indexes are within 0 and len(waveform),
-    #   amplitudes are positive, etc. A failure of this check implies errors in
-    #   the dsp json config file. Abort the analysis immediately.
+    # - In-range checks.  Check if indexes are within 0 and len(waveform),
+    #   amplitudes are positive, etc.  A failure of this check implies errors in
+    #   the DSP JSON config file.  Abort the analysis immediately.
     #
-    if (np.isnan(w_in).any() or np.isnan(t_in) or np.isnan(a_in)):
+    if np.isnan(w_in).any() or np.isnan(t_in) or np.isnan(a_in):
         return
 
-    if (not t_in in range(len(w_in)) or not a_in >= 0):
-        raise DSPFatal('Error Message e.g. t_in not in range must be within length of waveform')
+    if a_in < 0:
+        raise DSPFatal('The error message goes here')
 
     # 7) Algorithm
     # 
-    # Loop over waveforms by using a `for i in range(.., .., ..)` instruction. 
-    # Avoid loops based on a while condition which might lead to segfault. Avoid
+    # Loop over waveforms by using a "for i in range(.., .., ..)" instruction.
+    # Avoid loops based on a while condition which might lead to segfault.  Avoid
     # also enumerate/ndenumerate to keep code as similar as possible among all
     # processors.
     #
-    # Example of an algorithm to find the first index above t_in in which the
-    # signal crossed the value a_in
+    # Example of an algorithm to find the first index above "t_in" in which the
+    # signal crossed the value "a_in"
     #
     for i in range(t_in, 1, 1):
-        if( w_in[i] >= a_in and w_in[i-1] < a_in):
+        if w_in[i] >= a_in and w_in[i-1] < a_in:
             t_out[0] = i
             return

--- a/pygama/dsp/_processors/time_point_thresh.py
+++ b/pygama/dsp/_processors/time_point_thresh.py
@@ -1,59 +1,59 @@
 import numpy as np
 from numba import guvectorize
-import math
 from pygama.dsp.errors import DSPFatal
 
-@guvectorize(["void(float32[:], float32, float32, int32 ,float32[:])",
-              "void(float64[:], float64, float32, int32 ,float32[:])"],
+@guvectorize(["void(float32[:], float32, float32, float32, float32[:])",
+              "void(float64[:], float64, float64, float64, float64[:])"],
              "(n),(),(),()->()", nopython=True, cache=True)
-
 def time_point_thresh(w_in, a_threshold, t_start, walk_forward, t_out):
     """
-    Find the time after/before t_start where w_in first crosses a threshold 
+    Find the index where the waveform value crosses the threshold,
+    walking either forward or backward from the starting index.
+
     Parameters
     ----------
-     w_in: array-like
-           Input waveform
-    
-     a_threshold: float
-                  Threshold to search for
-     t_start: float
-               Start point to walk forwards from 
-     walk_forward: int
-                   Define search direction 1 is forward, 0 is back
-    
-     tp_out: float
-             Final time that waveform is less than threshold
+    w_in        : array-like
+                  The input waveform
+    a_threshold : float
+                  The threshold value
+    t_start     : int
+                  The starting index
+    walk_forward: int
+                  The backward (0) or forward (1) search direction
+    t_out       : float
+                  The index where the waveform value crosses the threshold
+
     Processing Chain Example
     ------------------------
-    
     "tp_0": {
         "function": "time_point_thresh",
         "module": "pygama.dsp.processors",
-        "args": [ "wf_atrap", "bl_std", "tp_start", 0 ,"tp_0" ],
+        "args": ["wf_atrap", "bl_std", "tp_start", 0, "tp_0"],
         "unit": "ns",
-        "prereqs": [ "wf_atrap", "bl_std", "tp_start" ]
-        },
+        "prereqs": ["wf_atrap", "bl_std", "tp_start"]
+    }
     """
-    
     t_out[0] = np.nan
 
-    if (np.isnan(w_in).any() or np.isnan(a_threshold) or np.isnan(t_start) or np.isnan(walk_forward)):
+    if np.isnan(w_in).any() or np.isnan(a_threshold) or np.isnan(t_start) or np.isnan(walk_forward):
         return
     
-    if (not np.floor(t_start)==t_start):
-        raise DSPFatal('Start time is not an integer')
+    if np.floor(t_start) != t_start:
+        raise DSPFatal('The starting index must be an integer')
 
-    if (not int(t_start) in range(len(w_in))):
-        raise DSPFatal('Time point not in length of waveform')
+    if np.floor(walk_forward) != walk_forward:
+        raise DSPFatal('The search direction must be an integer')
 
-    if(walk_forward == 1):
-        for i in range(int(t_start), len(w_in)-1):
-            if(w_in[i] <= a_threshold < w_in[i+1]):
+    if int(t_start) < 0 or int(t_start) >= len(w_in):
+        raise DSPFatal('The starting index is out of range')
+
+    if int(walk_forward) == 1:
+        for i in range(int(t_start), len(w_in) - 1, 1):
+            if w_in[i] <= a_threshold < w_in[i+1]:
                 t_out[0] = i
                 return
     else:
         for i in range(int(t_start), 1, -1):
-            if(w_in[i-1] < a_threshold <= w_in[i]):
+            if w_in[i-1] < a_threshold <= w_in[i]:
                 t_out[0] = i
                 return

--- a/pygama/dsp/_processors/trap_filters.py
+++ b/pygama/dsp/_processors/trap_filters.py
@@ -1,247 +1,260 @@
 import numpy as np
 from numba import guvectorize
-import math
 from pygama.dsp.errors import DSPFatal
 
-
 @guvectorize(["void(float32[:], float32, float32, float32[:])",
-              "void(float64[:], float32, float32, float64[:])"],
+              "void(float64[:], float64, float64, float64[:])"],
              "(n),(),()->(n)", nopython=True, cache=True)
 def trap_filter(w_in, rise, flat, w_out):
-    
     """
-    Applies a symmetric trapezoidal filter (rise= fall) to the waveform 
-    Parameters:
-    -----------
+    Apply a symmetric trapezoidal filter to the waveform.
+
+    Parameters
+    ----------
     w_in : array-like
-           Input Waveform
-    rise : float
-           Sets the number of samples that will be averaged in the rise and fall sections
-    flat : float
-            Controls the delay between the rise and fall averaging sections, 
-            typically around 3us for ICPC energy estimation, lower for detectors with shorter drift times
-    w_out : array-like
-            Output waveform after trap filter applied
+           The input waveform
+    rise : int
+           The number of samples averaged in the rise and fall sections
+    flat : int
+           The delay between the rise and fall sections
+    w_out: array-like
+           The filtered waveform
+
     Processing Chain Example
     ------------------------
-    "wf_trap": {
+    "wf_tf": {
         "function": "trap_filter",
         "module": "pygama.dsp.processors",
-        "args": ["wf_pz", "10*us", "3*us", "wf_trap"],
-        "prereqs": ["wf_pz"],
-        "unit": "ADC"
-        },
+        "args": ["wf_pz", "10*us", "3*us", "wf_tf"],
+        "unit": "ADC",
+        "prereqs": ["wf_pz"]
+    }
     """
-    
     w_out[:] = np.nan
 
-    if (np.isnan(w_in).any()):
+    if np.isnan(w_in).any() or np.isnan(rise) or np.isnan(flat):
         return
 
-    if (not  0 <= rise):
-        raise DSPFatal('Rise must be >= 0')
+    if np.floor(rise) != rise:
+        raise DSPFatal('The number of samples in the rise secion must be an integer')
+
+    if np.floor(flat) != flat:
+        raise DSPFatal('The number of samples in the flat secion must be an integer')
+
+    if int(rise) < 0:
+        raise DSPFatal('The number of samples in the rise secion must be positive')
     
-    if (not  0 <= flat):
-        raise DSPFatal('Flat must be >= 0')
+    if int(flat) < 0:
+        raise DSPFatal('The number of samples in the flat secion must be positive')
     
-    if (not 2*rise+flat <= len(w_in)):
-        raise DSPFatal('Trap Filter longer than waveform')
+    if 2 * int(rise) + int(flat) > len(w_in):
+        raise DSPFatal('The trapezoid width is wider than the waveform')
     
     rise_int = int(rise)
     flat_int = int(flat)
     w_out[0] = w_in[0]
-    for i in range(1, rise_int):
+    for i in range(1, rise_int, 1):
         w_out[i] = w_out[i-1] + w_in[i]
-    for i in range(rise_int, rise_int+flat_int):
+    for i in range(rise_int, rise_int + flat_int, 1):
         w_out[i] = w_out[i-1] + w_in[i] - w_in[i-rise_int]
-    for i in range(rise_int+flat_int, 2*rise_int+flat_int):
+    for i in range(rise_int + flat_int, 2 * rise_int + flat_int, 1):
         w_out[i] = w_out[i-1] + w_in[i] - w_in[i-rise_int] - w_in[i-rise_int-flat_int]
-    for i in range(2*rise_int+flat_int, len(w_in)):
+    for i in range(2 * rise_int + flat_int, len(w_in), 1):
         w_out[i] = w_out[i-1] + w_in[i] - w_in[i-rise_int] - w_in[i-rise_int-flat_int] + w_in[i-2*rise_int-flat_int]
 
 @guvectorize(["void(float32[:], float32, float32, float32[:])",
-              "void(float64[:], float32, float32, float64[:])"],
+              "void(float64[:], float64, float64, float64[:])"],
              "(n),(),()->(n)", nopython=True, cache=True)
-
 def trap_norm(w_in, rise, flat, w_out):
-   
     """
-    Applies a symmetric trapezoidal filter (rise= fall) to the waveform normalized by integration time
-    Parameters:
-    -----------
+    Apply a symmetric trapezoidal filter to the waveform, normalized
+    by the number of samples averaged in the rise and fall sections.
+
+    Parameters
+    ----------
     w_in : array-like
-           Input Waveform
-    rise : float
-           Sets the number of samples that will be averaged in the rise and fall sections
-    flat : float
-            Controls the delay between the rise and fall averaging sections, 
-            typically around 3us for ICPC energy estimation, lower for detectors with shorter drift times
-    w_out : array-like
-            Output waveform after trap filter applied
+           The input waveform
+    rise : int
+           The number of samples averaged in the rise and fall sections
+    flat : int
+           The delay between the rise and fall sections
+    w_out: array-like
+           The normalized, filtered waveform
+
     Processing Chain Example
     ------------------------
-    "wf_trap": {
+    "wf_tf": {
         "function": "trap_norm",
         "module": "pygama.dsp.processors",
-        "args": ["wf_pz", "10*us", "3*us", "wf_trap"],
-        "prereqs": ["wf_pz"],
-        "unit": "ADC"
-        },
+        "args": ["wf_pz", "10*us", "3*us", "wf_tf"],
+        "unit": "ADC",
+        "prereqs": ["wf_pz"]
+    }
     """
-    
     w_out[:] = np.nan
 
-    if (np.isnan(w_in).any()):
+    if np.isnan(w_in).any() or np.isnan(rise) or np.isnan(flat):
         return
 
-    if (not  0 <= rise):
-        raise DSPFatal('Rise must be >= 0')
-    
-    if (not  0 <= flat):
-        raise DSPFatal('Flat must be >= 0')
-    
-    if (not 2*rise+flat <= len(w_in)):
-        raise DSPFatal('Trap Filter longer than waveform')
+    if np.floor(rise) != rise:
+        raise DSPFatal('The number of samples in the rise secion must be an integer')
+
+    if np.floor(flat) != flat:
+        raise DSPFatal('The number of samples in the flat secion must be an integer')
+
+    if int(rise) < 0:
+        raise DSPFatal('The number of samples in the rise secion must be positive')
+
+    if int(flat) < 0:
+        raise DSPFatal('The number of samples in the flat secion must be positive')
+
+    if 2 * int(rise) + int(flat) > len(w_in):
+        raise DSPFatal('The trapezoid width is wider than the waveform')
     
     rise_int = int(rise)
     flat_int = int(flat)
-    w_out[0] = w_in[0]/float(rise)
-    for i in range(1, rise_int):
-        w_out[i] = w_out[i-1] + w_in[i]/rise
-    for i in range(rise_int, rise_int+flat_int):
-        w_out[i] = w_out[i-1] + (w_in[i] - w_in[i-rise_int])/rise
-    for i in range(rise_int+flat_int, 2*rise_int+flat_int):
-        w_out[i] = w_out[i-1] + (w_in[i] - w_in[i-rise_int] - w_in[i-rise_int-flat_int])/rise
-    for i in range(2*rise_int+flat_int, len(w_in)):
-        w_out[i] = w_out[i-1] + (w_in[i] - w_in[i-rise_int] - w_in[i-rise_int-flat_int] + w_in[i-2*rise_int-flat_int])/rise
+    w_out[0] = w_in[0] / rise
+    for i in range(1, rise_int, 1):
+        w_out[i] = w_out[i-1] + w_in[i] / rise
+    for i in range(rise_int, rise_int + flat_int, 1):
+        w_out[i] = w_out[i-1] + (w_in[i] - w_in[i-rise_int]) / rise
+    for i in range(rise_int + flat_int, 2 * rise_int + flat_int, 1):
+        w_out[i] = w_out[i-1] + (w_in[i] - w_in[i-rise_int] - w_in[i-rise_int-flat_int]) / rise
+    for i in range(2 * rise_int + flat_int, len(w_in), 1):
+        w_out[i] = w_out[i-1] + (w_in[i] - w_in[i-rise_int] - w_in[i-rise_int-flat_int] + w_in[i-2*rise_int-flat_int]) / rise
 
 @guvectorize(["void(float32[:], float32, float32, float32, float32[:])",
-              "void(float64[:], float32, float32, float32, float64[:])"],
+              "void(float64[:], float64, float64, float64, float64[:])"],
              "(n),(),(),()->(n)", nopython=True, cache=True)
-
 def asym_trap_filter(w_in, rise, flat, fall, w_out):
-       
     """
-    Applies asymmetric trapezoidal filter to the waveform normalized by the integration times
-    Parameters:
+    Apply an asymmetric trapezoidal filter to the waveform, normalized
+    by the number of samples averaged in the rise and fall sections.
+
+    Parameters
     ----------
     w_in : array-like
-           Input Waveform
-    rise : float
-           Sets the number of samples that will be averaged in the rise section
-    flat : float
-            Controls the delay between the rise and fall averaging sections, 
-            typically around 3us for ICPC energy estimation, lower for detectors with shorter drift times
-    rise : float
-           Sets the number of samples that will be averaged in the fall section
-    w_out : array-like
-            Output waveform after trap filter applied
+           The input waveform
+    rise : int
+           The number of samples averaged in the rise section
+    flat : int
+           The delay between the rise and fall sections
+    fall : int
+           The number of samples averaged in the fall section
+    w_out: array-like
+           The normalized, filtered waveform
+
     Processing Chain Example
     ------------------------
-    "wf_atrap": {
+    "wf_af": {
         "function": "asym_trap_filter",
         "module": "pygama.dsp.processors",
-        "args": ["wf_pz", "128*ns", "64*ns","2*us", "wf_atrap"],
-        "prereqs": ["wf_pz"],
-        "unit": "ADC"
-        },
+        "args": ["wf_pz", "128*ns", "64*ns", "2*us", "wf_af"],
+        "unit": "ADC",
+        "prereqs": ["wf_pz"]
+    }
     """
-
     w_out[:] = np.nan
 
-    if (np.isnan(w_in).any()):
+    if np.isnan(w_in).any() or np.isnan(rise) or np.isnan(flat) or np.isnan(fall):
         return
 
-    if (not  0 <= rise):
-        raise DSPFatal('Rise must be >= 0')
-    
-    if (not  0 <= flat):
-        raise DSPFatal('Flat must be >= 0')
+    if np.floor(rise) != rise:
+        raise DSPFatal('The number of samples in the rise secion must be an integer')
 
-    if (not  0 <= fall):
-        raise DSPFatal('Fall must be >= 0')
-    
-    if (not rise+flat+fall <= len(w_in)):
-        raise DSPFatal('Trap Filter longer than waveform')
+    if np.floor(flat) != flat:
+        raise DSPFatal('The number of samples in the flat secion must be an integer')
+
+    if np.floor(fall) != fall:
+        raise DSPFatal('The number of samples in the fall secion must be an integer')
+
+    if int(rise) < 0:
+        raise DSPFatal('The number of samples in the rise secion must be positive')
+
+    if int(flat) < 0:
+        raise DSPFatal('The number of samples in the flat secion must be positive')
+
+    if int(fall) < 0:
+        raise DSPFatal('The number of samples in the fall secion must be positive')
+
+    if int(rise) + int(flat) + int(fall) > len(w_in):
+        raise DSPFatal('The trapezoid width is wider than the waveform')
 
     rise_int = int(rise)
     flat_int = int(flat)
     fall_int = int(fall)
-    w_out[0] = w_in[0]/float(rise)
-    for i in range(1, rise_int):
-        w_out[i] = w_out[i-1] + w_in[i]/rise
-    for i in range(rise_int, rise_int+flat_int):
-        w_out[i] = w_out[i-1] + (w_in[i] - w_in[i-rise_int])/rise
-    for i in range(rise_int+flat_int, rise_int+flat_int+fall_int):
-        w_out[i] = w_out[i-1] + (w_in[i] - w_in[i-rise_int])/rise - w_in[i-rise_int-flat_int]/fall
-    for i in range(rise_int+flat_int+fall_int, len(w_in)):
-        w_out[i] = w_out[i-1] + (w_in[i] - w_in[i-rise_int])/rise - (w_in[i-rise_int-flat_int] - w_in[i-rise_int-flat_int-fall_int])/fall
+    w_out[0] = w_in[0] / rise
+    for i in range(1, rise_int, 1):
+        w_out[i] = w_out[i-1] + w_in[i] / rise
+    for i in range(rise_int, rise_int + flat_int, 1):
+        w_out[i] = w_out[i-1] + (w_in[i] - w_in[i-rise_int]) / rise
+    for i in range(rise_int + flat_int, rise_int + flat_int + fall_int, 1):
+        w_out[i] = w_out[i-1] + (w_in[i] - w_in[i-rise_int]) / rise - w_in[i-rise_int-flat_int] / fall
+    for i in range(rise_int + flat_int + fall_int, len(w_in), 1):
+        w_out[i] = w_out[i-1] + (w_in[i] - w_in[i-rise_int]) / rise - (w_in[i-rise_int-flat_int] - w_in[i-rise_int-flat_int-fall_int]) / fall
 
 @guvectorize(["void(float32[:], float32, float32, float32, float32[:])",
-              "void(float64[:], float32, float32, float32, float64[:])"],
+              "void(float64[:], float64, float64, float64, float64[:])"],
              "(n),(),(),()->()", nopython=True, cache=True)
-
 def trap_pickoff(w_in, rise, flat, t_pickoff, a_out):
     """
-    Gives the value of a trapezoid, normalized by the "rise" (integration) time, at a specific time equal to pickoff_time. Use when the rest of the trapezoid output is extraneous.
+    Pick off the value at the provided index of a symmetric trapezoidal
+    filter to the input waveform, normalized by the number of samples averaged
+    in the rise and fall sections.
     
-    Parameters:
+    Parameters
     ----------
-    w_in : array-like
-           Input Waveform
-    rise : float
-           Sets the number of samples that will be averaged in the rise section
-    flat : float
-            Controls the delay between the rise and fall averaging sections, 
-            typically around 3us for ICPC energy estimation, lower for detectors with shorter drift times
-    t_pickoff : float
-            Time to take sample
-    a_out : float
-            Output waveform after trap filter applied
+    w_in     : array-like
+               The input waveform
+    rise     : int
+               The number of samples averaged in the rise and fall sections
+    flat     : int
+               The delay between the rise and fall sections
+    t_pickoff: int
+               The waveform index to pick off
+    a_out    : float
+               The output pick-off value of the filtered waveform
     
     Processing Chain Example
     ------------------------
     "ct_corr": {
         "function": "trap_pickoff",
         "module": "pygama.dsp.processors",
-        "args":["wf_pz", "1.5*us", 0, "tp_0", "ct_corr"],
+        "args": ["wf_pz", "1.5*us", 0, "tp_0", "ct_corr"],
         "unit": "ADC",
         "prereqs": ["wf_pz", "tp_0"]
-        },
-    
+    }
     """
-
     a_out[0] = np.nan
 
-    if (np.isnan(w_in).any()):
+    if np.isnan(w_in).any() or np.isnan(rise) or np.isnan(flat) or np.isnan(t_pickoff):
         return
 
-    if (not  0 <= t_pickoff <= len(w_in)) :
-        return
+    if np.floor(rise) != rise:
+        raise DSPFatal('The number of samples in the rise secion must be an integer')
 
-    if (not np.floor(t_pickoff)==t_pickoff):
-        raise DSPFatal('Pickoff time is not an integer')
+    if np.floor(flat) != flat:
+        raise DSPFatal('The number of samples in the flat secion must be an integer')
 
-    if (not  0 <= rise):
-        raise DSPFatal('Rise must be >= 0')
-    
-    if (not  0 <= flat):
-        raise DSPFatal('Flat must be >= 0')
+    if np.floor(t_pickoff) != t_pickoff:
+        raise DSPFatal('The pick-off index must be an integer')
 
-    if (not 2*rise+flat <= len(w_in)):
-        raise DSPFatal('Trap Filter longer than waveform')
+    if int(rise) < 0:
+        raise DSPFatal('The number of samples in the rise secion must be positive')
 
+    if int(flat) < 0:
+        raise DSPFatal('The number of samples in the flat secion must be positive')
+
+    if 2 * int(rise) + int(flat) > len(w_in):
+        raise DSPFatal('The trapezoid width is wider than the waveform')
 
     I_1 = 0.
     I_2 = 0.
-    rise_int = int(rise)
-    flat_int = int(flat)
-    start_time = int(t_pickoff + 1) # the +1 makes slicing prettier
-    
-    for i in range(start_time-rise_int, start_time):
+    rise_int   = int(rise)
+    flat_int   = int(flat)
+    start_time = int(t_pickoff + 1)
+    for i in range(start_time - rise_int, start_time, 1):
         I_1 += w_in[i]
-
-    for k in range(start_time - 2*rise_int - flat_int, start_time - rise_int - flat_int):
-        I_2 += w_in[k]
-
-    a_out[0] = (I_1 - I_2)/rise
+    for i in range(start_time - 2 * rise_int - flat_int, start_time - rise_int - flat_int, 1):
+        I_2 += w_in[i]
+    a_out[0] = (I_1 - I_2) / rise

--- a/pygama/dsp/_processors/trap_filters.py
+++ b/pygama/dsp/_processors/trap_filters.py
@@ -36,16 +36,16 @@ def trap_filter(w_in, rise, flat, w_out):
         return
 
     if np.floor(rise) != rise:
-        raise DSPFatal('The number of samples in the rise secion must be an integer')
+        raise DSPFatal('The number of samples in the rise section must be an integer')
 
     if np.floor(flat) != flat:
-        raise DSPFatal('The number of samples in the flat secion must be an integer')
+        raise DSPFatal('The number of samples in the flat section must be an integer')
 
     if int(rise) < 0:
-        raise DSPFatal('The number of samples in the rise secion must be positive')
+        raise DSPFatal('The number of samples in the rise section must be positive')
     
     if int(flat) < 0:
-        raise DSPFatal('The number of samples in the flat secion must be positive')
+        raise DSPFatal('The number of samples in the flat section must be positive')
     
     if 2 * int(rise) + int(flat) > len(w_in):
         raise DSPFatal('The trapezoid width is wider than the waveform')
@@ -97,16 +97,16 @@ def trap_norm(w_in, rise, flat, w_out):
         return
 
     if np.floor(rise) != rise:
-        raise DSPFatal('The number of samples in the rise secion must be an integer')
+        raise DSPFatal('The number of samples in the rise section must be an integer')
 
     if np.floor(flat) != flat:
-        raise DSPFatal('The number of samples in the flat secion must be an integer')
+        raise DSPFatal('The number of samples in the flat section must be an integer')
 
     if int(rise) < 0:
-        raise DSPFatal('The number of samples in the rise secion must be positive')
+        raise DSPFatal('The number of samples in the rise section must be positive')
 
     if int(flat) < 0:
-        raise DSPFatal('The number of samples in the flat secion must be positive')
+        raise DSPFatal('The number of samples in the flat section must be positive')
 
     if 2 * int(rise) + int(flat) > len(w_in):
         raise DSPFatal('The trapezoid width is wider than the waveform')
@@ -160,22 +160,22 @@ def asym_trap_filter(w_in, rise, flat, fall, w_out):
         return
 
     if np.floor(rise) != rise:
-        raise DSPFatal('The number of samples in the rise secion must be an integer')
+        raise DSPFatal('The number of samples in the rise section must be an integer')
 
     if np.floor(flat) != flat:
-        raise DSPFatal('The number of samples in the flat secion must be an integer')
+        raise DSPFatal('The number of samples in the flat section must be an integer')
 
     if np.floor(fall) != fall:
-        raise DSPFatal('The number of samples in the fall secion must be an integer')
+        raise DSPFatal('The number of samples in the fall section must be an integer')
 
     if int(rise) < 0:
-        raise DSPFatal('The number of samples in the rise secion must be positive')
+        raise DSPFatal('The number of samples in the rise section must be positive')
 
     if int(flat) < 0:
-        raise DSPFatal('The number of samples in the flat secion must be positive')
+        raise DSPFatal('The number of samples in the flat section must be positive')
 
     if int(fall) < 0:
-        raise DSPFatal('The number of samples in the fall secion must be positive')
+        raise DSPFatal('The number of samples in the fall section must be positive')
 
     if int(rise) + int(flat) + int(fall) > len(w_in):
         raise DSPFatal('The trapezoid width is wider than the waveform')
@@ -231,19 +231,19 @@ def trap_pickoff(w_in, rise, flat, t_pickoff, a_out):
         return
 
     if np.floor(rise) != rise:
-        raise DSPFatal('The number of samples in the rise secion must be an integer')
+        raise DSPFatal('The number of samples in the rise section must be an integer')
 
     if np.floor(flat) != flat:
-        raise DSPFatal('The number of samples in the flat secion must be an integer')
+        raise DSPFatal('The number of samples in the flat section must be an integer')
 
     if np.floor(t_pickoff) != t_pickoff:
         raise DSPFatal('The pick-off index must be an integer')
 
     if int(rise) < 0:
-        raise DSPFatal('The number of samples in the rise secion must be positive')
+        raise DSPFatal('The number of samples in the rise section must be positive')
 
     if int(flat) < 0:
-        raise DSPFatal('The number of samples in the flat secion must be positive')
+        raise DSPFatal('The number of samples in the flat section must be positive')
 
     if 2 * int(rise) + int(flat) > len(w_in):
         raise DSPFatal('The trapezoid width is wider than the waveform')

--- a/pygama/dsp/_processors/windower.py
+++ b/pygama/dsp/_processors/windower.py
@@ -1,40 +1,46 @@
-from numba import guvectorize
 import numpy as np
+from numba import guvectorize
 from pygama.dsp.errors import DSPFatal
 
-@guvectorize(["void(float32[:], float64, float32[:])",
+@guvectorize(["void(float32[:], float32, float32[:])",
               "void(float64[:], float64, float64[:])"],
              "(n),(),(m)", nopython=True, cache=True)
-def windower(wf_in, t0_in, wf_out):
-    """Waveform windower: returns a shorter sample of the waveform
-    starting at t0_in. Note that the length of the output waveform
-    is determined by the length of wf_out rather than an input parameter!
-    If the the length of wf_out plus t0_in extends past the end of wf_in,
-    or if t0_in<0, pad the remaining values with NaN.
+def windower(w_in, t0_in, w_out):
+    """
+    Return a shorter sample of the waveform, starting at the
+    specified index.  Note that the length of the output waveform
+    is determined by the length of "w_out" rather than an input
+    parameter.  If the the length of "w_out" plus "t0_in" extends
+    past the end of "w_in" or if "t0_in" is negative, remaining
+    values are padded with NaN.
     
     Parameters
     ----------
-    wf_in : array of float32/float64
-            full waveform
-    t0_in : float64
-            start time of window. First index is floor(t0_in).
-    wf_out: array of float32/float64
-            windowed waveform
+    w_in : array-like
+           The input waveform
+    t0_in: int
+           The starting index of the window
+    w_out: array-like
+           The windowed waveform
     """
-    if len(wf_out) >= len(wf_in):
-        raise DSPFatal("Windowed waveform must be smaller than input waveform!")
+    w_out[:] = np.nan
 
-    if np.isnan(t0_in):
-        wf_out[:] = np.nan
+    if np.isnan(w_in).any() or np.isnan(t0_in):
         return
+
+    if np.floor(t0_in) != t0_in:
+        raise DSPFatal('The starting index must be an integer')
+
+    if len(w_out) >= len(w_in):
+        raise DSPFatal('The windowed waveform must be smaller than the input waveform')
     
-    begin = min(np.floor(t0_in), len(wf_in))
-    end = max(begin + len(wf_out), 0)
-    if begin<0:
-        wf_out[:len(wf_out)-end] = np.nan
-        wf_out[len(wf_out)-end:] = wf_in[:end]
-    elif end<len(wf_in):
-        wf_out[:] = wf_in[begin:end]
+    beg = min(int(t0_in), len(w_in))
+    end = max(beg + len(w_out), 0)
+    if beg < 0:
+        w_out[:len(w_out)-end] = np.nan
+        w_out[len(w_out)-end:] = w_in[:end]
+    elif end < len(w_in):
+        w_out[:] = w_in[beg:end]
     else:
-        wf_out[:len(wf_in)-begin] = wf_in[begin:len(wf_in)]
-        wf_out[len(wf_in)-begin:] = np.nan
+        w_out[:len(w_in)-beg] = w_in[beg:len(w_in)]
+        w_out[len(w_in)-beg:] = np.nan


### PR DESCRIPTION
These changes follow up on the discussion in pull request https://github.com/legend-exp/pygama/pull/180.

A set of conventions for the DSP processors—described in template.py—was meant to be established.  This pull request strives to conform the current processors to those desired conventions.  It also strives to format the code in a uniform manner so as to make it easier to read.  The only convention from template.py not established here is the prefixes/suffixes in the function argument names because that discussion seems to be still ongoing.

I've tested these changes on the PGT calibration data using some of the analysis scripts on the `exp-lpgta` branch.  As far as I can tell, the results are the same before and after these commits.  However, my scripts do not utilize all of the DSP processors that have been updated.  It'd be helpful if someone could review and/or test a different subset of processors used in their analysis procedure.  Perhaps after the major refactor, we should develop a unit test for each processor so that such changes in the future can be easily checked.