### PR TITLE
Minor fixes for sipms processors to work in processing chain

### DIFF
--- a/pygama/dsp/_processors/get_multi_local_extrema.py
+++ b/pygama/dsp/_processors/get_multi_local_extrema.py
@@ -6,8 +6,8 @@ from pygama.dsp.errors import DSPFatal
 
 @guvectorize(["void(float32[:], float32, float32[:], float32[:], float32[:], float32[:], float32[:], float32[:])",
               "void(float64[:], float64, float64[:], float64[:], float64[:],float64[:], float64[:], float64[:])"],
-             "(n),(),(m) -> (m),(m),(),(),()", nopython=True, cache=True)
-def get_multi_local_extrema(w_in, a_delta_in, t_arbitrary_in, vt_max_out, vt_min_out, n_max_out, n_min_out, flag_out):
+             "(n),(),(m),(m),(),(),()", nopython=True, cache=True)
+def get_multi_local_extrema(w_in, a_delta_in, vt_max_out, vt_min_out, n_max_out, n_min_out, flag_out):
     """
     Get lists of indices of the local maxima and minima of data
     The "local" extrema are those maxima / minima that have heights / depths of
@@ -20,8 +20,6 @@ def get_multi_local_extrema(w_in, a_delta_in, t_arbitrary_in, vt_max_out, vt_min
     a_delta_in : scalar
         The absolute level by which data must vary (in one direction) about an
         extremum in order for it to be tagged
-    t_arbitrary_in : array-like
-        An array of fixed length that tells numba to expect to return a list of amplitudes of the same length
     Returns
     -------
     vt_max_out, vt_min_out : array-like, array-like
@@ -54,14 +52,11 @@ def get_multi_local_extrema(w_in, a_delta_in, t_arbitrary_in, vt_max_out, vt_min
     if (np.isnan(w_in).any() or np.isnan(a_delta_in)):
         return
 
-    if (not len(t_arbitrary_in)<len(w_in)):
+    if (not len(vt_max_out)<len(w_in) or not len(vt_min_out)<len(w_in)):
         raise DSPFatal('The length of your return array must be smaller than the length of your waveform')
     if (not a_delta_in >= 0): 
         raise DSPFatal('a_delta_in must be positive')
-    if (not len(t_arbitrary_in)==len(vt_max_out) or not len(t_arbitrary_in)==len(vt_min_out)):
-        raise DSPFatal('Output arrays must be the same length as the arbitary input array')
-            
-
+        
     # now loop over data
     
     imax, imin = 0, 0

--- a/pygama/dsp/_processors/get_multi_local_extrema.py
+++ b/pygama/dsp/_processors/get_multi_local_extrema.py
@@ -4,8 +4,8 @@ from pygama.dsp.errors import DSPFatal
 
 
 
-@guvectorize(["void(float32[:], float32, float32[:], float32[:], float32[:], float32[:], float32[:], float32[:])",
-              "void(float64[:], float64, float64[:], float64[:], float64[:],float64[:], float64[:], float64[:])"],
+@guvectorize(["void(float32[:], float32, float32[:], float32[:], float32[:], float32[:], float32[:])",
+              "void(float64[:], float64, float64[:], float64[:],float64[:], float64[:], float64[:])"],
              "(n),(),(m),(m),(),(),()", nopython=True, cache=True)
 def get_multi_local_extrema(w_in, a_delta_in, vt_max_out, vt_min_out, n_max_out, n_min_out, flag_out):
     """

