### PR TITLE
DSP Refactor

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/pygama/dsp/_processors/pole_zero.py
+++ b/pygama/dsp/_processors/pole_zero.py
@@ -36,9 +36,6 @@ def pole_zero(w_in, t_tau, w_out):
     if (np.isnan(w_in).any() or np.isnan(t_tau)):
         return
 
-    if (not t_tau > 0):
-        raise DSPFatal('t_tau is out of range, must be >= 0')
-
     const = np.exp(-1/t_tau)
     w_out[0] = w_in[0]
     for i in range(1, len(w_in)):
@@ -83,13 +80,6 @@ def double_pole_zero(w_in, t_tau1, t_tau2, frac, w_out):
 
     if (np.isnan(w_in).any() or np.isnan(t_tau1) or np.isnan(t_tau2) or np.isnan(frac)):
         return
-
-    if (not t_tau1 > 0):
-        raise DSPFatal('t_tau1 is out of range, must be >= 0')
-    if (not t_tau2 > 0):
-        raise DSPFatal('t_tau2 is out of range, must be >= 0')
-    if (not frac >= 0):
-        raise DSPFatal('frac is out of range, must be >= 0')
 
     const1 = 1/t_tau1 #np.exp(-1/t_tau1)
     const2 = 1/t_tau2 #np.exp(-1/t_tau2)

--- a/pygama/dsp/_processors/presum.py
+++ b/pygama/dsp/_processors/presum.py
@@ -1,9 +1,7 @@
 from numba import guvectorize
 
 @guvectorize(["void(float32[:], float32[:])",
-              "void(float64[:], float64[:])",
-              "void(int32[:], int32[:])",
-              "void(int64[:], int64[:])"],
+              "void(float64[:], float64[:])"],
              "(n),(m)", nopython=True, cache=True)
 def presum(wf_in, wf_out):
     """Presum the waveform. Combine bins in chunks of len(wf_in)/len(wf_out),
@@ -12,6 +10,6 @@ def presum(wf_in, wf_out):
     ps_fact = len(wf_in)//len(wf_out)
     for i in range(0, len(wf_out)):
         j0 = i*ps_fact
-        wf_out[i] = wf_in[j0]
+        wf_out[i] = wf_in[j0]/ps_fact
         for j in range(j0+1, j0+ps_fact):
-            wf_out[i] += wf_in[j]
+            wf_out[i] += wf_in[j]/ps_fact

--- a/pygama/dsp/_processors/time_point_thresh.py
+++ b/pygama/dsp/_processors/time_point_thresh.py
@@ -3,8 +3,8 @@ from numba import guvectorize
 import math
 from pygama.dsp.errors import DSPFatal
 
-@guvectorize(["void(float32[:], float32, float32, int32 ,float32[:])",
-              "void(float64[:], float64, float32, int32 ,float32[:])"],
+@guvectorize(["void(float32[:], float32, float64, int32 ,float32[:])",
+              "void(float64[:], float64, float64, int32 ,float32[:])"],
              "(n),(),(),()->()", nopython=True, cache=True)
 
 def time_point_thresh(w_in, a_threshold, t_start, walk_forward, t_out):

--- a/pygama/dsp/_processors/trap_filters.py
+++ b/pygama/dsp/_processors/trap_filters.py
@@ -183,7 +183,9 @@ def asym_trap_filter(w_in, rise, flat, fall, w_out):
 
 def trap_pickoff(w_in, rise, flat, t_pickoff, a_out):
     """
-    Gives the value of a trapezoid, normalized by the "rise" (integration) time, at a specific time equal to pickoff_time. Use when the rest of the trapezoid output is extraneous.
+    Gives the value of a trapezoid, normalized by the "rise" (integration)
+    time, at a specific time equal to pickoff_time. Use when the rest of
+    the trapezoid output is extraneous.
     
     Parameters:
     ----------
@@ -197,7 +199,7 @@ def trap_pickoff(w_in, rise, flat, t_pickoff, a_out):
     t_pickoff : float
             Time to take sample
     a_out : float
-            Output waveform after trap filter applied
+            Output amplitude after trap filter applied
     
     Processing Chain Example
     ------------------------
@@ -216,12 +218,6 @@ def trap_pickoff(w_in, rise, flat, t_pickoff, a_out):
     if (np.isnan(w_in).any()):
         return
 
-    if (not  0 <= t_pickoff <= len(w_in)) :
-        return
-
-    if (not np.floor(t_pickoff)==t_pickoff):
-        raise DSPFatal('Pickoff time is not an integer')
-
     if (not  0 <= rise):
         raise DSPFatal('Rise must be >= 0')
     
@@ -237,6 +233,9 @@ def trap_pickoff(w_in, rise, flat, t_pickoff, a_out):
     rise_int = int(rise)
     flat_int = int(flat)
     start_time = int(t_pickoff + 1) # the +1 makes slicing prettier
+
+    if not len(w_in) >= start_time >= 2*rise_int + flat_int:
+        return
     
     for i in range(start_time-rise_int, start_time):
         I_1 += w_in[i]

--- a/pygama/dsp/build_dsp.py
+++ b/pygama/dsp/build_dsp.py
@@ -6,36 +6,63 @@ import json
 import h5py
 import time
 import numpy as np
-from collections import OrderedDict
-from pprint import pprint
 import argparse
+from importlib.resources import read_text
 
-from pygama import __version__ as pygama_version
-from pygama.dsp.ProcessingChain import ProcessingChain
-from pygama.dsp.units import *
-from pygama import lh5
-from pygama.utils import update_progress
-import pygama.git as git
-from pygama.dsp.build_processing_chain import *
+import pygama
+from pygama import git
+from pygama.dsp.processing_chain import build_processing_chain
 from pygama.dsp.errors import DSPFatal
+import pygama.lgdo.lh5_store as lh5
+from pygama.math.utils import update_progress
 
 def raw_to_dsp(f_raw, f_dsp, dsp_config, lh5_tables=None, database=None,
-               outputs=None, n_max=np.inf, overwrite=True, buffer_len=3200,
+               outputs=None, n_max=np.inf, write_mode='r', buffer_len=3200,
                block_width=16, verbose=1):
     """
-    Uses the ProcessingChain class.
-    The list of processors is specifed via a JSON file.
+    Convert raw-tier LH5 data into dsp-tier LH5 data by running a sequence of
+    processors via the ProcessingChain.
+    
+    Parameters
+    ----------
+    f_raw : str
+        Name of raw LH5 file to read from
+    f_dsp : str
+        Name of dsp LH% file to write to
+    dsp_config : str
+        Name of json file containing ProcessingChain config. See
+        pygama.processing_chain.build_processing_chain for details
+    database : str (optional)
+        Name of json file containing a parameter database. See
+        pygama.processing_chain.build_processing_chain for details
+    outputs : list of strs (optional)
+        List of parameter names to write to f_dsp. If not provided, use
+        list provided in dsp_config
+    n_max : int (optional)
+        Number of waveforms to process. Default all.
+    write_mode : 'r' 'a' or 'u' (optional)
+        'r': Delete old file at f_dsp before writing
+        'a': Append to end of existing f_dsp
+        'u': Update values in existing f_dsp
+    buffer_len : int (optional)
+        Number of waveforms to read/write from disk at a time. Default 3200.
+    block_width : int (optional)
+        Number of waveforms to process at a time. Default 16.
+    verbose : int (optional)
+        0: Silent except for exceptions thrown
+        1: Minimal information printed (default)
+        2: Verbose output for debugging purposes
     """
     t_start = time.time()
 
     if isinstance(dsp_config, str):
         with open(dsp_config, 'r') as config_file:
-            dsp_config = json.load(config_file, object_pairs_hook=OrderedDict)
+            dsp_config = json.load(config_file)
 
     if not isinstance(dsp_config, dict):
         raise Exception('Error, dsp_config must be an dict')
 
-    raw_store = lh5.Store()
+    raw_store = lh5.LH5Store()
     lh5_file = raw_store.gimme_file(f_raw, 'r')
     if lh5_file is None:
         print(f'raw_to_dsp: input file not found: {f_raw}')
