### PR TITLE
Enabling tests

### DIFF
--- a/.github/workflows/get-dependencies.sh
+++ b/.github/workflows/get-dependencies.sh
@@ -9,4 +9,4 @@ else
     sudo ln -s /usr/bin/llvm-config-8 /usr/bin/llvm-config
 fi
 
-python -m pip install --upgrade pip wheel setuptools numpy GitPython
+python -m pip install --upgrade pip wheel setuptools numpy GitPython pytest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,23 +27,24 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Run unit tests
+    - name: Get dependencies and install the package
       run: |
         .github/workflows/get-dependencies.sh
         python -m pip install .
-    # - name: Test
-    #   run: |
-    #     pytest
+    - name: Run unit tests
+      run: pytest test
 
   test-in-legend-container:
-    name: Test pygama in LEGEND container (CentOS Linux)
+    name: Test pygama in LEGEND container
     runs-on: ubuntu-latest
     container: docker://legendexp/legend-base:latest
 
     steps:
     - uses: actions/checkout@v2
-    - name: Run unit tests
-      run: pip install .
+    - name: Install and run unit tests
+      run: |
+        pip install .
+        pytest test
 
   deploy-docs:
     name: Deploy documentation on legend-exp.github.io/pygama

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,11 +14,12 @@ jobs:
 
   build-and-test:
     name: Test pygama with Python
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         python-version: [3.7, 3.8]
+        os: [ubuntu-latest, macOS-latest]
 
     steps:
     - uses: actions/checkout@v2

--- a/test/lh5/test_types.py
+++ b/test/lh5/test_types.py
@@ -1,0 +1,6 @@
+import pygama.lh5 as lh5
+
+
+def test_array():
+    a = lh5.Array(shape=(1), dtype=float)
+    assert a.dataype_name() == 'array'


### PR DESCRIPTION
- [x] Enable GitHub action tests on OSX
- [x] Use pytest rather than unittest, `pip install` it in CI jobs
- [ ] Test sub-folder per module, with micro tests for each function. Should test on syntetic traces rather than real?
- [ ] High-level testing of the full production chain on real data:
  - Fetch `daq` test files from <https://github.com/legend-exp/legend-testdata>
    (note: the repo is and should stay public)
  - What should it be? A couple of (coincident) FC files from HPGe + SiPM streams
    to really be a 100% realistic?
  - I guess we need test files from other data-takers?
- [ ] What else would be interesting to test?
- [ ] Test coverage?