--- a/pygama/dsp/_processors/multi_a_filter.py
+++ b/pygama/dsp/_processors/multi_a_filter.py
@@ -5,7 +5,7 @@ from pygama.dsp._processors.fixed_time_pickoff import fixed_time_pickoff
 
 @guvectorize(["void(float32[:], float32[:], float32[:])",
               "void(float64[:], float64[:], float64[:])"],
-             "(n),(m)->(m)", forceobj=True, cache=True)
+             "(n),(m),(m)", forceobj=True, cache=True)
 def multi_a_filter(w_in, vt_maxs_in, va_max_out): 
     """
     Finds the maximums in a waveform and returns the amplitude of the wave at those points

--- a/pygama/dsp/_processors/multi_t_filter.py
+++ b/pygama/dsp/_processors/multi_t_filter.py
@@ -5,7 +5,7 @@ from pygama.dsp._processors.time_point_thresh import time_point_thresh
     
 @guvectorize(["void(float32[:],float32[:],float32[:])",
               "void(float64[:],float64[:],float64[:])"],
-             "(m),(m) -> (m)", nopython=True, cache=True)
+             "(n),(n) -> (n)", nopython=True, cache=True)
 def remove_duplicates(t_in, vt_min_in, t_out):
     """ 
     time_point_thresh has issues with afterpulsing in waveforms that causes  
@@ -53,7 +53,7 @@ def remove_duplicates(t_in, vt_min_in, t_out):
 
 @guvectorize(["void(float32[:], float32[:], float32[:], float32[:], float32[:])",
               "void(float64[:], float64[:], float64[:], float64[:], float64[:])"],
-             "(n),(),(m),(m)->(m)", forceobj=True, cache=True)
+             "(n),(),(m),(m),(m)", forceobj=True, cache=True)
 def multi_t_filter(w_in, a_threshold_in, vt_max_in, vt_min_in, t_out):
     """
     Gets list of indices of the start of leading edges of multiple peaks within a waveform.
@@ -95,7 +95,7 @@ def multi_t_filter(w_in, a_threshold_in, vt_max_in, vt_min_in, t_out):
     intermediate_t_out = np.full_like(t_out, np.nan, dtype=np.float32)
     
     # Go through the list of maxima, calling time_point_thresh (the refactored version ignores the nan padding)
-    time_point_thresh(w_in, a_threshold_in, t_maxs, 0, intermediate_t_out)
+    time_point_thresh(w_in, a_threshold_in, vt_max_in, 0, intermediate_t_out)
 
     # Remove duplicates from the t_out list
-    remove_duplicates(intermediate_t_out, t_mins, t_out)
+    remove_duplicates(intermediate_t_out, vt_min_in, t_out)

--- a/pygama/dsp/_processors/multi_t_filter.py
+++ b/pygama/dsp/_processors/multi_t_filter.py
@@ -1,13 +1,12 @@
 import numpy as np
 from numba import guvectorize
-from time_point_thresh import time_point_thresh
-from get_multi_local_extrema import get_multi_local_extrema
+from pygama.dsp._processors.time_point_thresh import time_point_thresh
 
     
 @guvectorize(["void(float32[:],float32[:],float32[:])",
               "void(float64[:],float64[:],float64[:])"],
              "(m),(m) -> (m)", nopython=True, cache=True)
-def remove_duplicates(t_in,vt_min_in, t_out):
+def remove_duplicates(t_in, vt_min_in, t_out):
     """ 
     time_point_thresh has issues with afterpulsing in waveforms that causes  
     an aferpulse peak's tp0 to be sent to 0 or the same index as the tp0 for the first pulse.
@@ -51,10 +50,11 @@ def remove_duplicates(t_in,vt_min_in, t_out):
             t_out[:] = np.append(t_out[1:],np.nan)
 
 
