### PR TITLE
build_processing_chain returns a field_mask

### DIFF
--- a/pygama/dsp/WaveformBrowser.py
+++ b/pygama/dsp/WaveformBrowser.py
@@ -164,7 +164,7 @@ class WaveformBrowser:
         if isinstance(self.norm_par, str): outputs += [self.norm_par]
         if isinstance(self.align_par, str): outputs += [self.align_par] 
         
-        self.proc_chain, self.lh5_out = build_processing_chain(self.lh5_in, dsp_config, db_dict=database, outputs=outputs, verbosity=self.verbosity, block_width=block_width)
+        self.proc_chain, self.field_mask, self.lh5_out = build_processing_chain(self.lh5_in, dsp_config, db_dict=database, outputs=outputs, verbosity=self.verbosity, block_width=block_width)
         
         self.fig = None
         self.ax = None        
@@ -228,6 +228,7 @@ class WaveformBrowser:
                                                           self.lh5_files[file_no],
                                                           start_row=chunk*self.buffer_len,
                                                           n_rows=len(self.lh5_in),
+                                                          field_mask = self.field_mask,
                                                           obj_buf=self.lh5_in)
             self.proc_chain.execute(0, n_read)
             

--- a/pygama/dsp/build_processing_chain.py
+++ b/pygama/dsp/build_processing_chain.py
@@ -14,51 +14,65 @@ def build_processing_chain(lh5_in, dsp_config, db_dict = None,
     Produces a ProcessingChain object and an lh5 table for output parameters
     from an input lh5 table and a json recipe.
     
-    Returns (proc_chain, lh5_out):
-    - proc_chain: ProcessingChain object that is bound to lh5_in and lh5_out;
-      all you need to do is handle file i/o for lh5_in/out and run execute
-    - lh5_out: output LH5 table
-    
-    Required arguments:
-    - lh5_in: input LH5 table
-    - config: dict or name of json file containing a recipe for
-      constructing the ProcessingChain object produced by this function.
-      config is formated as a json dict with different processors. Config
-      should have a dictionary called processors, containing dictionaries
-      of the following format:
-        Key: parameter name: name of parameter produced by the processor.
-             can optionally provide multiple, separated by spaces
-        Values:
-          processor (req): name of gufunc
-          module (req): name of module in which to find processor
-          prereqs (req): name of parameters from other processors and from 
-            input that are required to exist to run this
-          args (req): list of arguments for processor, with variables passed
-            by name or value. Names should either be inputs from lh5_in, or
-            parameter names for other processors. Names of the format db.name
-            will look up the parameter in the metadata. 
-          kwargs (opt): kwargs used when adding processors to proc_chain
-          init_args (opt): args used when initializing a processor that has
-            static data (for factory functions)
-          default (opt): default value for db parameters if not found
-          unit (opt): unit to be used for attr in lh5 file.
-      There may also be a list called 'outputs', containing a list of parameters
-      to put into lh5_out.
-    
-    Optional keyword arguments:
-    - outputs: list of parameters to put in the output lh5 table. If None,
-      use the parameters in the 'outputs' list from config
-    - db_dict: a nested dict pointing to values for db args.
-      e.g. if a processor uses arg db.trap.risetime, it will look up
+    Parameters
+    ----------
+    lh5_in : lgdo.Table
+        HDF5 table from which raw data is read. At least one row of entries
+        should be read in prior to calling this!
+    dsp_config: dict or str
+        A dict or json filename containing the recipes for computing DSP
+        parameter from raw parameters. The format is as follows:
+        {
+            "outputs" : [ "parnames", ... ] -> list of output parameters
+                 to compute by default; see outputs parameter.
+            "processors" : {
+                 "name1, ..." : { -> names of parameters computed
+                      "function" : str -> name of function to call. Function
+                           should implement the gufunc interface, a factory
+                           function returning a gufunc, or an arbitrary
+                           function that can be mapped onto a gufunc
+                      "module" : str -> name of module containing function
+                      "args" : [ str or numeric, ... ] -> list of names of
+                           computed and input parameters or constant values
+                           used as inputs to function. Note that outputs
+                           should be fed by reference as args! Arguments read
+                           from the database are prepended with db.
+                      "kwargs" : dict -> keyword arguments for
+                           ProcesssingChain.add_processor.
+                      "init_args" : [ str or numeric, ... ] -> list of names
+                           of computed and input parameters or constant values
+                           used to initialize a gufunc via a factory function
+                      "unit" : str or [ strs, ... ] -> units for parameters
+                      "defaults" : dict -> default value to be used for
+                           arguments read from the database
+                      "prereqs" : DEPRECATED [ strs, ...] -> list of parameters
+                           that must be computed before these can
+                 }
+    outputs: [str, ...] (optional)
+        List of parameters to put in the output lh5 table. If None,
+        use the parameters in the 'outputs' list from config
+    db_dict: dict (optional)
+        A nested dict pointing to values for db args. e.g. if a processor
+        uses arg db.trap.risetime, it will look up
           db_dict['trap']['risetime']
-      and use the found value. If no value is found, use the default defined
-      in the config file.
-    - verbosity: verbosity level:
-            0: Print nothing (except errors...)
-            1: Print basic warnings (default)
-            2: Print basic debug info
-            3: Print friggin' everything!    
-    - block_width: number of entries to process at once.
+        and use the found value. If no value is found, use the default
+        defined in the config file.
+    verbosity : int (optional)
+        0: Print nothing (except errors...)
+        1: Print basic warnings (default)
+        2: Print basic debug info
+        3: Print friggin' everything!    
+    block_width : int (optional)
+        number of entries to process at once. To optimize performance,
+        a multiple of 16 is preferred, but if performance is not an issue
+        any value can be used.
+    
+    Returns
+    -------
+    (proc_chain, field_mask, lh5_out) : tuple
+        proc_chain : ProcessingChain object that is executed
+        field_mask : List of input fields that are used
+        lh5_out : output lh5 table containing processed values
     """
     proc_chain = ProcessingChain(block_width, lh5_in.size, verbosity = verbosity)
     
@@ -262,4 +276,6 @@ def build_processing_chain(lh5_in, dsp_config, db_dict = None,
         
         buf_out = proc_chain.get_output_buffer(out_par, unit=scale)
         lh5_out.add_field(out_par, lh5.Array(buf_out, attrs={"units":unit}) )
-    return (proc_chain, lh5_out)
+
+    field_mask = input_par_list + copy_par_list
+    return (proc_chain, field_mask, lh5_out)

--- a/pygama/dsp/dsp_optimize.py
+++ b/pygama/dsp/dsp_optimize.py
@@ -37,7 +37,7 @@ def run_one_dsp(tb_data, dsp_config, db_dict=None, fom_function=None, verbosity=
         If fom_function is None, returns the output lh5 table for the DSP iteration
     """
     
-    pc, tb_out = build_processing_chain(tb_data, dsp_config, db_dict=db_dict, verbosity=verbosity)
+    pc, _, tb_out = build_processing_chain(tb_data, dsp_config, db_dict=db_dict, verbosity=verbosity)
     pc.execute()
     if fom_function is not None: return fom_function(tb_out, verbosity)
     else: return tb_out

--- a/pygama/lh5/array.py
+++ b/pygama/lh5/array.py
@@ -58,5 +58,5 @@ class Array:
     def resize(self, new_size):
         """Resize the array to new_size (int)"""
         new_shape = (new_size,) + self.nda.shape[1:]
-        self.nda.resize(new_shape)
+        self.nda = np.resize(self.nda, new_shape)
 

--- a/pygama/lh5/array.py
+++ b/pygama/lh5/array.py
@@ -58,5 +58,5 @@ class Array:
     def resize(self, new_size):
         """Resize the array to new_size (int)"""
         new_shape = (new_size,) + self.nda.shape[1:]
-        self.nda = np.resize(self.nda, new_shape)
+        self.nda.resize(new_shape)
 

--- a/pygama/lh5/store.py
+++ b/pygama/lh5/store.py
@@ -109,14 +109,15 @@ class Store:
             will be sliced to obey those constraints, where n_rows is
             interpreted as the (max) number of -selected- values (in idx) to be
             read out.
-        field_mask : dict or defaultdict { str : bool } (optional)
+        field_mask : dict or defaultdict { str : bool } or list/tuple (optional)
             For tables and structs, determines which fields get written out.
             Only applies to immediate fields of the requested objects. If a dict
             is used, a defaultdict will be made with the default set to the
             opposite of the first element in the dict. This way if one specifies
             a few fields at "false", all but those fields will be read out,
             while if one specifies just a few fields as "true", only those
-            fields will be read out.
+            fields will be read out. If a list is provided, the listed fields
+            will be set to "true", while the rest will default to "false".
         obj_buf : lh5 object (optional)
             Read directly into memory provided in obj_buf. Note: the buffer will
             be expanded to accommodate the data requested. To maintain the
@@ -227,6 +228,8 @@ class Store:
                 if len(field_mask) > 0:
                     default = not field_mask[field_mask.keys[0]]
                 field_mask = defaultdict(lambda : default, field_mask)
+            elif isinstance(field_mask, (list, tuple)):
+                field_mask = defaultdict(lambda : False, { field : True for field in field_mask} )
             elif not isinstance(field_mask, defaultdict):
                 print('bad field_mask of type', type(field_mask).__name__)
                 return None, 0
@@ -274,6 +277,8 @@ class Store:
                 if len(field_mask) > 0:
                     default = not (field_mask[list(field_mask.keys())[0]])
                 field_mask = defaultdict(lambda : default, field_mask)
+            elif isinstance(field_mask, (list, tuple)):
+                field_mask = defaultdict(lambda : False, { field : True for field in field_mask} )
             elif not isinstance(field_mask, defaultdict):
                 print('bad field_mask of type', type(field_mask).__name__)
                 return None, 0


### PR DESCRIPTION
build_processing_chain now returns a field mask so that we don't read every field for every block of data when processing. This also avoids a problem where reading VectorOfVectors caused an error if a reference of the ndarray existed elsewhere. This problem will be fixed long-term by refactoring ProcessingChain to work with LGDO classes. Also:
- Updated build_processing_chain docstring to follow the preferred standard
- field_mask argument in Store.read_object can handle lists