@@ -74,7 +101,7 @@ def raw_to_dsp(f_raw, f_dsp, dsp_config, lh5_tables=None, database=None,
         print('database is not a valid json file or dict. Using default db values.')
 
     # clear existing output files
-    if overwrite:
+    if write_mode=='r':
         if os.path.isfile(f_dsp):
             if verbose:
                 print('Overwriting existing file:', f_dsp)
@@ -87,24 +114,42 @@ def raw_to_dsp(f_raw, f_dsp, dsp_config, lh5_tables=None, database=None,
 
         chan_name = tb.split('/')[0]
         db_dict = database.get(chan_name) if database else None
-        lh5_in, n_rows_read = raw_store.read_object(tb, f_raw, start_row=0, n_rows=buffer_len)
-        pc, mask, tb_out = build_processing_chain(lh5_in, dsp_config, db_dict, outputs, verbose, block_width)
+        tb_name = tb.replace('/raw', '/dsp')
+
+        write_offset = 0
+        raw_store.gimme_file(f_dsp, 'a')
+        if write_mode=='a' and raw_store.ls(f_dsp, tb_name):
+            write_offset = raw_store.read_n_rows(tb_name, f_dsp)
 
         print(f'Processing table: {tb} ...')
-        for start_row in range(0, tot_n_rows, buffer_len):
+        lh5_it = lh5.LH5Iterator(f_raw, tb, buffer_len = buffer_len)
+        proc_chain = None
+        tb_out = None
+        for lh5_in, start_row, n_rows in lh5_it:
+            if proc_chain is None:
+                proc_chain, lh5_it.field_mask, tb_out = build_processing_chain(lh5_in, dsp_config, db_dict, outputs, verbose, block_width)
+            
             if verbose > 0:
                 update_progress(start_row/tot_n_rows)
-            lh5_in, n_rows = raw_store.read_object(tb, f_raw, start_row=start_row, n_rows=buffer_len, field_mask = mask, obj_buf=lh5_in)
             n_rows = min(tot_n_rows-start_row, n_rows)
             try:
-                pc.execute(0, n_rows)
+                proc_chain.execute(0, n_rows)
             except DSPFatal as e:
                 # Update the wf_range to reflect the file position
                 e.wf_range = "{}-{}".format(e.wf_range[0]+start_row, e.wf_range[1]+start_row)
                 raise e
             
-            raw_store.write_object(tb_out, tb.replace('/raw', '/dsp'), f_dsp, n_rows=n_rows)
+            raw_store.write_object(obj=tb_out,
+                                   name=tb_name,
+                                   lh5_file=f_dsp,
+                                   n_rows=n_rows,
+                                   wo_mode= 'o' if write_mode=='u' else 'a',
+                                   write_start=write_offset+start_row,
+            )
 
+            if start_row+n_rows > tot_n_rows:
+                break
+            
         if verbose > 0:
             update_progress(1)
         print(f'Done.  Writing to file {f_dsp}')
@@ -116,10 +161,10 @@ def raw_to_dsp(f_raw, f_dsp, dsp_config, lh5_tables=None, database=None,
     dsp_info.add_field('numpy_version', lh5.Scalar(np.version.version))
     dsp_info.add_field('h5py_version', lh5.Scalar(h5py.version.version))
     dsp_info.add_field('hdf5_version', lh5.Scalar(h5py.version.hdf5_version))
-    dsp_info.add_field('pygama_version', lh5.Scalar(pygama_version))
-    dsp_info.add_field('pygama_branch', lh5.Scalar(git.branch))
-    dsp_info.add_field('pygama_revision', lh5.Scalar(git.revision))
-    dsp_info.add_field('pygama_date', lh5.Scalar(git.commit_date))
+    dsp_info.add_field('pygama_version', lh5.Scalar(pygama.__version__))
+    dsp_info.add_field('pygama_branch', lh5.Scalar(pygama.git.branch))
+    dsp_info.add_field('pygama_revision', lh5.Scalar(pygama.git.revision))
+    dsp_info.add_field('pygama_date', lh5.Scalar(pygama.git.commit_date))
     dsp_info.add_field('dsp_config', lh5.Scalar(json.dumps(dsp_config, indent=2)))
     raw_store.write_object(dsp_info, 'dsp_info', f_dsp)
 
@@ -134,34 +179,37 @@ if __name__=="__main__":
 json config file and raw_to_dsp.""")
 
     arg = parser.add_argument
-    arg('file', help="Input (tier 1) LH5 file.")
-    arg('-o', '--output',
-        help="Name of output file. By default, output to ./t2_[input file name].")
-
-    arg('-v', '--verbose', default=1, type=int,
-        help="Verbosity level: 0=silent, 1=basic warnings, 2=verbose output, 3=debug. Default is 2.")
-
-    arg('-b', '--block', default=16, type=int,
-        help="Number of waveforms to process simultaneously. Default is 8")
-
-    arg('-c', '--chunk', default=3200, type=int,
-        help="Number of waveforms to read from disk at a time. Default is 256. THIS IS NOT IMPLEMENTED YET!")
-    arg('-n', '--nevents', default=None, type=int,
-        help="Number of waveforms to process. By default do the whole file")
+    arg('file', help="Input raw LH5 file.")
     arg('-g', '--group', default=None, action='append', type=str,
         help="Name of group in LH5 file. By default process all base groups. Supports wildcards.")
-    defaultconfig = os.path.dirname(os.path.realpath(__loader__.get_filename())) + '/dsp_config.json'
+    defaultconfig = json.loads(read_text(pygama, 'processor_list.json'))
     arg('-j', '--jsonconfig', default=defaultconfig, type=str,
         help="Name of json file used by raw_to_dsp to construct the processing routines used. By default use dsp_config in pygama/apps.")
-    arg('-p', '--outpar', default=None, action='append', type=str,
-        help="Add outpar to list of parameters written to file. By default use the list defined in outputs list in config json file.")
     arg('-d', '--dbfile', default=None, type=str,
         help="JSON file to read DB parameters from. Should be nested dict with channel at the top level, and parameters below that.")
-    arg('-r', '--recreate', action='store_const', const=0, dest='writemode', default=0,
+    arg('-o', '--output',
+        help="Name of output file. By default, output to ./t2_[input file name].")
+    arg('-p', '--outpar', default=None, action='append', type=str,
+        help="Add outpar to list of parameters written to file. By default use the list defined in outputs list in config json file.")
+
+    arg('-n', '--nevents', default=None, type=int,
+        help="Number of waveforms to process. By default do the whole file")
+    
+    arg('-v', '--verbose', action='store_const', const=2, default=1,
+        help="Verbose output, useful for debugging")
+    arg('-q', '--quiet', action='store_const', const=0, dest='verbose',
+        help="Silent output, print only exceptions thrown")
+    
+    arg('-b', '--block', default=16, type=int,
+        help="Number of waveforms to process simultaneously. Default is 8")
+    arg('-c', '--chunk', default=3200, type=int,
+        help="Number of waveforms to read from disk at a time. Default is 256. THIS IS NOT IMPLEMENTED YET!")
+    
+    arg('-r', '--recreate', action='store_const', const='r', dest='writemode', default='r',
         help="Overwrite file if it already exists. Default option. Multually exclusive with --update and --append")
-    arg('-u', '--update', action='store_const', const=1, dest='writemode',
+    arg('-u', '--update', action='store_const', const='u', dest='writemode',
         help="Update existing file with new values. Useful with the --outpar option. Mutually exclusive with --recreate and --append THIS IS NOT IMPLEMENTED YET!")
-    arg('-a', '--append', action='store_const', const=1, dest='writemode',
+    arg('-a', '--append', action='store_const', const='a', dest='writemode',
         help="Append values to existing file. Mutually exclusive with --recreate and --update THIS IS NOT IMPLEMENTED YET!")
     args = parser.parse_args()
 
@@ -169,4 +217,4 @@ json config file and raw_to_dsp.""")
     if out is None:
         out = 't2_'+args.file[args.file.rfind('/')+1:].replace('t1_', '')
 
-    raw_to_dsp(args.file, out, args.jsonconfig, lh5_tables=args.group, database=args.dbfile, verbose=args.verbose, outputs=args.outpar, n_max=args.nevents, overwrite=(args.writemode==0), buffer_len=args.chunk, block_width=args.block)
+    raw_to_dsp(args.file, out, args.jsonconfig, lh5_tables=args.group, database=args.dbfile, verbose=args.verbose, outputs=args.outpar, n_max=args.nevents, write_mode=args.writemode, buffer_len=args.chunk, block_width=args.block)

--- a/pygama/dsp/processing_chain.py
+++ b/pygama/dsp/processing_chain.py
@@ -1,24 +1,240 @@
+from __future__ import annotations
+
 import numpy as np
 import json
 import re
 import ast
 import itertools as it
 import importlib
+from abc import ABCMeta, abstractmethod
+
+from dataclasses import dataclass, field
+from typing import Union
 from copy import deepcopy
 from scimath.units import convert
 from scimath.units.api import unit_parser
 from scimath.units.unit import unit
 
-from pygama.core.units import *
+from numba import vectorize
+
 from pygama import lh5
 
-from pygama.dsp.units import *
-from pygama.dsp.errors import *
+from pygama.lgdo.array import Array
+from pygama.lgdo.arrayofequalsizedarrays import ArrayOfEqualSizedArrays
+from pygama.lgdo.waveform_table import WaveformTable
+from pygama.lgdo.vectorofvectors import VectorOfVectors
 
-ast_ops_dict = {ast.Add: np.add, ast.Sub: np.subtract, ast.Mult: np.multiply,
-                ast.Div: np.divide, ast.FloorDiv: np.floor_divide,
-                ast.USub: np.negative}
+from pygama.math.units import unit_registry as ureg
+from pygama.math.units import Unit, Quantity
 
+# Filler value for variables to be automatically deduced later
+auto = 'auto'
+
+# Map from ast interpretter operations to functions to call and format string
+ast_ops_dict = {ast.Add: (np.add, '{}+{}'),
+                ast.Sub: (np.subtract, '{}-{}'),
+                ast.Mult: (np.multiply, '{}*{}'),
+                ast.Div: (np.divide, '{}/{}'),
+                ast.FloorDiv: (np.floor_divide, '{}//{}'),
+                ast.USub: (np.negative, '-{}')}
+
+@dataclass
+class CoordinateGrid:
+    """Helper class that describes a system of units, consisting of a period
+    and offset. Period is a unitted Quantity, offset is a scalar in units of
+    period, a Unit or a ProcChainVar. In the last case, a ProcessingChain
+    variable is used to store a different offset for each event"""
+    period: Union[Quantity, Unit]
+    offset: Union[float, int, Quantity, ProcChainVar]
+
+    def __post_init__(self):
+        if isinstance(self.period, Unit):
+            self.period *= 1 # make Quantity
+        if isinstance(self.offset, Quantity):
+            self.offset = float(self.offset/self.period)
+
+    def __eq__(self, other):
+        # true if values are equal; if offset is a variable, compare reference
+        return self.period==other.period and \
+            (self.offset is other.offset if isinstance(self.offset, ProcChainVar) else self.offset==other.offset)
+
+    def unit_str(self):
+        str = format(self.period.u, '~')
+        if str=='': str = str(self.period.u)
+        return str
+
+    def get_period(self, unit):
+        if isinstance(unit, str): unit = ureg.Quantity(unit)
+        return float(self.period/unit)
+
+    def get_offset(self, unit=None):
+        # Get the offset (convert)ed to unit. If unit is None use period
+        if unit is None:
+            if isinstance(self.offset, (int, float)):
+                return self.offset
+            unit = self.period.u
+        if isinstance(unit, str): unit = ureg.Quantity(unit)
+
+        if isinstance(self.offset, ProcChainVar):
+            return self.offset.get_buffer(CoordinateGrid(unit, 0))
+        elif isinstance(self.offset, Quantity):
+            return float(self.offset/unit)
+        else:
+            return self.offset * float(self.period/unit)
+
+    def __str__(self):
+        offset = self.offset.name if isinstance(self.offset, ProcChainVar) \
+            else str(self.offset)
+        return "({},{})".format(str(self.period), offset)
+
+class ProcChainVar:
+    """Helper data class with buffer and information for internal variables in
+    ProcessingChain. Members can be set to auto to attempt to deduce these
+    when adding this variable to a processor for the first time"""
+    def __init__(self,
+                 proc_chain: ProcessingChain,
+                 name: str,
+                 shape: tuple = auto,
+                 dtype: np.dtype = auto,
+                 grid: CoordinateGrid = auto,
+                 unit: str = auto,
+                 is_coord: bool = auto ):
+        assert isinstance(proc_chain, ProcessingChain) and isinstance(name, str)
+        self.proc_chain = proc_chain
+        self.name = name
+        
+        self.shape = shape
+        self.dtype = dtype
+        self.grid = grid
+        self.unit = unit
+        self.is_coord = is_coord
+
+        # ndarray containing data buffer of size block_width x shape
+        # list of ndarrays in different coordinate systems if is_coord is true
+        self._buffer: Union[list, np.ndarray] = None
+        
+        self.proc_chain._print(2, 'Added variable:', self.description())
+
+    # Use this to enforce type constraints and perform conversions
+    def __setattr__(self, name, value):
+        if value is auto:
+            pass
+        
+        elif name=='shape':
+            if isinstance(value, int):
+                value = (value,)
+            value = tuple(value)
+            assert all(isinstance(d, int) for d in value)
+
+        elif name=='dtype' and not isinstance(value, np.dtype):
+            value = np.dtype(value)
+
+        elif name=='grid' and not isinstance(value, CoordinateGrid) and not value is None:
+            period, offset = value if isinstance(value, tuple) else value, 0
+            
+            if isinstance(period, str) and period in ureg:
+                period = Quantity(period)
+            elif not isinstance(period, (Quantity, Unit)):
+                raise ProcessingChainError('Cannot parse '+str(period)+' into a valid period.')
+            
+            if isinstance(offset, str):
+                offset = self.proc_chain.get_variable(offset)
+            value = CoordinateGrid(period, offset)
+
+        elif name=='unit' and not value is None:
+            value = str(value)
+            
+        elif name=='is_coord':
+            value = bool(value)
+            if value:
+                if self._buffer is None:
+                    self._buffer = []
+                elif isinstance(self._buffer, np.ndarray):
+                    self._buffer = [(self._buffer, CoordinateGrid(self.unit))]
+
+        super(ProcChainVar, self).__setattr__(name, value)
+        
+    def get_buffer(self, unit=None):
+        # If buffer needs to be created, do so now
+        if self._buffer is None:
+            if self.shape is auto:
+                raise ProcessingChainError("Cannot deduce shape of "+self.name)
+            if self.dtype is auto:
+                raise ProcessingChainError("Cannot deduce shape of "+self.name)
+
+            # create the buffer so that the array start is aligned in memory on a multiple of 64 bytes
+            self._buffer = np.zeros(shape=(self.proc_chain._block_width,)+self.shape, dtype=self.dtype)
+
+        # if variable isn't a coordinate, we're all set
+        if self.is_coord is False or self.is_coord is auto:
+            return self._buffer
+
+        # if no unit is given, use the native unit
+        if unit is None:
+            if isinstance(self.unit, str):
+                unit = CoordinateGrid(self.unit)
+        elif not isinstance(unit, CoordinateGrid):
+            unit = CoordinateGrid(unit)
+
+        # if this is our first time accessing, no conversion is needed
+        if len(self._buffer)==0:
+            if self.shape is auto:
+                raise ProcessingChainError("Cannot deduce shape of "+self.name)
+            if self.dtype is auto:
+                raise ProcessingChainError("Cannot deduce shape of "+self.name)
+            
+            buff = np.zeros(shape=(self.proc_chain._block_width,)+self.shape, dtype=self.dtype)
+            self._buffer.append((buff, unit))
+            return buff
+        
+        # check if coordinate conversion has been done already
+        for buff, grid in self._buffer:
+            if grid == unit:
+                return buff
+
+        # If we get this far, add conversion processor to ProcChain and add new buffer to _buffer
+        conversion_manager = UnitConversionManager(self, unit)
+        self._buffer.append(conversion_manager.out_buffer, unit)
+        self.proc_chain._proc_managers.append(conversion_manager)
+        return out
+
+    @property
+    def buffer(self):
+        return self.get_buffer()
+
+    def description(self):
+        return "{}({}, {}, coords: {}, unit: {}{})".format(self.name, \
+            str(self.shape), str(self.dtype), str(self.grid), \
+            str(self.unit), " (coord)" if self.is_coord is True else '' )
+
+    # Update any variables set to auto; leave the others alone. Emit a messsage
+    # only if anything was updated
+    def update_auto(self, shape=auto, dtype=auto, grid=auto, unit=auto, is_coord=auto):
+        updated = False
+        if self.shape is auto and shape is not auto:
+            self.shape = shape
+            updated = True
+        if self.dtype is auto and dtype is not auto:
+            self.dtype = dtype
+            updated = True
+        if self.grid is auto and grid is not auto:
+            self.grid = grid
+            updated = True
+        if self.unit is auto and unit is not auto:
+            self.unit = unit
+            updated = True
+        if self.is_coord is auto and is_coord is not auto:
+            self.is_coord = is_coord
+            updated = True
+        if updated:
+            self.proc_chain._print(2, 'Updated variable:', self.description())
+        
+    def __str__(self):
+        return self.name
+
+###############################################################################
+############################### The Main Class ################################
+###############################################################################
 
 class ProcessingChain:
     """
@@ -42,168 +258,150 @@ class ProcessingChain:
     available to correctly allocate memory, it can be provided through the
     named variable strings or by calling add_vector or add_scalar.
     """
-    def __init__(self, block_width=8, buffer_len=None, clock_unit=None, verbosity=1):
+    def __init__(self, block_width=8, buffer_len=None, verbosity=1):
         """Named arguments:
         - block_width: number of entries to simultaneously process.
         - buffer_len: length of input and output buffers. Should be a multiple
             of block_width
-        - clock_unit: period or frequency of the clock for all waveforms.
-            constant values with time units will be converted to this unit.
         - verbosity: integer indicating the verbosity level:
             0: Print nothing (except errors...)
             1: Print basic warnings (default)
             2: Print basic debug info
-            3: Print friggin' everything!
         """
-        # Dictionary with numpy arrays containing input and output variables
-        self.__vars_dict = {}
-        # Ordered list of processors and a tuple containing the bound parameters
-        # as either constants or variables from vars_dict
-        self.__proc_list = []
-        self.__proc_strs = []
-        # lists of tuple pairs of external buffers and internal buffers
-        self.__input_buffers = {}
-        # strings of input transforms and variable names for printings
-        self.__output_buffers = {}
+        # Dictionary from name to scratch data buffers as ProcChainVar
+        self._vars_dict = {}
+        # list of processors with variables they are called on
+        self._proc_managers = []
+        # lists of I/O managers that handle copying data to/from external memory buffers
+        self._input_managers = []
+        self._output_managers = []
 
         self._block_width = block_width
         self._buffer_len = buffer_len
-        self._clk = clock_unit
         self._verbosity = verbosity
+
+
+    def add_variable(self, name, dtype=auto, shape=auto, grid=auto, unit=auto, is_coord=auto):
+        """Add a named variable containing a block of values or arrays
+        Parameters
+        ----------
+        name : name of variable
+        dtype : numpy dtype or type string. Default is None, meaning dtype
+            will be deduced later, if possible
+        shape : length or shape tuple of element. Default is None, meaning
+            length will be deduced later, if possible
+        period : unit with period of waveform associated with object
+        offset : unit with offset of waveform associated with object
+        is_coord : if True, transform value based on period and offset
+        """
+        self._validate_name(name, raise_exception=True)
+        if name in self._vars_dict:
+            raise ProcessingChainError(name+' is already in variable list')
         
+        var = ProcChainVar(self, name, shape=shape, dtype=dtype, grid=grid,
+                           unit=unit, is_coord=is_coord)
+        self._vars_dict[name] = var
+        return var
+    
+    
+    def link_input_buffer(self, varname, buff=None):
+        """Link an input buffer to a variable
+        Parameters
+        ----------
+        varname : name of internal variable to copy into buffer at the end
+            of processor execution. If variable does not yet exist, it will
+            be created with a similar shape to the provided buffer
+        buff : numpy array or lgdo class to use as input buffer. If None,
+            create a new buffer with a similar shape to the variable
         
-    def add_waveform(self, name, dtype, length):
-        """Add named variable containing a waveform block with fixed type and length"""
-        self.__add_variable(name, dtype, (self._block_width, length))
-
-
-    def add_scalar(self, name, dtype):
-        """Add named variable containing a scalar block with fixed type"""
-        self.__add_variable(name, dtype, (self._block_width))
-
-
-    def add_input_buffer(self, varname, buff, dtype=None, buffer_len=None, unit=None):
-        """Link an input buffer to a variable. The buffer should be a numpy
-        ndarray with length that is a multiple of the buffer length, the block
-        width, and the named variable length. If any of these are unknown we
-        will try to deduce the right lengths. varname can be of the form:
-          "varname(length, type)[range]"
-        The optional (length, type) field is used to initialize a new variable.
-        The optional [range] field copies from the buffer into a subrange of the
-        array.
-
-        Optional keyword args:
-        - buffer_len: number of entries in buffer. This is needed if we cannot
-          figure it out from the shape (i.e. multi-dimensional buffer fed as
-          a one-dimensional array)
-        - dtype: data type used for the variable. Use this if the variable is
-          automatically allocated here, but with a different type from buff
-        - unit specifies a unit to convert the input from. Unit must have same type as clk, or be a ratio to multiply the input by
+        Return : buff or newly allocated input buffer
         """
-        self.__add_io_buffer(buff, varname, True, dtype, buffer_len, unit)
+        self._validate_name(varname, raise_exception=True)
+        var = self.get_variable(varname)
+        if var is None:
+            var = self.add_variable(varname)
+        
+        if not isinstance(var, ProcChainVar):
+            raise ProcessingChainError("Must link an input buffer to a processing chain variable")
 
+        # Create input buffer that will be linked and returned if none exists
+        if buff is None:
+            if var is None:
+                raise ProcessingChainError(varname+" does not exist and no buffer was provided")
+            elif isinstance(var.grid, CoordinateGrid) and len(var.shape)==1:
+                buff = WaveformTable(size = self._buffer_len,
+                                     wf_len = var.shape[0],
+                                     dtype = var.dtype)
+            elif len(var.shape)==1:
+                buff = Array(shape=(self._buffer_len), dtype = var.dtype)
+            else:
+                buff = np.ndarray((self._buffer_len,) + var.shape[1:], var.dtype)
 
-    def get_input_buffer(self, varname, dtype=None, buffer_len=None, unit=None):
-        """Get the input buffer associated with varname. If there is no such
-        buffer, create one with a shape compatible with the input variable and
-        return it. The input varname has the form:
-          "varname(length, type)[range]"
-        The optional (length, type) field is used to initialize a new variable.
-        The optional [range] field copies a subrange of the named array into the
-        output buffer.
+        # Add the buffer to the input buffers list
+        if isinstance(buff, np.ndarray):
+            out_man = NumpyIOManager(buff, var)
+        elif isinstance(buff, Array):
+            out_man = LGDOsArrayIOManager(buff, var)
+        elif isinstance(buff, WaveformTable):
+            out_man = LGDOWaveformIOManager(buff, var)
+        else:
+            raise ProcessingChainError("Could not link input buffer of unknown type", str(buff))
 
-        Optional keyword arguments:
-        - dtype can be used to specify the numpy data type of the buffer if it
-          should differ from that held in varname
-        - buffer_len specifies the buffer length, if it has not already been set
-        - unit specifies a unit to convert the input from. Unit must have same type as clk, or be a ratio to multiply the input by
+        self._print(2, "Added input buffer:", str(out_man))
+        self._input_managers.append(out_man)
+
+        return buff
+    
+    
+    def link_output_buffer(self, varname, buff=None):
+        """Link an output buffer to a variable
+        Parameters
+        ----------
+        varname : name of internal variable to copy into buffer at the end
+            of processor execution. If variable does not yet exist, it will
+            be created with a similar shape to the provided buffer
+        buff : numpy array or lgdo class to use as output buffer. If None,
+            create a new buffer with a similar shape to the variable
+        
+        Return : buff or newly allocated output buffer
         """
-        name = re.search('(\w+)', varname).group(0)
-        if name not in self.__input_buffers:
-            self.__add_io_buffer(None, varname, True, dtype, buffer_len, unit)
-        return self.__input_buffers[name][0]
+        self._validate_name(varname, raise_exception=True)
+        var = self.get_variable(varname)
+        if var is None:
+            var = self.add_variable(varname)
+        
+        if not isinstance(var, ProcChainVar):
+            raise ProcessingChainError("Must link an output buffer to a processing chain variable")
 
+        # Create output buffer that will be linked and returned if none exists
+        if buff is None:
+            if var is None:
+                raise ProcessingChainError(varname+" does not exist and no buffer was provided")
+            elif isinstance(var.grid, CoordinateGrid) and len(var.shape)==1:
+                buff = WaveformTable(size = self._buffer_len,
+                                     wf_len = var.shape[0],
+                                     dtype = var.dtype)
+            elif len(var.shape)==1:
+                buff = Array(shape=(self._buffer_len), dtype = var.dtype)
+            else:
+                buff = np.ndarray((self._buffer_len,) + var.shape[1:], var.dtype)
 
-    def add_output_buffer(self, varname, buff, dtype=None, buffer_len=None, unit=None):
-        """Link an output buffer to a variable. The buffer should be a numpy
-        ndarray with length that is a multiple of the buffer length, the block
-        width, and the named variable length. If any of these are unknown we
-        will try to deduce the right lengths. varname can be of the form:
-          "varname(length, type)[range]"
-        The optional (length, type) field is used to initialize a new variable.
-        The optional [range] field copies a subrange of the named array into the
-        output buffer.
+        # Add the buffer to the output buffers list
+        if isinstance(buff, np.ndarray):
+            out_man = NumpyIOManager(buff, var)
+        elif isinstance(buff, Array):
+            out_man = LGDOsArrayIOManager(buff, var)
+        elif isinstance(buff, WaveformTable):
+            out_man = LGDOWaveformIOManager(buff, var)
+        else:
+            raise ProcessingChainError("Could not link output buffer of unknown type", str(buff))
 
-        Optional keyword args:
-        - buffer_len: number of entries in buffer. This is needed if we cannot
-          figure it out from the shape (i.e. multi-dimensional buffer fed as
-          a one-dimensional array)
-        - dtype: data type used for the variable. Use this if the variable is
-          automatically allocated here, but with a different type from buff
-        - unit specifies a unit to convert the output into. Unit must have same type as clk, or be a ratio to divide the output by
+        self._print(2, "Added output buffer:", str(out_man))
+        self._output_managers.append(out_man)
 
-        """
-        self.__add_io_buffer(buff, varname, False, dtype, buffer_len, unit)
+        return buff
 
-
-    def get_output_buffer(self, varname, dtype=None, buffer_len=None, unit=None):
-        """Get the output buffer associated with varname. If there is no such
-        buffer, create one with a shape compatible with the input variable and
-        return it. The input varname has the form:
-          "varname(length, type)[range]"
-        The optional (length, type) field is used to initialize a new variable.
-        The optional [range] field copies a subrange of the named array into the
-        output buffer.
-
-        Optional keyword arguments:
-        - dtype can be used to specify the numpy data type of the buffer if it
-          should differ from that held in varname
-        - buffer_len specifies the buffer length, if it has not already been set
-        - unit specifies a unit to convert the output into. Unit must have same type as clk, or be a ratio to divide the output by
-        """
-        name = re.search('(\w+)', varname).group(0)
-        if name not in self.__output_buffers:
-            self.__add_io_buffer(None, varname, False, dtype, buffer_len, unit)
-        return self.__output_buffers[name][0]
-
-
-    def add_processor(self, func, *args, **kwargs):
-        """
-        Add a new processor and bind it to a set of parameters.
-        - func should be a function implementing the numpy ufunc class. If not,
-          then the signature and types keyword arguments will be necessary.
-        - args is a list of names and constants. The names link to internal
-          numpy array variables that will be bound to the function. Names can
-          be given in the form:
-            "varname(length, type)[range]"
-          The optional (length, type) field is used to initialize a new variable
-          if necessary. The optional [range] field copies binds only a subrange
-          of the array to the function. Non-string constant values will be
-          converted to the right type and bound to the function. Constants with
-          scimath time units will be converted to the internal clock unit.
-        - keyword arguments include:
-          - signature: broadcasting signature for a ufunc. By default, use
-            func.signature
-          - types: a list of strings defining the types of arrays needed for
-            the func. By default, use func.types
-        """
-
-        # Get the signature and list of valid types for the function
-        signature = kwargs.get("signature", None)
-        if(signature == None): signature = func.signature
-        if(signature == None):
-            signature = '->'
-            for i in range(func.nin): signature = ',()'+signature
-            for i in range(func.nout): signature = signature+'(),'
-            signature = signature.strip(',')
-
-        types = kwargs.get("types", None)
-        if(types == None): types = func.types.copy()
-        if(types == None):
-            raise ProcessingChainError("Could not find a type signature list for " + func.__name__ + ". Please supply a valid list of types.")
-        for i, typestr in enumerate(types):
-            types[i]=typestr.replace('->', '')
-
+    def add_processor(self, func, *args, signature=None, types=None):
         # make a list of parameters from *args. Replace any strings in the list
         # with numpy objects from vars_dict, where able
         params = []
@@ -214,113 +412,23 @@ class ProcessingChain:
                     param=param_val
             params.append(param)
 
-        # Make sure arrays obey the broadcasting rules, and make a dictionary
-        # of the correct dimensions
-        dims_list = re.findall("\((.*?)\)", signature)
-        dims_dict = {}
-        outerdims = []
-        # print('\nsetting param:', params[-1])
-        # print('dims list is:', dims_list)
-        for ipar, dims in enumerate(dims_list):
-            # print(ipar, dims, params[ipar])
-            if not isinstance(params[ipar], np.ndarray):
-                continue
-
-            fun_dims = outerdims + [d.strip() for d in dims.split(',') if d]
-            arr_dims = list(params[ipar].shape)
-            #check if arr_dims can be broadcast to match fun_dims
-            for i in range(max(len(fun_dims), len(arr_dims))):
-                fd = fun_dims[-i-1] if i<len(fun_dims) else None
-                ad = arr_dims[-i-1] if i<len(arr_dims) else None
-                if(isinstance(fd, str)):
-                    # Define the dimension or make sure it is consistent
-                    if not ad or dims_dict.setdefault(fd, ad)!=ad:
-                        raise ProcessingChainError("Failed to broadcast array dimensions for "+func.__name__+". Could not find consistent value for dimension "+fd)
-                elif not fd:
-                    # if we ran out of function dimensions, add a new outer dim
-                    outerdims.insert(0, ad)
-                elif not ad:
-                    continue
-                elif fd != ad:
-                    # If dimensions disagree, either insert a broadcasted array dimension or raise an exception
-                    if len(fun_dims)>len(arr_dims):
-                        arr_dims.insert(len(arr_dims)-i, 1)
-                    elif len(fun_dims)<len(arr_dims):
-                        outerdims.insert(len(fun_dims)-i, ad)
-                        fun_dims.insert(len(fun_dims)-i, ad)
-                    else:
-                        raise ProcessingChainError("Failed to broadcast array dimensions for "+func.__name__+". Input arrays do not have consistent outer dimensions.")
-
-            # find type signatures that array can be cast into
-            arr_type = params[ipar].dtype.char
-            types = [type_sig for type_sig in types if np.can_cast(arr_type, type_sig[ipar])]
-
-        # Get the type signature we are using
-        if(not types):
-            error_str = "Could not find a type signature matching the types of the variables given for " + func.__name__ + str(tuple(args))
-            for param, name in zip(params, args):
-                if not isinstance(param, np.ndarray): continue
-                error_str += '\n' + name + ': ' + str(param.dtype)
-            raise ProcessingChainError(error_str)
-        # Use the first types in the list that all our types can be cast to
-        types = [np.dtype(t) for t in types[0]]
-
-        # Reshape variable arrays to add broadcast dimensions and allocate new arrays as needed
-        for i, param, dims, dtype in zip(range(len(params)), params, dims_list, types):
-            shape = outerdims + [dims_dict[d.strip()] for d in dims.split(',') if d]
-            if isinstance(param, str):
-                params[i] = self.__add_var(param, dtype, shape)
-            elif isinstance(param, np.ndarray):
-                arshape = list(param.shape)
-                for idim in range(-1, -1-len(shape), -1):
-                    if arshape[idim]!=shape[idim]:
-                        arshape.insert(len(arshape)+idim+1, 1)
-                params[i] = param.reshape(tuple(arshape))
-            else:
-                if isinstance(param, unit):
-                    param = convert(1, param, self._clk)
-                if np.issubdtype(dtype, np.integer):
-                    params[i] = dtype.type(round(param))
-                else:
-                    params[i] = dtype.type(param)
-
-        # Make strings of input variables/constants for later printing
-        proc_strs = []
-        for i, arg in enumerate(args):
-            if isinstance(arg, str):
-                proc_strs.append(arg)
-            else:
-                proc_strs.append(str(params[i]))
-        proc_strs = tuple(proc_strs)
-
-        self.__print(2, 'Added processor:', func.__name__ + str(proc_strs).replace("'", ""))
-
-        # Add the function and bound parameters to the list of processors
-        self.__proc_list.append((func, tuple(params)))
-        self.__proc_strs.append(proc_strs)
-        return None
-
+        proc_man = ProcessorManager(self, func, params, signature, types)
+        self._proc_managers.append(proc_man)
 
     def execute(self, start=0, end=None):
         """Execute the dsp chain on the entire input/output buffers"""
         if end is None: end = self._buffer_len
         for begin in range(start, end, self._block_width):
-            self.execute_block(begin)
-
-
-    def execute_block(self, offset=0):
-        """Execute the dsp chain on a sub-set of the input/output buffers
-        starting at entry offset, with length equal to the internal block size.
-        """
-        end = min(offset+self._block_width, self._buffer_len)
-        self.__execute_procs(offset, end)
+            end = min(offset+self._block_width, self._buffer_len)
+            self._execute_procs(offset, end)
+        
 
 
     def get_variable(self, expr, get_names_only=False):
         """Parse string expr into a numpy array or value, using the following
         syntax:
           - numeric values are parsed into ints or floats
-          - units found in the dsp.units module are parsed into floats
+          - units found in the pint package
           - other strings are parsed into variable names. If get_name_only is
             False, fetch the internal buffer (creating it as needed). Else,
             return a string of the name
@@ -342,8 +450,8 @@ class ProcessingChain:
         """
         names = []
         try:
-            var = self.__parse_expr(ast.parse(expr, mode='eval').body, \
-                                    not get_names_only, names)
+            var = self._parse_expr(ast.parse(expr, mode='eval').body, \
+                                    expr, get_names_only, names)
         except Exception as e:
             raise ProcessingChainError("Could not parse expression:\n  " + expr) from e
         
@@ -351,14 +459,14 @@ class ProcessingChain:
             return var
         else: return names
 
-    
-    def __parse_expr(self, node, allocate_memory, var_name_list):
+
+    def _parse_expr(self, node, expr, dry_run, var_name_list):
         """
         helper function for get_variable that recursively evaluates the AST tree
         based on: https://stackoverflow.com/a/9558001. Whenever we encounter
         a variable name, add it to var_name_list (which should begin as an
         empty list). Only add new variables and processors to the chain if
-        allocate_memory is True
+        dry_run is True
         """
         if node is None:
             return None
@@ -368,283 +476,177 @@ class ProcessingChain:
 
         elif isinstance(node, ast.Str):
             return node.s
-
+        
         elif isinstance(node, ast.Constant):
             return node.val
 
         # look for name in variable dictionary
         elif isinstance(node, ast.Name):
             # check if it is a unit
-            val = unit_parser.parse_unit(node.id)
-            if val.is_valid():
-                try:
-                    return convert(1, val, self._clk)
-                except:
-                    return None
+            if node.id in ureg:
+                return ureg.Unit(node.id)
 
             #check if it is a variable
             var_name_list.append(node.id)
-            val = self.__vars_dict.get(node.id, None)
+            val = self._vars_dict.get(node.id, None)
             return val
 
         # define binary operators (+,-,*,/)
         elif isinstance(node, ast.BinOp):
-            lhs = self.__parse_expr(node.left, allocate_memory, var_name_list)
-            if lhs is None: return None
-            rhs = self.__parse_expr(node.right, allocate_memory, var_name_list)
-            if rhs is None: return None
-            op = ast_ops_dict[type(node.op)]
-            if isinstance(lhs, np.ndarray) or isinstance(rhs, np.ndarray):
-                if not isinstance(lhs, np.ndarray):
-                    if np.issubdtype(rhs.dtype, np.integer):
-                        lhs = rhs.dtype.type(round(lhs))
-                    else:
-                        lhs = rhs.dtype.type(lhs)
-                if not isinstance(rhs, np.ndarray):
-                    if np.issubdtype(lhs.dtype, np.integer):
-                        rhs = lhs.dtype.type(round(rhs))
-                    else:
-                        rhs = lhs.dtype.type(rhs)
-                out = op(lhs, rhs)
-                if allocate_memory:
-                    self.__proc_list.append((op, (lhs, rhs, out)))
-                    self.__proc_strs.append("Binary operator: " + op.__name__)
-                return out
-            return op(lhs, rhs)
+            lhs = self._parse_expr(node.left, expr, dry_run, var_name_list)
+            rhs = self._parse_expr(node.right, expr, dry_run, var_name_list)
+            if rhs is None or lhs is None: return None
+            op, op_form = ast_ops_dict[type(node.op)]
+
+            if not (isinstance(lhs, ProcChainVar) or isinstance(rhs, ProcChainVar)):
+                return op(lhs, rhs)
+
+            name = '('+op_form.format(str(lhs), str(rhs))+')'
+            if isinstance(lhs, ProcChainVar) and isinstance(rhs, ProcChainVar):
+                #TODO: handle units/coords; for now make them match lhs
+                out = ProcChainVar(self, name, is_coord=lhs.is_coord)
+            elif isinstance(lhs, ProcChainVar):
+                out = ProcChainVar(self, name, lhs.shape, lhs.dtype, lhs.grid, lhs.unit, is_coord=lhs.is_coord)
+            else:
+                out = ProcChainVar(self, name, rhs.shape, rhs.dtype, rhs.grid, rhs.unit, is_coord=rhs.is_coord)
+                
+            self._proc_managers.append(ProcessorManager(self, op, [lhs, rhs, out]))
+            return out
 
         # define unary operators (-)
         elif isinstance(node, ast.UnaryOp):
-            operand = self.__parse_expr(node.operand, allocate_memory, var_name_list)
+            operand = self._parse_expr(node.operand, expr, dry_run, var_name_list)
             if operand is None: return None
-            op = ast_ops_dict[type(node.op)]
-            out = op(operand)
-            # if we have a np array, add to processor list
-            if isinstance(out, np.ndarray) and allocate_memory:
-                self.__proc_list.append((op, (operand, out)))
-                self.__proc_strs.append("Unary operator: " + op.__name__)
+            op, op_form = ast_ops_dict[type(node.op)]
+            name = '('+op_form.format(str(operand))+')'
+            
+            if isinstance(operand, ProcChainVar):
+                out = ProcChainVar(self, name, operand.shape, operand.dtype,
+                              operand.grid, operand.unit, operand.is_coord)
+                self._proc_managers.append(ProcessorManager(self, op, [operand, out]))
+            else:
+                out = op(out)
+
             return out
 
         elif isinstance(node, ast.Subscript):
             # print(ast.dump(node))
-            val = self.__parse_expr(node.value, allocate_memory, var_name_list)
+            val = self._parse_expr(node.value, expr, dry_run, var_name_list)
             if val is None: return None
+            if not isinstance(val, ProcChainVar):
+                raise ProcessingChainError("Cannot apply subscript to", node.value)
+
+            def get_index(slice_value):
+                ret = self._parse_expr(slice_value, expr, dry_run, var_name_list)
+                if isinstance(ret, Quantity):
+                    ret = float(ret/val.grid.period)
+                if isinstance(ret, float):
+                    round_ret = int(round(ret))
+                    if abs(ret - round_ret) > 0.0001:
+                        self._print(0, 'Slice value', str(slice_value), \
+                                    'is non-integer. Rounding to', round_ret)
+                    return round_ret
+                return int(ret)
+
+            out = val
             if isinstance(node.slice, ast.Index):
-                if isinstance(val, np.ndarray):
-                    return val[..., self.__parse_expr(node.slice.value, allocate_memory, var_name_list)]
-                else:
-                    return val[self.__parse_expr(node.slice.value, allocate_memory, var_name_list)]
+                out.buffer = val[..., get_index(node.slice.value)]
             elif isinstance(node.slice, ast.Slice):
-                if isinstance(val, np.ndarray):
-                    return val[..., slice(self.__parse_expr(node.slice.lower, allocate_memory, var_name_list),
-                                          self.__parse_expr(node.slice.upper, allocate_memory, var_name_list),
-                                          self.__parse_expr(node.slice.step, allocate_memory, var_name_list) )]
-                else:
-                    return val[slice(self.__parse_expr(node.slice.upper, allocate_memory, var_name_list),self.__parse_expr(node.slice.lower, allocate_memory, var_name_list),self.__parse_expr(node.slice.step, allocate_memory, var_name_list))]
+                sl = slice(get_index(node.slice.lower),
+                           get_index(node.slice.upper),
+                           get_index(node.slice.step) )
+                out.buffer = val[..., sl]
+                if sl.start is not None:
+                    out.grid[1] += out.grid[0] * sl.start
+                if sl.step is not None:
+                    out.grid[0] *= sl.step
+
             elif isinstance(node.slice, ast.ExtSlice):
                 slices = tuple(node.slice.dims)
                 for i, sl in enumerate(slices):
                     if isinstance(sl, ast.index):
-                        slices[i] = self.__parse_expr(sl.value, allocate_memory, var_name_list)
+                        slices[i] = self._parse_expr(sl.value, expr, dry_run, var_name_list)
                     else:
-                        slices[i] = slice(self.__parse_expr(sl.upper, allocate_memory, var_name_list),
-                                          self.__parse_expr(sl.lower, allocate_memory, var_name_list),
-                                          self.__parse_expr(sl.step, allocate_memory, var_name_list) )
-                return val[..., slices]
+                        slices[i] = slice(self._parse_expr(sl.upper, expr, dry_run, var_name_list),
+                                          self._parse_expr(sl.lower, expr, dry_run, var_name_list),
+                                          self._parse_expr(sl.step, expr, dry_run, var_name_list) )
+                out.buffer = val[..., slices]
+            return out
 
         # for name.attribute
         elif isinstance(node, ast.Attribute):
-            val = self.__parse_expr(node.value, allocate_memory, var_name_list)
+            val = self._parse_expr(node.value, expr, dry_run, var_name_list)
             if val is None: return None
             # get shape with buffer_len dimension removed
             if node.attr=='shape' and isinstance(val, np.ndarray):
                 return val.shape[1:]
 
-        # for func([args])
+        # for func(args, kwargs)
         elif isinstance(node, ast.Call):
-            func = node.func.id
-            # get length of 1D array variable
-            if func=="len" and len(node.args)==1 and isinstance(node.args[0], ast.Name):
-                var = self.__parse_expr(node.args[0], allocate_memory, var_name_list)
-                if var is None: return None
-                if isinstance(var, np.ndarray) and len(var.shape)==2:
-                    return var.shape[1]
+            func = self.func_list.get(node.func.id, None)
+            args = [ self._parse_expr(arg, expr, dry_run, var_name_list) \
+                     for arg in node.args ]
+            kwargs = { kwarg.arg:self._parse_expr(kwarg.value, expr, dry_run, var_name_list) for kwarg in node.keywords }
+            if func is not None:
+                return func(self, *args, **kwargs)
+            elif self._validate_name(node.func.id):
+                var_name = node.func.id
+                var_name_list.append(var_name)
+                if var_name in self._vars_dict:
+                    return var
+                elif not dry_run:
+                    return self.add_variable(var_name, *args, **kwargs)
                 else:
-                    raise ProcessingChainError("len(): " + node.args[0].id + "has wrong number of dims")
-            elif func=="round" and len(node.args)==1:
-                var = self.__parse_expr(node.args[0], allocate_memory, var_name_list)
-                if var is None: return None
-                return int(round(var))
-            # if this is a valid call to construct a new array, do so; otherwise raise an exception
-            else:
-                if len(node.args)==2:
-                    shape = self.__parse_expr(node.args[0], allocate_memory, var_name_list)
-                    if shape is None:
-                        shape = (self._block_width,)
-                    if isinstance(shape, (int, np.int32, np.int64)):
-                        shape = (self._block_width, shape)
-                    elif isinstance(shape, tuple):
-                        shape = (self._block_width, ) + shape
-                    else:
-                        raise ProcessingChainError("Do not recognize call to "+func+" with arguments of types " + str([arg.__dict__ for arg in node.args]))
-                    try: dtype = np.dtype(node.args[1].id)
-                    except: raise ProcessingChainError("Do not recognize call to "+func+" with arguments of types " + str([arg.__dict__ for arg in node.args]))
-                    
-                    var_name_list.append(func)
-                    
-                    if func in self.__vars_dict:
-                        var = self.__vars_dict[func]
-                        if not var.shape==shape and var.dtype==dtype:
-                            raise ProcessingChainError("Requested shape and type for " + func + " do not match existing values")
-                        return var
-                    else:
-                        var = np.zeros(shape, dtype, 'F')
-                        if allocate_memory:
-                            self.__vars_dict[func] = var
-                            self.__print(2, 'Added variable', func, 'with shape', tuple(shape), 'and type', dtype)
+                    return None
 
-                        return var
-                else:
-                    raise ProcessingChainError("Do not recognize call to "+func+" with arguments " + str([str(arg.__dict__) for arg in node.args]))
+            else:
+                raise ProcessingChainError("Do not recognize call to "+func+" with arguments " + str([str(arg.__dict__) for arg in node.args]))
 
         raise ProcessingChainError("Cannot parse AST nodes of type " + str(node.__dict__))
 
+    # Get length of ProcChainVar
+    def _length(self, var):
+        if not isinstance(var, ProcChainVar):
+            raise ProcessingChainError("Cannot call len() on " + str(var))
+        if not len(var.buffer.shape)==2:
+            raise ProcessingChainError(str(var)+" has wrong number of dims")
+        return var.buffer.shape[1]
 
-    def __add_var(self, name, dtype, shape):
-        """
-        Add an array of zeros to the vars dict called name and return it
-        """
-        if not re.match("\A\w+$", name):
-            raise ProcessingChainError(name+' is not a valid alphanumeric name')
-        if name in self.__vars_dict:
-            raise ProcessingChainError(name+' is already in variable list')
-        arr = np.zeros(shape, dtype)
-        self.__vars_dict[name] = arr
-        self.__print(2, 'Added variable', re.search('(\w+)', name).group(0), 'with shape', tuple(shape), 'and type', dtype)
-        return arr
+    def _validate_name(self, name, raise_exception=False):
+        """Check that name is alphanumeric, and not an already used keyword"""
+        isgood = re.match("\A\w+$", name) and name not in self.func_list \
+            and not name in ureg
+        if raise_exception and not isgood:
+            raise ProcessingChainError(name+" is not a valid variable name")
+        return isgood
 
-    
-    def __execute_procs(self, start, end):
+
+    def _execute_procs(self, start, end):
         """
         copy from input buffers to variables
         call all the processors on their paired arg tuples
         copy from variables to list of output buffers
         """
-        # Track names that have been printed so we only print each variable once
-        if self._verbosity >= 3:
-            names = set(self.__vars_dict.keys())
-            self.__print(3, 'Input:')
-
         # Copy input buffers into proc chain buffers
-        for name, (buf, var, scale) in self.__input_buffers.items():
-            if scale:
-                np.multiply(buf[start:end, ...], scale, var[0:end-start, ...])
-            else:
-                np.copyto(var[0:end-start, ...], buf[start:end, ...], 'unsafe')
-
-            if self._verbosity >= 3:
-                self.__print(3, name, '=', var)
-                names.discard(name)
+        for in_man in self._input_managers:
+            in_man.read(start, end)
 
         # Loop through processors and run each one
-        self.__print(3, 'Processing:')
-        for (func, args), strs in zip(self.__proc_list, self.__proc_strs):
+        for proc_man in self._proc_managers:
             try:
-                func(*args)
+                proc_man.execute()
             except DSPFatal as e:
-                e.processor = func.__name__ + str(strs).replace("'", "")
+                e.processor = str(proc_man)
                 e.wf_range = (start, end)
                 raise e
-                
-            if self._verbosity >= 3:
-                self.__print(3, func.__name__ + str(strs).replace("'", ""))
-                for name, arg in zip(strs, args):
-                    try:
-                        names.remove(name)
-                        self.__print(3, name, '=', arg)
-                    except: pass
 
         # copy from processing chain buffers into output buffers
-        self.__print(3, 'Output:')
-        for name, (buf, var, scale) in self.__output_buffers.items():
-            if scale:
-                np.divide(var[0:end-start, ...], scale, buf[start:end, ...])
-            else:
-                np.copyto(buf[start:end, ...], var[0:end-start, ...], 'unsafe')
-
-            self.__print(3, name, '=', var)
-
-    
-    def __add_io_buffer(self, buff, varname, input, dtype, buffer_len, scale):
-        """
-        append a tuple with the buffer and variable to either the input buffer
-        list (if input=true) or output buffer list (if input=false), making sure
-        that buffer shapes are compatible
-        """
-        var = self.get_variable(varname)
-        if buff is not None and not isinstance(buff, np.ndarray):
-            raise ProcessingChainError("Buffers must be ndarrays.")
-
-        # if buffer length is not defined, figure out what it should be
-        if buffer_len is not None:
-            if self._buffer_len is None:
-                self._buffer_len = buffer_len
-            elif self._buffer_len != buffer_len:
-                raise ProcessingChainError("Buffer length was already set to a number different than the one provided. To change the buffer length, you must reset the buffers.")
-        if not self._buffer_len:
-            if buff is not None: self._buffer_len = buff.shape[0]
-            else: self._buffer_len = self._block_width
-            self.__print(1, "Setting i/o buffer length to", self._buffer_len)
-
-        # if a unit is given, convert it to a scaling factor
-        if isinstance(scale, unit):
-            scale = convert(1, scale, self._clk)
-
-        # if no buffer was provided, make one
-        returnbuffer=False
-        if buff is None:
-            if var is None:
-                raise ProcessingChainError("Cannot make buffer for non-existent variable " + varname)
-            # deduce dtype. If scale is used, force float type
-            if not dtype:
-                if not scale:
-                    dtype=var.dtype
-                else:
-                    dtype=np.dtype('float'+str(var.dtype.itemsize*8))
-            buff = np.zeros((self._buffer_len,)+var.shape[1:], dtype)
-            returnbuffer=True
-
-        # Check that the buffer length is correct. For 1D buffer, reshape
-        # it if possible, assuming array of structure ordering
-        if not buff.shape[0] == self._buffer_len:
-            if buff.ndim==1 and len(buff)%self._buffer_len==0:
-                buff = buff.reshape(self._buffer_len, len(buff)//self._buffer_len)
-            else:
-                raise ProcessingChainError("Buffer provided for " + varname + " is the wrong length.")
-
-        # Check that shape of buffer is compatible with shape of variable.
-        # If variable does not yet exist, add it here
-        if var is None:
-            if dtype is None:
-                if not scale:
-                    dtype=buff.dtype
-                else:
-                    dtype=np.dtype('float'+str(buff.dtype.itemsize*8))
-            var = self.__add_var(varname, dtype, (self._block_width,)+buff.shape[1:])
-        elif var.shape[1:] != buff.shape[1:]:
-            raise ProcessingChainError("Provided buffer has shape " + str(buff.shape) + " which is not compatible with " + str(varname) + " shape " + str(var.shape))
-
-        varname = re.search('(\w+)', varname).group(0)
-        if input:
-            self.__input_buffers[varname]=(buff, var, scale)
-            self.__print(2, 'Binding input buffer of shape', buff.shape, 'and type', buff.dtype, 'to variable', varname, 'with shape', var.shape, 'and type', var.dtype)
-        else:
-            self.__output_buffers[varname]=(buff, var, scale)
-            self.__print(2, 'Binding output buffer of shape', buff.shape, 'and type', buff.dtype, 'to variable', varname, 'with shape', var.shape, 'and type', var.dtype)
-
-        if returnbuffer: return buff
+        for out_man in self._output_managers:
+            io_man.write(start, end)
 
 
-    def __print(self, verbosity, *args, **kwargs):
+
+    def _print(self, verbosity, *args, **kwargs):
         """Helper for output that checks verbosity before printing and
         converts things into strings. At verbosity 0, print to stderr"""
         if verbosity==0 and not 'file' in kwargs:
@@ -654,12 +656,358 @@ class ProcessingChain:
 
 
     def __str__(self):
-        ret = 'Input variables: ' + str([name for name in self.__input_buffers.keys()])
-        for proc, strs in zip(self.__proc_list, self.__proc_strs):
-            ret += '\n' + proc[0].__name__ + str(strs)
-        ret += '\nOutput variables: ' + str([name for name in self.__output_buffers.keys()])
-        return ret.replace("'", "")
+        return 'Input variables:\n  ' \
+        + '\n  '.join([str(in_man) for in_man in self._input_managers]) \
+        + '\nProcessors:\n  ' \
+        + '\n  '.join([str(proc_man) for proc_man in self._proc_managers]) \
+        + '\nOutput variables:\n  ' \
+        + '\n  '.join([str(out_man) for out_man in self._output_managers])
 
+    # Map from function names when using ast interpretter to ProcessorChain functions that can be called
+    func_list = {'len':_length,
+                 'round':round, }
+    #'period':get_period,
+    #'offset':get_offset }
+
+
+########################################################################### 
+# The class that calls processors and makes sure variables are compatible #
+###########################################################################
+class ProcessorManager:
+
+    @dataclass
+    class DimInfo:
+        length : int # length of arrays in this dimension
+        grid : CoordinateGrid # period and offset of arrays in this dimension
+    
+    def __init__(self, proc_chain, func, params, signature=None, types=None):
+        assert isinstance(proc_chain, ProcessingChain) and callable(func) \
+            and isinstance(params, list)
+
+        # reference back to our processing chain
+        self.proc_chain = proc_chain
+        # callable function used to process data
+        self.processor = func
+        # list of parameters prior to converting to internal representation
+        self.params = params
+        # list of raw values and buffers from params; we will fill this soon
+        self.raw_params = []
+        
+        # Get the signature and list of valid types for the function
+        if signature is None:
+            self.signature = func.signature
+        if self.signature is None:
+            self.signature = ','.join(['()']*func.nin) + '->' \
+                           + ','.join(['()']*func.nout)
+        
+        # Get list of allowed type signatures
+        if types is None:
+            types = func.types.copy()
+        if types is None:
+            raise ProcessingChainError("Could not find a type signature list for " + func.__name__ + ". Please supply a valid list of types.")
+        if not isinstance(types, list):
+            types = [types]
+        types = [ typestr.replace('->', '') for typestr in types]
+        
+        # Make sure arrays obey the broadcasting rules, and make a dictionary
+        # of the correct dimensions and unit system
+        dims_list = re.findall("\((.*?)\)", self.signature)
+
+        if not len(dims_list)==len(params):
+            raise ProcessingChainError("Expected {} arguments from signature {}; found {}: ({})".format(len(dims_list), self.signature, len(params), ', '.join([str(par) for par in params])))
+        
+        dims_dict = {} # map from dim name -> DimInfo
+        outerdims = [] # list of DimInfo
+        grid = None # period/offset to use for unit and coordinate conversions
+
+        for ipar, dims in enumerate(dims_list):
+            param = self.params[ipar]
+            if not isinstance(param, ProcChainVar):
+                continue
+
+            # find type signatures that match type of array
+            if param.dtype is not auto:
+                arr_type = param.dtype.char
+                types = [type_sig for type_sig in types if arr_type==type_sig[ipar]]
+
+            # fill out dimensions from dim signature and check if it works
+            if param.shape is auto:
+                continue
+            fun_dims = [od for od in outerdims] + \
+                [d.strip() for d in dims.split(',') if d]
+            arr_dims = list(param.shape)
+            arr_grid = param.grid if param.grid is not auto else None
+            if not grid:
+                grid = arr_grid
+
+            #check if arr_dims can be broadcast to match fun_dims
+            for i in range(max(len(fun_dims), len(arr_dims))):
+                fd = fun_dims[-i-1] if i<len(fun_dims) else None
+                ad = arr_dims[-i-1] if i<len(arr_dims) else None
+                
+                if(isinstance(fd, str)):
+                    if fd in dims_dict:
+                        this_dim = dims_dict[fd]
+                        if not ad or this_dim.length!=ad:
+                            raise ProcessingChainError("Failed to broadcast array dimensions for "+func.__name__+". Could not find consistent value for dimension "+fd)
+                        if not this_dim.grid:
+                            dims_dict[fd].grid = arr_grid
+                        elif arr_grid and arr_grid!=this_dim.grid:
+                            self._print(0, "Arrays of dimension", fd, "for", func.__name__, "do not have consistent period and offset!")
+                    else:
+                        dims_dict[fd] = self.DimInfo(ad, arr_grid)
+                
+                elif not fd:
+                    # if we ran out of function dimensions, add a new outer dim
+                    outerdims.insert(0, self.DimInfo(ad, arr_grid))
+                    
+                elif not ad:
+                    continue
+                
+                elif fd.length != ad:
+                    # If dimensions disagree, either insert a broadcasted array dimension or raise an exception
+                    if len(fun_dims)>len(arr_dims):
+                        arr_dims.insert(len(arr_dims)-i, 1)
+                    elif len(fun_dims)<len(arr_dims):
+                        outerdims.insert(len(fun_dims)-i, self.DimInfo(ad, arr_grid))
+                        fun_dims.insert(len(fun_dims)-i, ad)
+                    else:
+                        raise ProcessingChainError("Failed to broadcast array dimensions for "+func.__name__+". Input arrays do not have consistent outer dimensions.")
+                elif not fd.grid:
+                    outerdims[len(fun_dims)-i].grid = arr_grid
+                
+                elif arr_grid and fd.grid!=arr_grid:
+                    self._print(0, "Arrays of dimension", fd, "for", func.__name__, "do not have consistent period and offset!")
+
+                arr_grid = None # this is only used for inner most dim
+
+
+        # Get the type signature we are using
+        if(not types):
+            error_str = "Could not find a type signature matching the types of the variables given for " + func.__name__ + str(tuple(args))
+            for param, name in zip(self.params, args):
+                if not isinstance(param, np.ndarray): continue
+                error_str += '\n' + name + ': ' + str(param.dtype)
+            raise ProcessingChainError(error_str)
+        # Use the first types in the list that all our types can be cast to
+        self.types = types[0]
+        types = [np.dtype(t) for t in self.types]
+
+        # Finish setting up of input parameters for function
+        #   Reshape variable arrays to add broadcast dimensions
+        #   Allocate new arrays as needed
+        #   Convert coords to right system of units as needed
+        for i, (param, dims, dtype) in enumerate(zip(self.params, dims_list, types)):
+            dim_list = [d for d in outerdims] + \
+                [dims_dict[d.strip()] for d in dims.split(',') if d]
+            shape = tuple([d.length for d in dim_list])
+            this_grid = dim_list[-1].grid if dim_list else None
+            
+            if isinstance(param, str):
+                # Create a new variable with the right dimensions and such
+                param = self.proc_chain.add_variable(param, dtype=np.dtype(dtype), shape=shape, grid=this_grid, unit=None, is_coord=False)
+                self.params[i] = param
+                self.raw_params.append(param.buffer)
+                
+            elif isinstance(param, ProcChainVar):
+                # Deduce any automated descriptions of parameter
+                unit = None
+                is_coord = False
+                if param.is_coord==True and grid is not None:
+                    unit = str(grid.period.u)
+                elif isinstance(param.unit, str) and param.unit in ureg and grid is not None and ureg.is_compatible_with(grid.period, param.unit):
+                    is_coord = True
+
+                param.update_auto(shape=shape,
+                                  dtype=np.dtype(dtype),
+                                  grid=this_grid,
+                                  unit=unit,
+                                  is_coord=is_coord)
+
+                if param.is_coord and not grid:
+                    grid = param.unit
+                raw_param = param.get_buffer(grid)
+                
+                # reshape just in case there are some missing dimensions
+                arshape = list(raw_param.shape)
+                for idim in range(-1, -1-len(shape), -1):
+                    if arshape[idim]!=shape[idim]:
+                        arshape.insert(len(arshape)+idim+1, 1)
+                self.raw_params.append(raw_param.reshape(tuple(arshape)))
+                
+            else:
+                # Convert scalar to right type, including units
+                if isinstance(param, (Quantity, Unit)):
+                    if grid is None or not ureg.is_compatible_with(grid.period, param):
+                        raise ProcessingChainError("Could not find valid conversion for " + str(param))
+                    param = float(param/grid.period)
+                if np.issubdtype(dtype, np.integer):
+                    self.raw_params.append(dtype.type(round(param)))
+                else:
+                    self.raw_params.append(dtype.type(param))
+        
+        self.proc_chain._print(2, 'Added processor:', str(self))
+
+    def execute(self):
+        self.processor(*self.raw_params)
+
+    def __str__(self):
+        return self.processor.__name__ + '(' \
+            + ", ".join([str(par) for par in self.params]) + ')'
+        
+
+
+# A special processor manager for handling converting variables between unit systems
+class UnitConvertionManager(ProcessorManager):
+    @vectorize(nopython=True, cache=True)
+    def convert(buf_in, offset_in, offset_out, period_ratio):
+        return (buf_in - offset_in) * period_ratio + offset_out
+    
+    def __init__(self, var, unit):
+        # reference back to our processing chain
+        self.proc_chain = var.proc_chain
+        # callable function used to process data
+        self.processor = UnitConversionManager.convert
+        # list of parameters prior to converting to internal representation
+        self.params = [var, unit]
+        # list of raw values and buffers from params; we will fill this soon
+        self.raw_params = []
+        
+        from_buffer, from_grid = var._buffer[0]
+        period_ratio = from_grid.get_period(unit.period)
+        self.out_buffer = np.zeros_like(from_buffer)
+        self.raw_params = [from_buffer, from_grid.get_offset(),
+                           unit.get_offset(), period_ratio, to_buffer]
+        self.proc_chain._print(2, 'Added conversion:', str(self))
+        
+##########################################################################
+# Now, classes to manage I/O from buffers into ProcessingChain variables #
+##########################################################################
+
+# Base class. IOManagers will be associated with a type of input/output
+#  buffer, and must define a read and write for each one. __init__ methods
+#  should update variable with any information from buffer, and check that
+#  buffer and variable are compatible.
+class IOManager(metaclass=ABCMeta):
+    @abstractmethod
+    def read(self, start: int, end: int):
+        pass
+
+    @abstractmethod
+    def write(self, start: int, end: int):
+        pass
+
+    @abstractmethod
+    def __str__(self):
+        pass
+
+
+# Ok, this one's not LGDO
+class NumpyIOManager(IOManager):
+    def __init__(self, io_buf, var):
+        assert isinstance(io_buf, np.ndarray) \
+            and isinstance(var, ProcChainVar)
+        
+        var.update_auto(dtype = io_buf.dtype,
+                        shape = io_buf.shape[1:])
+        
+        if var.shape != io_buf.shape[1:] or var.dtype != io_buf.dtype:
+            raise ProcessingChainError("numpy.array<{}>\{{}\}@{}) is not compatible with variable {}".format(self.io_buf.shape, self.io_buf.dtype, self.io_buf.data, str(self.var)))
+
+        self.io_buf = io_buf
+        self.var = var
+        self.raw_var = var.buffer
+
+    def read(self, start, end):
+        np.copyto(self.raw_var[0:end-start, ...],
+                  self.io_buf[start:end, ...], 'unsafe')
+
+    def write(self, start, end):
+        np.copyto(self.io_buf[start:end, ...],
+                  self.raw_var[0:end-start, ...], 'unsafe')
+
+    def __str__(self):
+        return '{} linked to numpy.array({}, {})@{})'.format(str(self.var), self.io_buf.shape, self.io_buf.dtype, self.io_buf.data)
+
+
+class LGDOArrayIOManager(IOManager):
+    def __init__(self, io_array, variable):
+        assert isinstance(io_buffer, np.ndarray) \
+            and isinatance(variable, ProcChainVar)
+
+        unit = io_array.attrs.get('units', None)
+        var.update_auto(dtype = io_array.dtype,
+                        shape = io_array.nda.shape[1:],
+                        unit = unit )
+        
+        if var.shape != io_array.nda.shape[1:] or var.dtype != io_array.dtype:
+            raise ProcessingChainError('LGDO object {}@{} is incompatible with {}'.format(self.io_buf.form_datatype(), self.raw_buf.data, str(self.var)))
+
+        if isinstance(var.unit, CoordinateGrid):
+            if unit is None:
+                unit = var.unit.period.u
+            elif ureg.is_compatible_with(var.unit.period, unit):
+                unit = ureg.Quantity(unit).u
+            else:
+                raise ProcessingChainError("LGDO array and variable {} have incompatible units ({} and {})".format(str(var), str(var.unit.period.u), str(unit)))
+        
+        if unit is None and not var.unit is None:
+            io_array.attrs['units'] = str(grid.period)
+        ureg.is_compatible_with(grid.period, param.unit)
+        self.io_array = io_array
+        self.raw_buf = io_array.nda
+        self.var = var.get_buffer(unit)
+        
+
+    def read(self, start, end):
+        np.copyto(self.raw_var[0:end-start, ...],
+                  self.raw_buf[start:end, ...], 'unsafe')
+
+    def write(self, start, end):
+        np.copyto(self.raw_buf[start:end, ...],
+                  self.raw[0:end-start, ...], 'unsafe')
+
+    def __str__(self):
+        return '{} linked to {}'.format(str(self.var), str(self.io_buf))
+
+
+# Waveforms
+class LGDOWaveformIOManager(IOManager):
+    def __init__(self, wf_table: WaveformTable, variable: ProcChainVar):
+        assert isinstance(wf_table, WaveformTable) \
+            and isinstance(variable, ProcChainVar)
+
+        self.wf_table = wf_table
+        self.wf_buf = wf_table.values.nda
+        self.t0_buf = wf_table.t0.nda
+        self.dt_buf = wf_table.dt.nda
+
+        period = wf_table.dt_units
+        if isinstance(period, str) and period in ureg:
+            grid = CoordinateGrid(ureg.Quantity(self.dt_buf[0], period), self.t0_buf[0])
+        else:
+            grid = None
+        
+        self.var = variable
+        self.var.update_auto(shape = self.wf_buf.shape[1:],
+                             dtype = self.wf_buf.dtype,
+                             grid = grid,
+                             unit = wf_table.values_units,
+                             is_coord = False)
+        
+        self.wf_var = self.var.buffer
+        self.t0_var = self.var.grid.get_offset(wf_table.t0_units)
+
+    def read(self, start, end):
+        self.wf_var[0:end-start, ...] = self.wf_buf[start:end, ...]
+
+    def write(self, start, end):
+        self.wf_buf[start:end, ...] = self.wf_var[0:end-start, ...]
+        self.t0_buf[start:end, ...] = self.t0_var[0:end-start, ...]
+
+    def __str__(self):
+        return  '{} linked to {}'.format(str(self.var), str(self.wf_table))
+    
 
 
 def build_processing_chain(lh5_in, dsp_config, db_dict = None,
@@ -667,12 +1015,12 @@ def build_processing_chain(lh5_in, dsp_config, db_dict = None,
     """
     Produces a ProcessingChain object and an lh5 table for output parameters
     from an input lh5 table and a json recipe.
-    
+
     Returns (proc_chain, lh5_out):
     - proc_chain: ProcessingChain object that is bound to lh5_in and lh5_out;
       all you need to do is handle file i/o for lh5_in/out and run execute
     - lh5_out: output LH5 table
-    
+
     Required arguments:
     - lh5_in: input LH5 table
     - config: dict or name of json file containing a recipe for
@@ -685,12 +1033,12 @@ def build_processing_chain(lh5_in, dsp_config, db_dict = None,
         Values:
           processor (req): name of gufunc
           module (req): name of module in which to find processor
-          prereqs (req): name of parameters from other processors and from 
+          prereqs (req): name of parameters from other processors and from
             input that are required to exist to run this
           args (req): list of arguments for processor, with variables passed
             by name or value. Names should either be inputs from lh5_in, or
             parameter names for other processors. Names of the format db.name
-            will look up the parameter in the metadata. 
+            will look up the parameter in the metadata.
           kwargs (opt): kwargs used when adding processors to proc_chain
           init_args (opt): args used when initializing a processor that has
             static data (for factory functions)
@@ -698,7 +1046,7 @@ def build_processing_chain(lh5_in, dsp_config, db_dict = None,
           unit (opt): unit to be used for attr in lh5 file.
       There may also be a list called 'outputs', containing a list of parameters
       to put into lh5_out.
-    
+
     Optional keyword arguments:
     - outputs: list of parameters to put in the output lh5 table. If None,
       use the parameters in the 'outputs' list from config
@@ -711,11 +1059,10 @@ def build_processing_chain(lh5_in, dsp_config, db_dict = None,
             0: Print nothing (except errors...)
             1: Print basic warnings (default)
             2: Print basic debug info
-            3: Print friggin' everything!    
     - block_width: number of entries to process at once.
     """
     proc_chain = ProcessingChain(block_width, lh5_in.size, verbosity = verbosity)
-    
+
     if isinstance(dsp_config, str):
         with open(dsp_config) as f:
             dsp_config = json.load(f)
@@ -729,7 +1076,7 @@ def build_processing_chain(lh5_in, dsp_config, db_dict = None,
         outputs = dsp_config['outputs']
 
     processors = dsp_config['processors']
-    
+
     # prepare the processor list
     multi_out_procs = {}
     for key, node in processors.items():
@@ -753,7 +1100,7 @@ def build_processing_chain(lh5_in, dsp_config, db_dict = None,
             print("Prereqs for", key, "are", node['prereqs'])
 
     processors.update(multi_out_procs)
-    
+
     # Recursive function to crawl through the parameters/processors and get
     # a sequence of unique parameters such that parameters always appear after
     # their dependencies. For parameters that are not produced by the ProcChain
@@ -776,7 +1123,7 @@ def build_processing_chain(lh5_in, dsp_config, db_dict = None,
         if isinstance(node, str):
             resolve_dependencies(node, resolved, leafs, unresolved)
             return
-        
+
         edges = node['prereqs']
         unresolved.append(par)
         for edge in edges:
@@ -800,23 +1147,13 @@ def build_processing_chain(lh5_in, dsp_config, db_dict = None,
         print('Required input parameters:', str(input_par_list))
         print('Copied output parameters:', str(copy_par_list))
         print('Processed output parameters:', str(out_par_list))
-    
+
     # Now add all of the input buffers from lh5_in (and also the clk time)
     for input_par in input_par_list:
         buf_in = lh5_in.get(input_par)
         if buf_in is None:
             print("I don't know what to do with " + input_par + ". Building output without it!")
-        elif isinstance(buf_in, lh5.Array):
-            proc_chain.add_input_buffer(input_par, buf_in.nda)
-        elif isinstance(buf_in, lh5.Table):
-            # check if this is waveform
-            if 't0' and 'dt' and 'values' in buf_in:
-                proc_chain.add_input_buffer(input_par, buf_in['values'].nda, 'float32')
-                clk = buf_in['dt'].nda[0] * unit_parser.parse_unit(lh5_in['waveform']['dt'].attrs['units'])
-                if proc_chain._clk is not None and proc_chain._clk != clk:
-                    print("Somehow you managed to set multiple clock frequencies...Using " + str(proc_chain._clk))
-                else:
-                    proc_chain._clk = clk
+        proc_chain.link_input_buffer(input_par, buf_in)
 
     # now add the processors
     for proc_par in proc_par_list:
@@ -824,6 +1161,17 @@ def build_processing_chain(lh5_in, dsp_config, db_dict = None,
         module = importlib.import_module(recipe['module'])
         func = getattr(module, recipe['function'])
         args = recipe['args']
+
+        # Initialize the new variables, if needed
+        if 'unit' in recipe:
+            new_vars = [k for k in re.split(",| ", recipe) if k!='']
+            for i, name in enumerate(new_vars):
+                unit = recipe.get('unit', auto)
+                if isinstance(unit, list): unit = unit[i]
+                
+                proc_chain.add_variable(name, unit=unit)
+            
+        # Parse the list of args
         for i, arg in enumerate(args):
             if isinstance(arg, str) and arg[0:3]=='db.':
                 lookup_path = arg[3:].split('.')
@@ -841,8 +1189,10 @@ def build_processing_chain(lh5_in, dsp_config, db_dict = None,
                             print("Database lookup: using default value of", args[i], "for", arg)
                     except (KeyError, TypeError):
                         raise ProcessingChainError('Did not find', arg, 'in database, and could not find default value.')
-            
+
+        # get this list of kwargs
         kwargs = recipe.get('kwargs', {}) # might also need db lookup here
+        
         # if init_args are defined, parse any strings and then call func
         # as a factory/constructor function
         try:
@@ -869,7 +1219,7 @@ def build_processing_chain(lh5_in, dsp_config, db_dict = None,
                 # see if string can be parsed by proc_chain
                 if isinstance(arg, str):
                     init_args[i] = proc_chain.get_variable(arg)
-                    
+
             if(verbosity>1):
                 print("Building function", func.__name__, "from init_args", init_args)
             func = func(*init_args)
@@ -877,44 +1227,22 @@ def build_processing_chain(lh5_in, dsp_config, db_dict = None,
             pass
         proc_chain.add_processor(func, *args, **kwargs)
 
-    
+
     # build the output buffers
     lh5_out = lh5.Table(size=proc_chain._buffer_len)
-    
+
     # add inputs that are directly copied
     for copy_par in copy_par_list:
         buf_in = lh5_in.get(copy_par)
-        if isinstance(buf_in, lh5.Array):
-            lh5_out.add_field(copy_par, buf_in)
-        elif isinstance(buf_in, lh5.Table):
-            # check if this is waveform
-            if 't0' and 'dt' and 'values' in buf_in:
-                lh5_out.add_field(copy_par, buf_in['values'])
-                clk = buf_in['dt'].nda[0] * unit_parser.parse_unit(lh5_in['waveform']['dt'].attrs['units'])
-                if proc_chain._clk is not None and proc_chain._clk != clk:
-                    print("Somehow you managed to set multiple clock frequencies...Using " + str(proc_chain._clk))
-                else:
-                    proc_chain._clk = clk
-        else:
+        if buf_in is None:
             print("I don't know what to do with " + input_par + ". Building output without it!")
+        else:
+            lh5_out.add_field(copy_par, buf_in)
     
     # finally, add the output buffers to lh5_out and the proc chain
     for out_par in out_par_list:
-        recipe = processors[out_par]
-        # special case for proc with multiple outputs
-        if isinstance(recipe, str):
-            i = [k for k in re.split(",| ", recipe) if k!=''].index(out_par)
-            recipe = processors[recipe]
-            unit = recipe['unit'][i]
-        else:
-            unit = recipe['unit']
-        
-        try:
-            scale = convert(1, unit_parser.parse_unit(unit), clk)
-        except InvalidConversion:
-            scale = None
-        
-        buf_out = proc_chain.get_output_buffer(out_par, unit=scale)
+        buf_out = proc_chain.link_output_buffer(out_par)
         lh5_out.add_field(out_par, lh5.Array(buf_out, attrs={"units":unit}) )
+    
     return (proc_chain, lh5_out)
 

--- a/pygama/lgdo/lh5_store.py
+++ b/pygama/lgdo/lh5_store.py
@@ -5,6 +5,9 @@ import fnmatch
 from collections import defaultdict
 from bisect import bisect_left
 
+import pandas as pd
+import glob
+
 from .lgdo_utils import *
 from .scalar import Scalar
 from .struct import Struct
@@ -54,7 +57,7 @@ class LH5Store:
             if not overwrite and grp_attrs != group.attrs:
                 print('warning: grp_attrs != group.attrs but overwrite not set')
                 print('ignoring grp_attrs')
-            else: 
+            elif overwrite:
                 if verbosity > 0: print(f'overwriting {group}.attrs...')
                 group.attrs = {}
                 group.attrs.update(grp_attrs)
@@ -153,10 +156,6 @@ class LH5Store:
             buffer.  For scalars and structs n_rows_read will be "1". For tables
             it is redundant with table.loc
         """
-        #TODO: Ian's idea: add an iterator so one can do something like
-        #      for data in lh5iterator(file, chunksize, nentries, ...):
-        #          proc.execute()
-
         # Handle list-of-files recursively
         if not isinstance(lh5_file, (str, h5py._hl.files.File)):
             lh5_file = list(lh5_file)
@@ -199,7 +198,7 @@ class LH5Store:
 
         # get the file from the store
         h5f = self.gimme_file(lh5_file, 'r', verbosity=verbosity)
-        if name not in h5f:
+        if not h5f or name not in h5f:
             print('LH5Store:', name, "not in", lh5_file)
             return None, 0
 
@@ -317,8 +316,8 @@ class LH5Store:
                                                                 obj_buf=fld_buf,
                                                                 obj_buf_start=obj_buf_start,
                                                                 verbosity=verbosity)
-                if obj_buf is not None and obj_buf_start+n_rows_read > len(obj_buf):
-                    obj_buf.resize(obj_buf_start+n_rows_read, do_warn=(verbosity>0))
+                if obj_buf is not None and obj_buf_start+n_rows > len(obj_buf):
+                    obj_buf.resize(obj_buf_start+n_rows, do_warn=(verbosity>0))
                 rows_read.append(n_rows_read)
             # warn if all columns don't read in the same number of rows
             n_rows_read = rows_read[0]
@@ -654,7 +653,7 @@ class LH5Store:
         in lh5_file. Return None if it is a scalar/struct."""
         # this is basically a stripped down version of read_object
         h5f = self.gimme_file(lh5_file, 'r')
-        if name not in h5f:
+        if not h5f or name not in h5f:
             print('LH5Store:', name, "not in", lh5_file)
             return None
 
@@ -761,3 +760,133 @@ def load_dfs(f_list, par_list, lh5_group='', idx_list=None, verbose=True):
         data for the associated parameters concatenated over all files in f_list
     """
     return pd.DataFrame( load_nda(f_list, par_list, lh5_group, verbose) )
+
+
+class LH5Iterator:
+    """
+    A class for iterating through one or more LH5 files, one block of entries
+    at a time. This also accepts an entry list/mask to enable event selection,
+    and a field mask.
+    
+    This class can be used either for random access:
+        lh5_obj, n_rows = lh5_it.read(entry)
+    to read the block of entries starting at entry. In case of multiple files
+    or the use of an event selection, entry refers to a global event index
+    accros files and does not count events that are excluded by the selection.
+    
+    This can also be used as an iterator:
+        for lh5_obj, entry, n_rows in LH5Iterator(...):
+            do the thing!
+    
+    This is intended for if you are reading a large quantity of data but
+    want to limit your memory usage (particularly when reading in waveforms!).
+    The lh5_obj that is read by this class is reused in order to avoid
+    reallocation of memory; this means that if you want to hold on to data
+    between reads, you will have to copy it somewhere!
+    """
+    def __init__(self, lh5_files, group, base_path='', entry_list=None, entry_mask=None, field_mask=None, buffer_len=3200):
+        """
+        Parameters
+        ----------
+        lh5_files : str or list
+            File or files to read from. May include wildcards and env vars
+        group : str
+            HDF5 group to read
+        selection_list : list-like or nested list-like of ints (optional)
+            List of entry numbers to read. If a nested list is provided,
+            expect one top-level list for each file, containing a list of
+            local entries. If a list of ints is provided, use global entries
+        entry_mask : array of bools or list of arrays of bools (optional)
+            Mask of entries to read. If a list of arrays is provided, expect
+            one for each file. Ignore if a selection list is provided...
+        field_mask : dict or defaultdict { str : bool } or list/tuple (optional)
+            Mask of which fields to read. See read_object for more details.
+        buffer_len : int (default 3200)
+            Number of entries to read at a time while iterating through files
+        """
+        self.lh5_st = LH5Store(base_path=base_path, keep_open=True)
+        
+        # List of files, with wildcards and env vars expanded
+        if isinstance(lh5_files, str): lh5_files = [lh5_files]
+        self.lh5_files = [f for f_wc in lh5_files for f in sorted(glob.glob(os.path.expandvars(f_wc)))]
+        # Map to last row in each file
+        self.file_map = np.array([self.lh5_st.read_n_rows(group, f) for f in self.lh5_files], 'int64').cumsum()
+        self.group = group
+        self.buffer_len = buffer_len
+        
+        self.lh5_buffer = self.lh5_st.get_buffer(self.group, self.lh5_files[0], self.buffer_len) if len(self.lh5_files)>0 else None
+        self.n_rows = 0
+        self.current_entry = 0
+
+        self.field_mask = field_mask
+        
+        # List of entry indices from each file
+        self.entry_list = None
+        if entry_list is not None:
+            entry_list = list(entry_list)
+            if is_instance(x[0], int):
+                entry_list.sort()
+                i_start = 0
+                self.entry_list = []
+                for f_end in self.file_map:
+                    i_stop = bisect.bisect_right(entry_list, f_end, lo=i_start)
+                    self.entry_list.append(entry_list[i_start:i_stop])
+                    i_start = i_stop
+
+            else:
+                self.entry_list = [[]]*len(self.file_map)
+                for i_file, local_list in enumerate(entry_list):
+                    self.entry_list[i_file] = list(local_list)
+                    
+        elif entry_mask is not None:
+            # Convert entry mask into an entry list
+            if isinstance(entry_mask, pd.Series):
+                entry_mask = entry_mask.values
+            if isinstance(entry_mask, np.ndarray):
+                self.entry_list = []
+                f_start = 0
+                for i_file, f_end in enumerate(self.file_map):
+                    self.entry_list.append(list(np.nonzero(entry_mask[f_start:f_end])[0]))
+                    f_start = f_end
+            else:
+                self.entry_list = [[]]*len(self.file_map)
+                for i_file, local_mask in enumerate(entry_mask):
+                    self.entry_list[i_file] = list(np.nonzero(local_mask)[0])
+
+        # Map to last entry of each file
+        self.entry_map = self.file_map if self.entry_list is None else \
+            np.array([len(elist) for elist in self.entry_list]).cumsum()
+
+
+    def read(self, entry):
+        """Read the next chunk of events, starting at entry. Return the
+        lh5 buffer and number of rows read"""
+        i_file = np.searchsorted(self.entry_map, entry, 'right')
+        local_entry = entry
+        if i_file>0: local_entry -= self.entry_map[i_file-1]
+        self.n_rows = 0
+        
+        while(self.n_rows < self.buffer_len and i_file < len(self.file_map)):
+            # Loop through files
+            local_idx = self.entry_list[i_file] if self.entry_list is not None else None
+            i_local = local_idx[local_entry] if local_idx is not None else local_entry
+            self.lh5_buffer, n_rows = self.lh5_st.read_object(self.group, self.lh5_files[i_file], start_row = i_local, n_rows = self.buffer_len - self.n_rows, idx = local_idx, field_mask = self.field_mask, obj_buf = self.lh5_buffer, obj_buf_start = self.n_rows )
+            
+            self.n_rows += n_rows
+            i_file += 1
+            local_entry = 0
+
+        self.current_entry = entry
+        return (self.lh5_buffer, self.n_rows)
+    
+    def __len__(self):
+        """Total number of entries"""
+        return self.entry_map[-1] if len(self.entry_map)>0 else 0
+
+    def __iter__(self):
+        """Loop through entries in blocks of size buffer_len"""
+        entry=0
+        while entry < len(self):
+            buf, n_rows = self.read(entry)
+            yield (buf, entry, n_rows)
+            entry += n_rows

--- a/pygama/lgdo/lh5_store.py
+++ b/pygama/lgdo/lh5_store.py
@@ -13,6 +13,7 @@ from .array import Array
 from .fixedsizearray import FixedSizeArray
 from .arrayofequalsizedarrays import ArrayOfEqualSizedArrays
 from .vectorofvectors import VectorOfVectors
+from .waveform_table import WaveformTable
 
 
 class LH5Store:

--- a/pygama/lgdo/waveform_table.py
+++ b/pygama/lgdo/waveform_table.py
@@ -24,7 +24,7 @@ class WaveformTable(Table):
     compression routine is used.
     """
 
-    def __init__(self, size=None, t0=0, t0_units=None, dt=1, dt_units=None, 
+    def __init__(self, size=None, t0=0, t0_units=None, dt=1, dt_units=None,
                  values=None, values_units=None, wf_len=None, dtype=None, attrs={}):
         """
         Parameters
@@ -77,7 +77,7 @@ class WaveformTable(Table):
             if nda.shape != shape: nda.resize(shape)
             t0 = Array(nda=nda)
         if t0_units is not None: t0.attrs['units'] = f'{t0_units}'
-            
+
         if not isinstance(dt, Array):
             shape = (size,)
             dt_dtype = dt.dtype if hasattr(dt, 'dtype') else np.float32
@@ -106,3 +106,34 @@ class WaveformTable(Table):
         col_dict['dt'] = dt
         col_dict['values'] = values
         super().__init__(size=size, col_dict=col_dict, attrs=attrs)
+
+    @property
+    def values(self):
+        return self['values']
+    @property
+    def values_units(self):
+        return self.values.attrs.get('units', None)
+    @values_units.setter
+    def values_units(self, units):
+        self.values.attrs['units'] = f'{units}'
+
+    @property
+    def t0(self):
+        return self['t0']
+    @property
+    def t0_units(self):
+        return self.t0.attrs.get('units', None)
+    @t0_units.setter
+    def t0_units(self, units):
+        self.t0.attrs['units'] = f'{units}'
+
+    @property
+    def dt(self):
+        return self['dt']
+
+    @property
+    def dt_units(self):
+        return self.dt.attrs.get('units', None)
+    @dt_units.setter
+    def dt_units(self, units):
+        self.dt.attrs['units'] = f'{units}'

--- a/pygama/lgdo/waveform_table.py
+++ b/pygama/lgdo/waveform_table.py
@@ -116,7 +116,10 @@ class WaveformTable(Table):
     @values_units.setter
     def values_units(self, units):
         self.values.attrs['units'] = f'{units}'
-
+    @property
+    def wf_len(self):
+        return self.values.nda.shape[1]
+    
     @property
     def t0(self):
         return self['t0']

--- a/pygama/math/units.py
+++ b/pygama/math/units.py
@@ -1,16 +1,8 @@
-from scimath.units.unit import unit
-from scimath.units.api import unit_parser
-from scimath.units.time import *
-from scimath.units.frequency import *
-from scimath.units.convert import convert, convert_str, InvalidConversion
-import sys
+from pint import UnitRegistry, Unit, Quantity, Measurement, set_application_registry
 
-ghz = 1000000000*hz
-ghz.label = 'gHz'
-gigahertz = ghz
+unit_registry = UnitRegistry(auto_reduce_dimensions=True)
+set_application_registry(unit_registry)
 
-mhz = 1000000*hz
-mhz.label = 'MHz'
-megahertz = mhz
-
-unit_parser.parser.extend(sys.modules['pygama.dsp.units'])
+# Define constants useful for LEGEND below
+unit_registry.define('m_76 = 75.921402729 * amu') # 10.1103/PhysRevC.81.032501
+unit_registry.define('Q_bb = 2039.061 * keV') # 10.1103/PhysRevC.81.032501

--- a/pygama/pargen/dsp_optimize.py
+++ b/pygama/pargen/dsp_optimize.py
@@ -37,7 +37,7 @@ def run_one_dsp(tb_data, dsp_config, db_dict=None, fom_function=None, verbosity=
         If fom_function is None, returns the output lh5 table for the DSP iteration
     """
     
-    pc, tb_out = build_processing_chain(tb_data, dsp_config, db_dict=db_dict, verbosity=verbosity)
+    pc, _, tb_out = build_processing_chain(tb_data, dsp_config, db_dict=db_dict, verbosity=verbosity)
     pc.execute()
     if fom_function is not None: return fom_function(tb_out, verbosity)
     else: return tb_out

--- a/pygama/processor_list.json
+++ b/pygama/processor_list.json
@@ -11,8 +11,7 @@
       "module": "numpy",
       "args": ["waveform", 1, "max_index"],
       "kwargs": {"signature":"(n),()->()", "types":["fi->i"]},
-      "unit": "ADC",
-      "prereqs":["waveform"]
+      "unit": "ADC"
     },
 
 
@@ -20,7 +19,6 @@
       "function": "linear_slope_fit",
       "module": "pygama.dsp.processors",
       "args" : ["waveform[:1650]", "bl","bl_sig", "slope","intercept"],
-      "prereqs": ["waveform"],
       "unit": ["ADC","ADC","ADC","ADC"]
     },
 
@@ -28,7 +26,6 @@
        "function": "subtract",
        "module": "numpy",
        "args": ["waveform", "bl", "wf_blsub"],
-       "prereqs": ["waveform", "bl"],
        "unit": "ADC"
     },
 
@@ -37,7 +34,6 @@
           "function": "log_check",
           "module": "pygama.dsp.processors",
           "args": ["wf_blsub[2100:]", "wf_logged"],
-          "prereqs": ["wf_blsub"],
           "unit": "ADC"
        },
 
@@ -45,7 +41,6 @@
          "function": "linear_slope_fit",
          "module": "pygama.dsp.processors",
          "args" : ["wf_logged", "tail_mean","tail_std", "tail_slope","tail_intercept"],
-         "prereqs": ["wf_logged"],
          "unit": ["ADC","ADC","ADC","ADC"]
       },
 
@@ -53,7 +48,6 @@
         "function": "pole_zero",
         "module": "pygama.dsp.processors",
         "args": ["wf_blsub", "db.pz.tau", "wf_pz"],
-        "prereqs": ["wf_blsub"],
         "unit": "ADC",
         "defaults": { "db.pz.tau":"44.56*us" }
       },
@@ -62,14 +56,12 @@
         "function": "linear_slope_fit",
         "module": "pygama.dsp.processors",
         "args" : ["wf_pz[2100:]", "pz_mean","pz_std", "pz_slope","pz_intercept"],
-        "prereqs": ["wf_pz"],
         "unit": ["ADC","ADC","ADC","ADC"]
       },
       "wf_trap": {
         "function": "trap_norm",
         "module": "pygama.dsp.processors",
         "args": ["wf_pz", "8*us", "2*us", "wf_trap"],
-        "prereqs": ["wf_pz"],
         "unit": "ADC"
       },
       "trapEmax": {
@@ -77,8 +69,7 @@
         "module": "numpy",
         "args": ["wf_trap", 1, "trapEmax"],
         "kwargs": {"signature":"(n),()->()", "types":["fi->f"]},
-        "unit": "ADC",
-        "prereqs": ["wf_trap"]
+        "unit": "ADC"
     }
 
 

--- a/pygama/vis/waveform_browser.py
+++ b/pygama/vis/waveform_browser.py
@@ -164,7 +164,7 @@ class WaveformBrowser:
         if isinstance(self.norm_par, str): outputs += [self.norm_par]
         if isinstance(self.align_par, str): outputs += [self.align_par] 
         
-        self.proc_chain, self.lh5_out = build_processing_chain(self.lh5_in, dsp_config, db_dict=database, outputs=outputs, verbosity=self.verbosity, block_width=block_width)
+        self.proc_chain, self.field_mask, self.lh5_out = build_processing_chain(self.lh5_in, dsp_config, db_dict=database, outputs=outputs, verbosity=self.verbosity, block_width=block_width)
         
         self.fig = None
         self.ax = None        
@@ -228,6 +228,7 @@ class WaveformBrowser:
                                                           self.lh5_files[file_no],
                                                           start_row=chunk*self.buffer_len,
                                                           n_rows=len(self.lh5_in),
+                                                          field_mask = self.field_mask,
                                                           obj_buf=self.lh5_in)
             self.proc_chain.execute(0, n_read)
             

--- a/setup.py
+++ b/setup.py
@@ -137,7 +137,6 @@ setup(
     packages=find_packages(),
     install_requires=[
         'numpy',
-        'scimath',
         'numba',
         'parse',
         'GitPython',
@@ -146,7 +145,8 @@ setup(
         'h5py>=3.2.0',
         'pandas',
         'matplotlib',
-        'pytest'
+        'pytest',
+        'pint'
 
         # 'fcutils @ https://github.com/legend-exp/pyfcutils.git#egg=1.0.0'
     ],

--- a/setup.py
+++ b/setup.py
@@ -135,6 +135,13 @@ setup(
     description='Python package for decoding and processing digitizer data',
     long_description='',
     packages=find_packages(),
+    scripts=[
+        'pygama/dsp/build_dsp.py'
+    ],
+    include_package_data=True,
+    package_data={
+        "":["*.json"]
+    },
     install_requires=[
         'numpy',
         'numba',

--- a/tutorials/WaveformBrowserTutorial.ipynb
+++ b/tutorials/WaveformBrowserTutorial.ipynb
@@ -29,18 +29,18 @@
    "source": [
     "#First, import necessary modules and set some input values for use later\n",
     "%matplotlib inline\n",
-    "import pygama.io.lh5 as lh5\n",
-    "from pygama.dsp.WaveformBrowser import WaveformBrowser\n",
+    "import pygama.lgdo.lh5_store as lh5\n",
+    "from pygama.vis.waveform_browser import WaveformBrowser\n",
     "import matplotlib.pyplot as plt\n",
     "import pandas as pd\n",
     "import numpy as np\n",
     "import os, json\n",
     "\n",
     "# Set input values for where to find our data. This will grab all calibration runs from run 30, parsing wildcards\n",
-    "pgt_dir = '$LEGENDDATADIR/lngs/pgt/'\n",
-    "raw_files = pgt_dir + 'raw/geds/LPGTA_r0030_*_calib_geds_raw.lh5'\n",
-    "dsp_files = pgt_dir + 'dsp/geds/LPGTA_r0030_*_calib_geds_dsp.lh5'\n",
-    "channel = 'g040'\n",
+    "raw_files = '/home/ian/Documents/test_pygama/LPGTA_*.lh5'\n",
+    "dsp_files = '/home/ian/Documents/test_pygama/t2_LPGTA_*.lh5'\n",
+    "channel = 'g024'\n",
+    "dsp_config_file = \"/home/ian/Documents/test_pygama/dsp_config.json\"\n",
     "\n",
     "# Set defaults for figures\n",
     "plt.rcParams['figure.figsize'] = (12, 8)\n",
@@ -102,7 +102,8 @@
    "outputs": [],
    "source": [
     "# First, load a dataframe from a DSP file that we can use to make our selection:\n",
-    "df = lh5.load_dfs(dsp_files, ['trapE', 'AoE'], channel+'/dsp')"
+    "print(dsp_files)\n",
+    "df = lh5.load_dfs(dsp_files, ['trapEmax', 'AoE'], channel+'/dsp', verbose=True)"
    ]
   },
   {
@@ -112,8 +113,8 @@
    "outputs": [],
    "source": [
     "# Create a selection mask around the 2614 keV peak\n",
-    "trapE = df['trapE']\n",
-    "energy_selection = (trapE>22100) & (trapE<22400)\n",
+    "trapE = df['trapEmax']\n",
+    "energy_selection = (trapE>13100) & (trapE<13400)\n",
     "\n",
     "trapE.hist(bins=1000, range=(0, 30000))\n",
     "trapE[energy_selection].hist(bins=1000, range=(0, 30000))\n",
@@ -129,12 +130,12 @@
     "# Now construct a WaveformBrowser with this cut\n",
     "browser = WaveformBrowser(raw_files, channel+'/raw',\n",
     "                          verbosity   = 0,                  # Silence output on construction\n",
-    "                          legend      = (trapE, df['AoE']), # Values to put in the legend\n",
+    "                          aux_values  = df,\n",
+    "                          legend      = 'energy={trapEmax}',       # Values to put in the legend\n",
     "                          x_lim       = (22000, 30000),     # Range for time-axis\n",
-    "                          selection   = energy_selection ,  # Apply cut\n",
+    "                          entry_mask  = energy_selection ,  # Apply cut\n",
     "                          n_drawn     = 10                  # number to draw for draw_next\n",
     "                         )\n",
-    "\n",
     "# Draw the next 5 batches of 10 waveforms, and move the legend outside\n",
     "for entries, i in zip(browser, range(5)):\n",
     "    print(\"Entries:\", entries)\n",
@@ -147,7 +148,45 @@
    "metadata": {},
    "source": [
     "## Example 3\n",
-    "Lets take it a step further: this time, lets draw waveforms from multiple populations for the sake of comparison. This will require creating two separate waveform browsers and drawing them onto the same axes. We'll also normalization of the waveforms. Finally, we'll add some formatting options to the lines and legend."
+    "Now, we'll shift from drawing populations of waveforms to drawing waveform transforms. We can draw any waveforms that are defined in a DSP JSON configuration file. This is useful for debugging purposes and for developing processors. We will draw the baseline subtracted WF, pole-zero corrected WF, and trapezoidal filter WF. We will also draw horizontal and vertical lines for trapE (the max of the trapezoid) and tp_0 (our estimate of the start of the waveform's rise). The browser will determine whether these lines should be horizontal or vertical based on the unit."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "browser = WaveformBrowser(raw_files, channel+'/raw',\n",
+    "                          dsp_config=dsp_config_file, # Need to include a dsp config file!\n",
+    "                          database={\"pz_const\":'396.9*us'}, # TODO: use metadata instead of manually defining...\n",
+    "                          lines=['wf_blsub', 'wf_pz', 'wf_trap', 'trapEmax', 'tp_0'], # names of waveforms from dsp config file\n",
+    "                          styles=[{'ls':['-'], 'c':['orange']},\n",
+    "                                  {'ls':[':'], 'c':['green']},\n",
+    "                                  {'ls':['--'], 'c':['blue']},\n",
+    "                                  {'lw':[0.5], 'c':['black']},\n",
+    "                                  {'lw':[0.5], 'c':['red']}],\n",
+    "                          legend=['Waveform', 'PZ Corrected', \"Trap Filter\", 'Trap Max={trapEmax}', 't0={tp_0}'],\n",
+    "                          legend_opts={'loc':\"upper left\"},\n",
+    "                          x_lim=('15*us', '50*us') # x axis range\n",
+    "                         )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "browser.draw_next()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example 4\n",
+    "Here's a more advanced example that combines the previous 2. We will draw waveforms from multiple populations for the sake of comparison. This will require creating two separate waveform browsers and drawing them onto the same axes. We'll also normalize and baseline subtract the waveforms from parameters in a DSP file. Finally, we'll add some formatting options to the lines and legend."
    ]
   },
   {
@@ -157,12 +196,11 @@
    "outputs": [],
    "source": [
     "AoE = df['AoE']\n",
-    "energy_cut = (trapE>10000)\n",
-    "aoe_cut = (AoE<0.056) & energy_cut\n",
-    "aoe_accept = (AoE>0.056) & energy_cut\n",
+    "aoe_cut = (AoE<0.045) & energy_selection\n",
+    "aoe_accept = (AoE>0.045) & energy_selection\n",
     "\n",
-    "AoE[energy_cut].hist(bins=200, range=(-0, 0.2))\n",
-    "AoE[aoe_cut].hist(bins=200, range=(-0, 0.2))"
+    "AoE[aoe_accept].hist(bins=200, range=(-0, 0.1))\n",
+    "AoE[aoe_cut].hist(bins=200, range=(-0, 0.1))"
    ]
   },
   {
@@ -172,23 +210,27 @@
    "outputs": [],
    "source": [
     "browser1 = WaveformBrowser(raw_files, channel+'/raw',\n",
+    "                           dsp_config  = dsp_config_file, # include so we can do bl subtraction\n",
+    "                           lines       = 'wf_blsub',\n",
+    "                           norm        = 'trapEmax',        # normalize wfs\n",
     "                           verbosity   = 0,                 # Silence output on construction\n",
-    "                           wf_styles   = {'color':['red', 'orange', 'salmon', 'darkorange', 'maroon']}, # set a color cycle for this\n",
-    "                           legend      = (\"E={:.0f} ADC, A/E={:.3f}\", trapE, AoE), # Formatted values to put in the legend\n",
-    "                           norm        = trapE,             # Normalize waveforms by energy\n",
-    "                           selection   = aoe_cut,           # Apply cut\n",
-    "                           n_drawn     = 5                  # number to draw for draw_next\n",
+    "                           styles      = {'color':['red', 'orange', 'salmon', 'magenta']}, # set a color cycle for this\n",
+    "                           legend      = \"E={trapEmax} ADC, A/E={AoE:~.3f}\", # Formatted values to put in the legend\n",
+    "                           entry_mask  = aoe_cut,           # Apply cut\n",
+    "                           n_drawn     = 4                  # number to draw for draw_next\n",
     "                          )\n",
     "\n",
     "browser2 = WaveformBrowser(raw_files, channel+'/raw',\n",
-    "                           verbosity = 0,                 # Silence output on construction\n",
-    "                           wf_styles = {'color':['blue', 'purple', 'cyan', 'violet', 'indigo']}, # set a color cycle for this\n",
-    "                           legend    = (\"E={:.0f} ADC, A/E={:.3f}\", trapE, AoE), # Formatted values to put in the legend\n",
+    "                           dsp_config  = dsp_config_file, # include so we can do bl subtraction\n",
+    "                           lines       = 'wf_blsub',\n",
+    "                           norm        = 'trapEmax',        # normalize wfs\n",
+    "                           verbosity   = 0,                 # Silence output on construction\n",
+    "                           styles      = {'color':['blue', 'navy', 'cyan', 'teal']}, # set a color cycle for this\n",
+    "                           legend      = \"E={trapEmax} ADC, A/E={AoE:~.3f}\", # Formatted values to put in the legend\n",
     "                           legend_opts = {'loc':\"center\",'bbox_to_anchor':(1,0.35)}, # set options for drawing the legend\n",
-    "                           norm      = trapE,             # Normalize waveforms by energy\n",
-    "                           x_lim     = (25000, 30000),    # Range for time-axis\n",
-    "                           selection = aoe_accept,           # Apply cut\n",
-    "                           n_drawn   = 5                  # number to draw for draw_next\n",
+    "                           x_lim       = (26500, 28000),    # Range for time-axis\n",
+    "                           entry_mask  = aoe_accept,           # Apply cut\n",
+    "                           n_drawn     = 4                  # number to draw for draw_next\n",
     "                          )"
    ]
   },
@@ -207,56 +249,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Example 4\n",
-    "Now, we'll shift from drawing populations of waveforms to drawing waveform transforms. We can draw any waveforms that are defined in a DSP JSON configuration file. This is useful for debugging purposes and for developing processors. We will draw the baseline subtracted WF, pole-zero corrected WF, and trapezoidal filter WF. We will also draw horizontal and vertical lines for trapE (the max of the trapezoid) and tp_0 (our estimate of the start of the waveform's rise). The browser will determine whether these lines should be horizontal or vertical based on the unit."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Use the lpgta dsp json file. TODO: get this from DataGroup\n",
-    "dsp_config_file = os.path.expandvars(\"$HOME/pygama/experiments/lpgta/LPGTA_dsp.json\")\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "browser = WaveformBrowser(raw_files, channel+'/raw', dsp_config_file, # Need to include a dsp config file!\n",
-    "                          database={\"pz_const\":'396.9*us'}, # TODO: use metadata instead of manually defining...\n",
-    "                          waveforms=['wf_blsub', 'wf_pz', 'wf_trap'], # names of waveforms from dsp config file\n",
-    "                          wf_styles=[{'linestyle':['-']},{'linestyle':[':']},{'ls':['--']}],\n",
-    "                          legend=['Waveform', 'PZ Corrected', \"Trap (max={trapE:.0f})\"],\n",
-    "                          legend_opts={'loc':\"upper left\"},\n",
-    "                          lines=['trapE', 'tp_0'], # add hlines and vlines\n",
-    "                          x_lim=(15000, 55000) # x axis range\n",
-    "                         )"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "browser.draw_next()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Example 5\n",
-    "Sometimes you just want to access the waveforms without drawing them. There can be many reasons for this: maybe you want to try processing them with a function that isn't part of the pygama dsp framework yet. Maybe the drawing options provided aren't right for you. Either way, if you need more control over what happens with waveforms, it is possible to directly and quickly access them through the waveform browser.\n",
     "\n",
-    "The waveforms are stored in the class as a list of lists of pairs of numpy arrays. The outer list is across the waveforms we have requested. The inner list contains the number of waveforms we have requested. Each waveform is stored as a tuple pair of (time, waveform)\n",
+    "The waveforms, lines and legend entries are all stored inside of the waveform browser. Sometimes you want to acess these directly; maybe you want to access the raw data, or do control the lines in a way not enabled by the WaveformBrowser interface. It is possible to access them quickly and easily. Waveforms and legend values are stored as a dict from the parameter name to a list of stored values.\n",
+    "- The waveforms are as a list of matplotlib Line2D artists\n",
+    "- Horizontal and vertical lines are also stored as Line2D artists\n",
+    "- Legend entries are stored as pint Quanitities\n",
     "\n",
-    "When accessing waveforms in this way, you can also do the same things previously shown, such as applying a data cut and grabbing processed waveforms. For this example, we are going to get waveforms and trap-waveforms that pass the A/E cut. We will simply print them, but the possibility exists to do whatever we want!"
+    "When accessing waveforms in this way, you can also do the same things previously shown, such as applying a data cut and grabbing processed waveforms. For this example, we are going to get waveforms, trap-waveforms and trap energies, after applying an A/E cut. We will simply print them, but the possibility exists to do more!"
    ]
   },
   {
@@ -265,11 +265,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "browser = WaveformBrowser(raw_files, channel+'/raw', dsp_config_file, # Need to include a dsp config file!\n",
-    "                          database  = {\"pz_const\":'396.9*us'},        # TODO: use metadata instead of manually defining...\n",
-    "                          waveforms = ['waveform', 'wf_trap'],        # names of waveforms from dsp config file\n",
-    "                          selection = aoe_accept,                     # apply A/E cut\n",
-    "                          n_drawn   = 5                               # get two at a time\n",
+    "browser = WaveformBrowser(raw_files, channel+'/raw',\n",
+    "                          dsp_config = dsp_config_file,                # Need to include a dsp config file!\n",
+    "                          database   = {\"pz_const\":'396.9*us'},        # TODO: use metadata instead of manually defining...\n",
+    "                          lines      = ['waveform', 'wf_trap'],        # names of waveforms from dsp config file\n",
+    "                          legend     = ['{trapEmax}'],\n",
+    "                          entry_mask = aoe_accept,                     # apply A/E cut\n",
+    "                          n_drawn    = 5                               # get five at a time\n",
     "                         )"
    ]
   },
@@ -280,17 +282,34 @@
    "outputs": [],
    "source": [
     "browser.find_next()\n",
-    "waveforms = browser.wf_data[0]\n",
-    "traps = browser.wf_data[1]\n",
-    "for wf, trap in zip(waveforms, traps):\n",
-    "    print(\"Raw waveform:\", wf[1])\n",
-    "    print(\"Trap-filtered waveform\", trap[1], '\\n')"
+    "waveforms = browser.lines['waveform']\n",
+    "traps = browser.lines['wf_trap']\n",
+    "energies = browser.legend_vals['trapEmax']\n",
+    "for wf, trap, en in zip(waveforms, traps, energies):\n",
+    "    print(\"Raw waveform:\", wf.get_ydata())\n",
+    "    print(\"Trap-filtered waveform:\", trap.get_ydata())\n",
+    "    print(\"TrapEmax:\", en)\n",
+    "    print()"
    ]
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
DSP refactoring
- Processing chain was reorganized to be more flexible, using helper classes to represent internal data
- Processing chain can now write out LGDO objects. Vector_of_vectors doesn't work yet
- Each parameter now has an associated CoordinateGrid which represents the clock frequency and offset of a waveform. Previously there was a single clock frequency associated with the whole processing chain. This is necessary to do presumming and windowing of waveforms. I tried automating the setting of coordinate grids as much as possible, but there will be cases where we need to manually set these parameters
- Added an LH5 iterator for iterating through one or more LH5 files by pulling out a specified chunk of waveforms at a time and reusing data buffers. This is how we already process giant quantities of data, and gives us an easier/reproducible way to do it. This will be the correct way to iterate through waveforms in the future.
- Replaced scimath with pint for handling units. This only matters for processing chain at this point
- Updated WaveformBrowser for other changes
- Added presumming processor
- Merged in dev branch a while back