-@guvectorize(["void(float32[:], float32[:],float32[:], float32, float32[:])",
-              "void(float64[:], float64[:], float64[:], float64, float64[:])"],
-             "(n),(m),(),()->(m)", forceobj=True, cache=True)
-def multi_t_filter(w_in, t_arbitrary_in, a_threshold_in, delta_in, t_out):
+
+@guvectorize(["void(float32[:], float32[:], float32[:], float32[:], float32[:])",
+              "void(float64[:], float64[:], float64[:], float64[:], float64[:])"],
+             "(n),(),(m),(m)->(m)", forceobj=True, cache=True)
+def multi_t_filter(w_in, a_threshold_in, vt_max_in, vt_min_in, t_out):
     """
     Gets list of indices of the start of leading edges of multiple peaks within a waveform.
     Is built to handle afterpulses/delayed cross talk and trains of pulses.
@@ -66,14 +66,12 @@ def multi_t_filter(w_in, t_arbitrary_in, a_threshold_in, delta_in, t_out):
     ----------
     w_in : array-like
         The array of data within which the list of tp0s will be found
-    t_arbitraty_in : array-like
-        A fixed length array of the same dimensions that you need the tp0 list to be
-        Used to tell numba what dimension of an array it should expect
     a_threshold_in: scalar 
         Threshold to search for using time_point_thresh
-    delta_in : scalar
-        The absolute level by which data must vary (in one direction) about an
-        extremum in order for it to be tagged
+    vt_maxs_in : array-like
+        The array of max positions for each wf
+    vt_mins_in : array-like
+        The array of min positions for each wf
     Returns
     -------
     t_out : array-like
@@ -84,33 +82,20 @@ def multi_t_filter(w_in, t_arbitrary_in, a_threshold_in, delta_in, t_out):
      
     # initialize arrays, padded with the elements we want
     t_out[:] = np.nan 
-    vt_max_out= np.full_like(t_arbitrary_in, np.nan, dtype=np.float32)
-    vt_min_out = np.full_like(t_arbitrary_in, np.nan, dtype=np.float32)
-    n_max_out = np.array([np.nan],dtype=np.float32)
-    n_min_out = np.array([np.nan],dtype=np.float32)
-    flag_out = np.array([np.nan],dtype=np.float32)
     
     # checks 
-    if (np.isnan(w_in).any() or np.isnan(delta_in) or np.isnan(a_threshold_in)):
+    if (np.isnan(w_in).any() or np.isnan(a_threshold_in)):
         return
-    if (not len(t_arbitrary_in)<len(w_in)):
+    if (np.isnan(vt_max_in).all() and np.isnan(vt_min_in).all()):
+        return 
+    if (not len(t_out)<=len(w_in)):
         raise DSPFatal('The length of your return array must be smaller than the length of your waveform')
-    if (not delta_in >= 0): 
-        raise DSPFatal('Delta must be positive')
-    if (not len(t_arbitrary_in)==len(t_out)):
-        raise DSPFatal('Output arrays must be the same length as the arbitary input array')
 
-    # call get_multi_local_extrema to get locations of the maxima and minima within a waveform
-    get_multi_local_extrema(w_in, delta_in,t_arbitrary_in, vt_max_out,vt_min_out,n_max_out,n_min_out,flag_out)
-
-    # set the walk_forward parameter so that we walk back using the refactored time_point_thresh
-    walk_forward = np.array([0],dtype=np.int32)
-    
     # Initialize an intermediate array to hold the tp0 values before we remove duplicates from it
-    intermediate_t_out = np.full_like(t_arbitrary_in, np.nan, dtype=np.float32)
+    intermediate_t_out = np.full_like(t_out, np.nan, dtype=np.float32)
     
     # Go through the list of maxima, calling time_point_thresh (the refactored version ignores the nan padding)
-    time_point_thresh(w_in, a_threshold_in, vt_max_out, walk_forward, intermediate_t_out)
-    
+    time_point_thresh(w_in, a_threshold_in, t_maxs, 0, intermediate_t_out)
+
     # Remove duplicates from the t_out list
-    remove_duplicates(intermediate_t_out, vt_min_out, t_out)
+    remove_duplicates(intermediate_t_out, t_mins, t_out)

--- a/pygama/dsp/_processors/mutli_a_filter.py
+++ b/pygama/dsp/_processors/mutli_a_filter.py
@@ -1,13 +1,12 @@
 import numpy as np
 from numba import guvectorize
 from pygama.dsp.errors import DSPFatal
-from fixed_time_pickoff import fixed_time_pickoff
-from get_multi_local_extrema import get_multi_local_extrema
+from pygama.dsp._processors.fixed_time_pickoff import fixed_time_pickoff
 
-@guvectorize(["void(float32[:], float32[:], float32, float32[:])",
-              "void(float64[:], float64[:], float64, float64[:])"],
-             "(n),(m),()->(m)", forceobj=True, cache=True)
-def multi_a_filter(w_in, va_arbitrary_in, a_delta_in, va_max_out): 
+@guvectorize(["void(float32[:], float32[:], float32[:])",
+              "void(float64[:], float64[:], float64[:])"],
+             "(n),(m)->(m)", forceobj=True, cache=True)
+def multi_a_filter(w_in, vt_maxs_in, va_max_out): 
     """
     Finds the maximums in a waveform and returns the amplitude of the wave at those points
     
