### PR TITLE
Strip metadata from jupyter notebooks

### DIFF
--- a/tutorials/DataProcessing.ipynb
+++ b/tutorials/DataProcessing.ipynb
@@ -154,22 +154,8 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "legend-base",
-   "language": "python",
-   "name": "legend-base"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "name": "python"
   }
  },
  "nbformat": 4,

--- a/tutorials/HADESDataTutorial.ipynb
+++ b/tutorials/HADESDataTutorial.ipynb
@@ -382,9 +382,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "sto.ls(files[0], 'raw/')"
@@ -473,9 +471,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "uncal_pass, uncal_cut = cts.load_nda_with_cuts(files,'raw',['cuspEmax_ctc'],verbose=False)"
@@ -491,9 +487,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "other_cuts_pass, other_cuts_fail  = cts.load_nda_with_cuts(files,'raw',['cuspEmax_ctc'], \n",
@@ -568,9 +562,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "pars, cov, results = cal.hpge_E_calibration(\n",
@@ -788,22 +780,8 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "legend-base",
-   "language": "python",
-   "name": "legend-base"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "name": "python"
   }
  },
  "nbformat": 4,

--- a/tutorials/IntroToDSP.ipynb
+++ b/tutorials/IntroToDSP.ipynb
@@ -396,22 +396,8 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "legend-base",
-   "language": "python",
-   "name": "legend-base"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "name": "python"
   }
  },
  "nbformat": 4,

--- a/tutorials/LH5ParGridSearch.ipynb
+++ b/tutorials/LH5ParGridSearch.ipynb
@@ -1547,22 +1547,8 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "legend-base",
-   "language": "python",
-   "name": "legend-base"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "name": "python"
   }
  },
  "nbformat": 4,

--- a/tutorials/WaveformBrowserTutorial.ipynb
+++ b/tutorials/WaveformBrowserTutorial.ipynb
@@ -303,22 +303,8 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "legend-base",
-   "language": "python",
-   "name": "legend-base"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "name": "python"
   }
  },
  "nbformat": 4,

--- a/tutorials/WriteProcessors.ipynb
+++ b/tutorials/WriteProcessors.ipynb
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "240ba40d-428c-4aea-822c-02a7a946310c",
    "metadata": {},
    "outputs": [],
@@ -46,18 +46,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "b085bca5-c323-4174-947c-089d71c8fcd8",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "test([0 1 2 3 4 5 6 7 8 9], 3.) = [ 3.  4.  5.  6.  7.  8.  9. 10. 11. 12.]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "@guvectorize([\"void(float32[:], float32, float32[:])\",\n",
     "              \"void(float64[:], float64, float64[:])\"],\n",
@@ -82,20 +74,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "ba4a4617-918f-4306-8711-8ec75f5fbe38",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "fft([0 1 2 3 4 5 6 7 8 9]) = [45. -0.j         -5.+15.38841769j -5. +6.8819096j  -5. +3.63271264j\n",
-      " -5. +1.62459848j -5. -0.j         -5. -1.62459848j -5. -3.63271264j\n",
-      " -5. -6.8819096j  -5.-15.38841769j]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import scipy.fft\n",
     "\n",
@@ -123,7 +105,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "07378535-02aa-4d70-a17b-6de95b1379c0",
    "metadata": {},
    "outputs": [],
@@ -162,22 +144,8 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "legend-base",
-   "language": "python",
-   "name": "legend-base"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "name": "python"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The Git filter that cleans up Jupyter notebooks on my laptop keeps modifying the upstream files. I cannot ignore it since it takes forever to run any Git command and I always have these unstaged changes around. The modifications make sense to me.

This commit should be propagated to `dev` and possibly other branches.