### PR TITLE
Fixed numba version check

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -145,7 +145,7 @@ setup(
     install_requires=[
         'numpy',
         'scimath',
-        'numba !=0.53, !=0.54',
+        'numba !=0.53, !=0.53.0, !=0.53.1, !=0.54, !=0.54.0, !=0.54.1',
         'parse',
         'GitPython',
         'tinydb',


### PR DESCRIPTION
Python's setup tools do not for subversions, so it does not recognize numba version `0.53.1` as breaking `!=0.53`. Fixed by explicitly adding `0.53.1` and other sub-versions of `0.53` and `0.54`.