@@ -15,12 +14,8 @@ def multi_a_filter(w_in, va_arbitrary_in, a_delta_in, va_max_out):
     ----------
     w_in : array-like
         The array of data within which amplitudes of extrema will be found 
-    va_arbitrary_in : array-like
-        An array of fixed length that tells numba to return the list of amplitudes of the same length
-    a_delta_in : scalar
-        The absolute level by which data must vary (in one direction) about an
-        extremum in order for it to be tagged
-        
+    vt_maxs_in : array-like
+        The array of max positions for each wf
     Returns
     -------
     va_max_out: array-like
@@ -33,27 +28,10 @@ def multi_a_filter(w_in, va_arbitrary_in, a_delta_in, va_max_out):
     
     # Check inputs 
     
-    if (np.isnan(w_in).any() or np.isnan(a_delta_in)):
+    if (np.isnan(w_in).any()):
         return
-
-    if not a_delta_in >= 0:
-        raise DSPFatal('Error Message: a_delta_in must be positive')
         
-    if len(va_arbitrary_in) != len(va_max_out): 
-        raise DSPFatal('Error Message: Output arrays must be the same length as the arbitary input array')
-        
-    if (not len(va_arbitrary_in)<len(w_in)):
+    if (not len(vt_maxs_in)<len(w_in)):
         raise DSPFatal('The length of your return array must be smaller than the length of your waveform')
     
-    # Use get_multi_local_extrema to find vt_max_out for a waveform
-    
-    vt_max_out = np.full_like(va_arbitrary_in, np.nan, dtype=np.float32)
-    vt_min_out = np.full_like(va_arbitrary_in, np.nan, dtype=np.float32)
-    n_max_out = np.array([np.nan], dtype=np.float32)
-    n_min_out = np.array([np.nan], dtype=np.float32)
-    flag_out = np.array([np.nan], dtype=np.float32)
-    get_multi_local_extrema(w_in, a_delta_in, va_arbitrary_in, vt_max_out, vt_min_out, n_max_out, n_min_out, flag_out)
-    
-    # Feed vt_max_out into fixed_time_pickoff to get va_max_out
-    
-    fixed_time_pickoff(w_in, vt_max_out, va_max_out)
+    fixed_time_pickoff(w_in, vt_maxs_in, va_max_out)

--- a/pygama/dsp/processors.py
+++ b/pygama/dsp/processors.py
@@ -26,3 +26,7 @@ from ._processors.moving_windows import moving_window_left, moving_window_right,
 from ._processors.soft_pileup_corr import soft_pileup_corr, soft_pileup_corr_bl
 from ._processors.optimize import optimize_1pz, optimize_2pz
 from ._processors.saturation import saturation
+from ._processors.gaussian_filter1d import gaussian_filter1d
+from ._processors.get_multi_local_extrema import get_multi_local_extrema
+from ._processors.multi_t_filter import multi_t_filter, remove_duplicates
+from ._processors.multi_a_filter import multi_a_filter


### PR DESCRIPTION
Small changes to signatures to make these work in processing chain, removed the arbitrary input arrays and removed the call to get local extrema instead run as a separate processor before the multi_t and multi_a filters.  Also added all these to the processors.py file. 