### PR TITLE
Docstring checks and fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,12 @@ repos:
   - id: requirements-txt-fixer
   - id: trailing-whitespace
 
+- repo: https://github.com/Carreau/velin.git
+  rev: "0.0.12"
+  hooks:
+    - id: velin
+      args: ["--check", "--write"]
+
 - repo: https://github.com/asottile/setup-cfg-fmt
   rev: "v1.20.1"
   hooks:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -14,7 +14,6 @@ extensions = [
     'sphinx.ext.mathjax',
     'sphinx.ext.napoleon',
     'sphinx.ext.intersphinx',
-    'sphinx.ext.autosectionlabel',
     'sphinx_rtd_theme',
     'sphinx_multiversion',
     'myst_parser'

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -90,7 +90,7 @@ contributing to the project, make sure to implement the following:
 * Documentation for functions, classes, modules and packages should be provided
   as `Docstrings <https://peps.python.org/pep-0257>`_ along with the respective
   source code. Docstrings are automatically converted to HTML as part of the
-  :ref:`pygama API documentation <pygama package>`.
+  :mod:`pygama` package API documentation.
 * General guides, comprehensive tutorials or other high-level documentation
   (e.g. referring to how separate parts of the code interact between each
   other) must be provided as separate pages in ``docs/source/`` and linked in

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -16,5 +16,5 @@ Table of Contents
 
    install
    tutorials
-   Package API reference <generated/pygama>
+   Package API reference <generated/modules>
    contributing

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,6 +63,7 @@ daq =
 docs =
     jupyter
     myst-parser
+    pygama[daq]
     sphinx
     sphinx-multiversion-pre-post-build>=0.2.4
     sphinx-rtd-theme

--- a/src/pygama/dsp/__init__.py
+++ b/src/pygama/dsp/__init__.py
@@ -19,4 +19,4 @@ main contents of this submodule are:
 """
 
 from .build_dsp import build_dsp
-from .processing_chain import (ProcessingChain, build_processing_chain)
+from .processing_chain import ProcessingChain, build_processing_chain

--- a/src/pygama/dsp/__init__.py
+++ b/src/pygama/dsp/__init__.py
@@ -1,16 +1,22 @@
 """
-The pygama signal processing framework is contained in the :mod:`pygama.dsp`
+The pygama signal processing framework is contained in the :mod:`.dsp`
 submodule. This code is responsible for running a variety of discrete signal
 processors on data, producing tier 2 (dsp) files from tier 1 (raw) files. The
 main contents of this submodule are:
 
-* :mod:`pygama.dsp.processors`: A collection of Numba functions that perform
-  individual DSP transforms and reductions on our data. Individual processors are
-  held in the ``_processors`` directory, which is where contributors will write
-  new processors for inclusion in the analysis. Available processors include all
+* :mod:`.processors`: A collection of Numba functions that perform individual
+  DSP transforms and reductions on our data. Individual processors are held in
+  the ``_processors`` directory, which is where contributors will write new
+  processors for inclusion in the analysis. Available processors include all
   numpy ufuncs as well.
-* :class:`pygama.dsp.ProcessingChain`: A class that manages and efficiently
-  runs a list of DSP processors
-* :func:`build_processing_chain`: A function that builds a ProcessingChain using lh5 formatted input and output files, and a json configuration file
-* :func:`build_dsp`: A function that runs build_processing_chain to build a ProcessingChain from a json config file and then processes an input file and writes into an output file, using the lh5 file format
+* :class:`.ProcessingChain`: A class that manages and efficiently runs a list
+  of DSP processors
+* :func:`.build_processing_chain`: A function that builds a :class:`.ProcessingChain`
+  using LH5-formatted input and output files, and a JSON configuration file
+* :func:`.build_dsp`: A function that runs :func:`.build_processing_chain` to build a
+  :class:`.ProcessingChain` from a JSON config file and then processes an input
+  file and writes into an output file, using the LH5 file format
 """
+
+from .build_dsp import build_dsp
+from .processing_chain import (ProcessingChain, build_processing_chain)

--- a/src/pygama/dsp/_processors/__init__.py
+++ b/src/pygama/dsp/_processors/__init__.py
@@ -1,2 +1,3 @@
 """
+Package documentation
 """

--- a/src/pygama/dsp/_processors/bl_subtract.py
+++ b/src/pygama/dsp/_processors/bl_subtract.py
@@ -20,15 +20,17 @@ def bl_subtract(w_in, a_baseline, w_out):
     w_out: array-like
            The output waveform with the baseline subtracted
 
-    Processing Chain Example
-    ------------------------
-    "wf_bl": {
-        "function": "bl_subtract",
-        "module": "pygama.dsp.processors",
-        "args": ["waveform", "baseline", "wf_bl"],
-        "unit": "ADC",
-        "prereqs": ["waveform", "baseline"]
-    }
+    Examples
+    --------
+    .. code-block :: json
+
+        "wf_bl": {
+            "function": "bl_subtract",
+            "module": "pygama.dsp.processors",
+            "args": ["waveform", "baseline", "wf_bl"],
+            "unit": "ADC",
+            "prereqs": ["waveform", "baseline"]
+        }
     """
     w_out[:] = np.nan
 

--- a/src/pygama/dsp/_processors/bl_subtract.py
+++ b/src/pygama/dsp/_processors/bl_subtract.py
@@ -14,11 +14,11 @@ def bl_subtract(w_in, a_baseline, w_out):
     Parameters
     ----------
     w_in : array-like
-           The input waveform
-    a_in : float
-           The baseline value to subtract
-    w_out: array-like
-           The output waveform with the baseline subtracted
+        The input waveform
+    a_baseline : float
+        The baseline value to subtract
+    w_out : array-like
+        The output waveform with the baseline subtracted
 
     Examples
     --------

--- a/src/pygama/dsp/_processors/convolutions.py
+++ b/src/pygama/dsp/_processors/convolutions.py
@@ -10,8 +10,8 @@ def cusp_filter(length, sigma, flat, decay):
     factory function that is called using the init_args argument and that
     the function the waveforms are passed to using args.
 
-    Initialization Parameters
-    -------------------------
+    Parameters
+    ----------
     length: int
             The length of the filter to be convolved
     sigma : float
@@ -20,13 +20,6 @@ def cusp_filter(length, sigma, flat, decay):
             The length of the flat section
     decay : int
             The decay constant of the exponential to be convolved
-
-    Parameters
-    ----------
-    w_in : array-like
-           The input waveform
-    w_out: array-like
-           The filtered waveform
 
     Processing Chain Example
     ------------------------
@@ -68,6 +61,14 @@ def cusp_filter(length, sigma, flat, decay):
                   "void(float64[:], float64[:])"],
                  "(n),(m)", forceobj=True)
     def cusp_out(w_in, w_out):
+        """
+        Parameters
+        ----------
+        w_in : array-like
+               The input waveform
+        w_out: array-like
+               The filtered waveform
+        """
         w_out[:] = np.nan
 
         if np.isnan(w_in).any():
@@ -86,8 +87,8 @@ def zac_filter(length, sigma, flat, decay):
     composed of a factory function that is called using the init_args
     argument and that the function the waveforms are passed to using args.
 
-    Initialization Parameters
-    -------------------------
+    Parameters
+    ----------
     length: int
             The length of the filter to be convolved
     sigma : float
@@ -96,13 +97,6 @@ def zac_filter(length, sigma, flat, decay):
             The length of the flat section
     decay : int
             The decay constant of the exponential to be convolved
-
-    Parameters
-    ----------
-    w_in : array-like
-           The input waveform
-    w_out: array-like
-           The filtered waveform
 
     Processing Chain Example
     ------------------------
@@ -162,6 +156,14 @@ def zac_filter(length, sigma, flat, decay):
                   "void(float64[:], float64[:])"],
                  "(n),(m)", forceobj=True)
     def zac_out(w_in, w_out):
+        """
+        Parameters
+        ----------
+        w_in : array-like
+               The input waveform
+        w_out: array-like
+               The filtered waveform
+        """
         w_out[:] = np.nan
 
         if np.isnan(w_in).any():
@@ -181,21 +183,14 @@ def t0_filter(rise, fall):
     that it is composed of a factory function that is called using the init_args
     argument and that the function the waveforms are passed to using args.
 
-    Initialization Parameters
-    -------------------------
+    Parameters
+    ----------
     rise: int
           The length of the rise section.  This is the linearly increasing
           section of the filter that performs a weighted average.
     fall: int
           The length of the fall section.  This is the simple averaging part
           of the filter.
-
-    Parameters
-    ----------
-    w_in : array-like
-           The input waveform
-    w_out: array-like
-           The filtered waveform
 
     Processing Chain Example
     ------------------------
@@ -221,6 +216,14 @@ def t0_filter(rise, fall):
                   "void(float64[:], float64[:])"],
                  "(n),(m)", forceobj=True)
     def t0_filter_out(w_in, w_out):
+        """
+        Parameters
+        ----------
+        w_in : array-like
+               The input waveform
+        w_out: array-like
+               The filtered waveform
+        """
         w_out[:] = np.nan
 
         if np.isnan(w_in).any():

--- a/src/pygama/dsp/_processors/convolutions.py
+++ b/src/pygama/dsp/_processors/convolutions.py
@@ -12,14 +12,14 @@ def cusp_filter(length, sigma, flat, decay):
 
     Parameters
     ----------
-    length: int
-            The length of the filter to be convolved
+    length : int
+        The length of the filter to be convolved
     sigma : float
-            The curvature of the rising and falling part of the kernel
-    flat  : int
-            The length of the flat section
+        The curvature of the rising and falling part of the kernel
+    flat : int
+        The length of the flat section
     decay : int
-            The decay constant of the exponential to be convolved
+        The decay constant of the exponential to be convolved
 
     Examples
     --------
@@ -67,9 +67,9 @@ def cusp_filter(length, sigma, flat, decay):
         Parameters
         ----------
         w_in : array-like
-               The input waveform
-        w_out: array-like
-               The filtered waveform
+            The input waveform
+        w_out : array-like
+            The filtered waveform
         """
         w_out[:] = np.nan
 
@@ -91,14 +91,14 @@ def zac_filter(length, sigma, flat, decay):
 
     Parameters
     ----------
-    length: int
-            The length of the filter to be convolved
+    length : int
+        The length of the filter to be convolved
     sigma : float
-            The curvature of the rising and falling part of the kernel
-    flat  : int
-            The length of the flat section
+        The curvature of the rising and falling part of the kernel
+    flat : int
+        The length of the flat section
     decay : int
-            The decay constant of the exponential to be convolved
+        The decay constant of the exponential to be convolved
 
     Examples
     --------
@@ -164,9 +164,9 @@ def zac_filter(length, sigma, flat, decay):
         Parameters
         ----------
         w_in : array-like
-               The input waveform
-        w_out: array-like
-               The filtered waveform
+            The input waveform
+        w_out : array-like
+            The filtered waveform
         """
         w_out[:] = np.nan
 
@@ -189,12 +189,12 @@ def t0_filter(rise, fall):
 
     Parameters
     ----------
-    rise: int
-          The length of the rise section.  This is the linearly increasing
-          section of the filter that performs a weighted average.
-    fall: int
-          The length of the fall section.  This is the simple averaging part
-          of the filter.
+    rise : int
+        The length of the rise section.  This is the linearly increasing
+        section of the filter that performs a weighted average.
+    fall : int
+        The length of the fall section.  This is the simple averaging part
+        of the filter.
 
     Examples
     --------
@@ -226,9 +226,9 @@ def t0_filter(rise, fall):
         Parameters
         ----------
         w_in : array-like
-               The input waveform
-        w_out: array-like
-               The filtered waveform
+            The input waveform
+        w_out : array-like
+            The filtered waveform
         """
         w_out[:] = np.nan
 

--- a/src/pygama/dsp/_processors/convolutions.py
+++ b/src/pygama/dsp/_processors/convolutions.py
@@ -21,16 +21,18 @@ def cusp_filter(length, sigma, flat, decay):
     decay : int
             The decay constant of the exponential to be convolved
 
-    Processing Chain Example
-    ------------------------
-    "wf_cusp": {
-        "function": "cusp_filter",
-        "module": "pygama.dsp.processors",
-        "args": ["wf_bl", "wf_cusp(101,f)"],
-        "unit": "ADC",
-        "prereqs": ["wf_bl"],
-        "init_args": ["len(wf_bl)-100", "40*us", "3*us", "45*us"]
-    }
+    Examples
+    --------
+    .. code-block :: json
+
+        "wf_cusp": {
+            "function": "cusp_filter",
+            "module": "pygama.dsp.processors",
+            "args": ["wf_bl", "wf_cusp(101,f)"],
+            "unit": "ADC",
+            "prereqs": ["wf_bl"],
+            "init_args": ["len(wf_bl)-100", "40*us", "3*us", "45*us"]
+        }
     """
     if length <= 0:
         raise DSPFatal('The length of the filter must be positive')
@@ -98,16 +100,18 @@ def zac_filter(length, sigma, flat, decay):
     decay : int
             The decay constant of the exponential to be convolved
 
-    Processing Chain Example
-    ------------------------
-    "wf_zac": {
-        "function": "zac_filter",
-        "module": "pygama.dsp.processors",
-        "args": ["wf_bl", "wf_zac(101,f)"],
-        "unit": "ADC",
-        "prereqs": ["wf_bl"],
-        "init_args": ["len(wf_bl)-100", "40*us", "3*us", "45*us"],
-    }
+    Examples
+    --------
+    .. code-block :: json
+
+        "wf_zac": {
+            "function": "zac_filter",
+            "module": "pygama.dsp.processors",
+            "args": ["wf_bl", "wf_zac(101,f)"],
+            "unit": "ADC",
+            "prereqs": ["wf_bl"],
+            "init_args": ["len(wf_bl)-100", "40*us", "3*us", "45*us"],
+        }
     """
     if length <= 0:
         raise DSPFatal('The length of the filter must be positive')
@@ -192,16 +196,18 @@ def t0_filter(rise, fall):
           The length of the fall section.  This is the simple averaging part
           of the filter.
 
-    Processing Chain Example
-    ------------------------
-    "wf_t0_filter": {
-        "function": "t0_filter",
-        "module": "pygama.dsp.processors",
-        "args": ["wf_pz", "wf_t0_filter(3748,f)"],
-        "unit": "ADC",
-        "prereqs": ["wf_pz"],
-        "init_args": ["128*ns", "2*us"]
-    }
+    Examples
+    --------
+    .. code-block :: json
+
+        "wf_t0_filter": {
+            "function": "t0_filter",
+            "module": "pygama.dsp.processors",
+            "args": ["wf_pz", "wf_t0_filter(3748,f)"],
+            "unit": "ADC",
+            "prereqs": ["wf_pz"],
+            "init_args": ["128*ns", "2*us"]
+        }
     """
     if rise < 0:
         raise DSPFatal('The length of the rise section must be positive')

--- a/src/pygama/dsp/_processors/fixed_time_pickoff.py
+++ b/src/pygama/dsp/_processors/fixed_time_pickoff.py
@@ -21,15 +21,17 @@ def fixed_time_pickoff(w_in, t_in, a_out):
     a_out: float
            The output pick-off value
 
-    Processing Chain Example
-    ------------------------
-    "trapEftp": {
-        "function": "fixed_time_pickoff",
-        "module": "pygama.dsp.processors",
-        "args": ["wf_trap", "tp_0+10*us", "trapEftp"],
-        "unit": "ADC",
-        "prereqs": ["wf_trap", "tp_0"]
-    }
+    Examples
+    --------
+    .. code-block :: json
+
+        "trapEftp": {
+            "function": "fixed_time_pickoff",
+            "module": "pygama.dsp.processors",
+            "args": ["wf_trap", "tp_0+10*us", "trapEftp"],
+            "unit": "ADC",
+            "prereqs": ["wf_trap", "tp_0"]
+        }
     """
     a_out[0] = np.nan
 

--- a/src/pygama/dsp/_processors/fixed_time_pickoff.py
+++ b/src/pygama/dsp/_processors/fixed_time_pickoff.py
@@ -15,11 +15,11 @@ def fixed_time_pickoff(w_in, t_in, a_out):
     Parameters
     ----------
     w_in : array-like
-           The input waveform
+        The input waveform
     t_in : int
-           The waveform index to pick off
-    a_out: float
-           The output pick-off value
+        The waveform index to pick off
+    a_out : float
+        The output pick-off value
 
     Examples
     --------

--- a/src/pygama/dsp/_processors/gaussian_filter1d.py
+++ b/src/pygama/dsp/_processors/gaussian_filter1d.py
@@ -40,6 +40,7 @@ from numba import guvectorize
 
 def gaussian_filter1d(sigma, truncate):
     """1-D Gaussian filter.
+
     Parameters
     ----------
     %(input)s
@@ -48,6 +49,7 @@ def gaussian_filter1d(sigma, truncate):
     truncate : float, optional
         Truncate the filter at this many standard deviations.
         Default is 4.0.
+
     Returns
     -------
     gaussian_filter1d : ndarray
@@ -80,6 +82,7 @@ def gaussian_filter1d(sigma, truncate):
     """Calculate a 1-D correlation along the given axis.
     The lines of the array along the given axis are correlated with the
     given weights.
+
     Parameters
     ----------
     %(input)s

--- a/src/pygama/dsp/_processors/get_multi_local_extrema.py
+++ b/src/pygama/dsp/_processors/get_multi_local_extrema.py
@@ -13,6 +13,7 @@ def get_multi_local_extrema(w_in, a_delta_in, vt_max_out, vt_min_out, n_max_out,
     The "local" extrema are those maxima / minima that have heights / depths of
     at least a_delta_in.
     Converted from MATLAB script at: http://billauer.co.il/peakdet.html
+
     Parameters
     ----------
     w_in : array-like
@@ -20,6 +21,7 @@ def get_multi_local_extrema(w_in, a_delta_in, vt_max_out, vt_min_out, n_max_out,
     a_delta_in : scalar
         The absolute level by which data must vary (in one direction) about an
         extremum in order for it to be tagged
+
     Returns
     -------
     vt_max_out, vt_min_out : array-like, array-like
@@ -30,7 +32,6 @@ def get_multi_local_extrema(w_in, a_delta_in, vt_max_out, vt_min_out, n_max_out,
     flag_out: scalar
         Returns 1 if there is only one maximum and it is a simple waveform,
         Returns 0 if there are no peaks, or multiple peaks in a waveform
-
     """
 
     # prepare output

--- a/src/pygama/dsp/_processors/get_multi_local_extrema.py
+++ b/src/pygama/dsp/_processors/get_multi_local_extrema.py
@@ -21,15 +21,12 @@ def get_multi_local_extrema(w_in, a_delta_in, vt_max_out, vt_min_out, n_max_out,
     a_delta_in : scalar
         The absolute level by which data must vary (in one direction) about an
         extremum in order for it to be tagged
-
-    Returns
-    -------
     vt_max_out, vt_min_out : array-like, array-like
         Arrays of fixed length (padded with nans) that hold the indices of
         the identified local maxima and minima
-    n_max_out, n_min_out: scalar, scalar
+    n_max_out, n_min_out : scalar, scalar
         The number of maxima and minima found in a waveform
-    flag_out: scalar
+    flag_out : scalar
         Returns 1 if there is only one maximum and it is a simple waveform,
         Returns 0 if there are no peaks, or multiple peaks in a waveform
     """

--- a/src/pygama/dsp/_processors/linear_slope_fit.py
+++ b/src/pygama/dsp/_processors/linear_slope_fit.py
@@ -15,16 +15,16 @@ def linear_slope_fit(w_in, mean, stdev, slope, intercept):
 
     Parameters
     ----------
-    w_in     : array-like
-               The input waveform
-    a_mean   : float
-               The mean of the waveform
-    stdev    : float
-               The standard deviation of the waveform
-    slope    : float
-               The slope of the linear fit
-    intercept: float
-               The intercept of the linear fit
+    w_in : array-like
+        The input waveform
+    mean : float
+        The mean of the waveform
+    stdev : float
+        The standard deviation of the waveform
+    slope : float
+        The slope of the linear fit
+    intercept : float
+        The intercept of the linear fit
 
     Examples
     --------

--- a/src/pygama/dsp/_processors/linear_slope_fit.py
+++ b/src/pygama/dsp/_processors/linear_slope_fit.py
@@ -26,15 +26,17 @@ def linear_slope_fit(w_in, mean, stdev, slope, intercept):
     intercept: float
                The intercept of the linear fit
 
-    Processing Chain Example
-    ------------------------
-    "bl_mean, bl_std, bl_slope, bl_intercept": {
-        "function": "linear_slope_fit",
-        "module": "pygama.dsp.processors",
-        "args": ["wf_blsub[0:1650]", "bl_mean", "bl_std", "bl_slope", "bl_intercept"],
-        "unit": ["ADC", "ADC", "ADC", "ADC"],
-        "prereqs": ["wf_blsub"]
-    }
+    Examples
+    --------
+    .. code-block :: json
+
+        "bl_mean, bl_std, bl_slope, bl_intercept": {
+            "function": "linear_slope_fit",
+            "module": "pygama.dsp.processors",
+            "args": ["wf_blsub[0:1650]", "bl_mean", "bl_std", "bl_slope", "bl_intercept"],
+            "unit": ["ADC", "ADC", "ADC", "ADC"],
+            "prereqs": ["wf_blsub"]
+        }
     """
     mean     [0] = np.nan
     stdev    [0] = np.nan

--- a/src/pygama/dsp/_processors/log_check.py
+++ b/src/pygama/dsp/_processors/log_check.py
@@ -15,9 +15,9 @@ def log_check(w_in, w_log):
     Parameters
     ----------
     w_in : array-like
-           The input waveform
-    w_log: array-like
-           The output waveform with logged values
+        The input waveform
+    w_log : array-like
+        The output waveform with logged values
 
     Examples
     --------

--- a/src/pygama/dsp/_processors/log_check.py
+++ b/src/pygama/dsp/_processors/log_check.py
@@ -19,15 +19,17 @@ def log_check(w_in, w_log):
     w_log: array-like
            The output waveform with logged values
 
-    Processing Chain Example
-    ------------------------
-    "wf_logged": {
-        "function": "log_check",
-        "module": "pygama.dsp.processors",
-        "args": ["wf_blsub[2100:]", "wf_logged"],
-        "unit": "ADC",
-        "prereqs": ["wf_blsub"]
-    }
+    Examples
+    --------
+    .. code-block :: json
+
+        "wf_logged": {
+            "function": "log_check",
+            "module": "pygama.dsp.processors",
+            "args": ["wf_blsub[2100:]", "wf_logged"],
+            "unit": "ADC",
+            "prereqs": ["wf_blsub"]
+        }
     """
     w_log[:] = np.nan
 

--- a/src/pygama/dsp/_processors/min_max.py
+++ b/src/pygama/dsp/_processors/min_max.py
@@ -16,15 +16,15 @@ def min_max(w_in, t_min, t_max, a_min, a_max):
     Parameters
     ----------
     w_in : array-like
-           The input waveform
-    t_min: int
-           The index of the minimum value
-    t_max: int
-           The index of the maximum value
-    a_min: float
-           The minimum value
-    a_max: float
-           The maximum value
+        The input waveform
+    t_min : int
+        The index of the minimum value
+    t_max : int
+        The index of the maximum value
+    a_min : float
+        The minimum value
+    a_max : float
+        The maximum value
 
     Examples
     --------

--- a/src/pygama/dsp/_processors/min_max.py
+++ b/src/pygama/dsp/_processors/min_max.py
@@ -26,15 +26,17 @@ def min_max(w_in, t_min, t_max, a_min, a_max):
     a_max: float
            The maximum value
 
-    Processing Chain Example
-    ------------------------
-    "tp_min, tp_max, wf_min, wf_max": {
-        "function": "min_max",
-        "module": "pygama.dsp.processors",
-        "args": ["waveform", "tp_min", "tp_max", "wf_min", "wf_max"],
-        "unit": ["ns", "ns", "ADC", "ADC"],
-        "prereqs": ["waveform"]
-    }
+    Examples
+    --------
+    .. code-block :: json
+
+        "tp_min, tp_max, wf_min, wf_max": {
+            "function": "min_max",
+            "module": "pygama.dsp.processors",
+            "args": ["waveform", "tp_min", "tp_max", "wf_min", "wf_max"],
+            "unit": ["ns", "ns", "ADC", "ADC"],
+            "prereqs": ["waveform"]
+        }
     """
     a_min[0] = np.nan
     a_max[0] = np.nan

--- a/src/pygama/dsp/_processors/moving_windows.py
+++ b/src/pygama/dsp/_processors/moving_windows.py
@@ -13,12 +13,12 @@ def moving_window_left(w_in, length, w_out):
 
     Parameters
     ----------
-    w_in  : array-like
-            The input waveform
-    length: int
-            The length of the moving window
+    w_in : array-like
+        The input waveform
+    length : int
+        The length of the moving window
     w_out : array-like
-            The windowed waveform
+        The windowed waveform
 
     Examples
     --------
@@ -58,12 +58,12 @@ def moving_window_right(w_in, length, w_out):
 
     Parameters
     ----------
-    w_in  : array-like
-            The input waveform
-    length: int
-            The length of the moving window
+    w_in : array-like
+        The input waveform
+    length : int
+        The length of the moving window
     w_out : array-like
-            The windowed waveform
+        The windowed waveform
 
     Examples
     --------
@@ -104,14 +104,14 @@ def moving_window_multi(w_in, length, num_mw, w_out):
 
     Parameters
     ----------
-    w_in  : array-like
-            The input waveform
-    length: int
-            The length of the moving window
-    num_mw: int
-            The number of moving windows
+    w_in : array-like
+        The input waveform
+    length : int
+        The length of the moving window
+    num_mw : int
+        The number of moving windows
     w_out : array-like
-            The windowed waveform
+        The windowed waveform
 
     Examples
     --------
@@ -168,12 +168,12 @@ def avg_current(w_in, length, w_out):
 
     Parameters
     ----------
-    w_in  : array-like
-            The input waveform
-    length: int
-            The length of the moving window
+    w_in : array-like
+        The input waveform
+    length : int
+        The length of the moving window
     w_out : array-like
-            The output derivative
+        The output derivative
 
     Examples
     --------

--- a/src/pygama/dsp/_processors/moving_windows.py
+++ b/src/pygama/dsp/_processors/moving_windows.py
@@ -20,15 +20,17 @@ def moving_window_left(w_in, length, w_out):
     w_out : array-like
             The windowed waveform
 
-    Processing Chain Example
-    ------------------------
-    "wf_mw": {
-        "function": "moving_window_left",
-        "module": "pygama.dsp.processors",
-        "args": ["wf_pz", "96*ns", "wf_mw"],
-        "unit": "ADC",
-        "prereqs": ["wf_pz"]
-    }
+    Examples
+    --------
+    .. code-block :: json
+
+        "wf_mw": {
+            "function": "moving_window_left",
+            "module": "pygama.dsp.processors",
+            "args": ["wf_pz", "96*ns", "wf_mw"],
+            "unit": "ADC",
+            "prereqs": ["wf_pz"]
+        }
     """
     w_out[:] = np.nan
 
@@ -63,15 +65,17 @@ def moving_window_right(w_in, length, w_out):
     w_out : array-like
             The windowed waveform
 
-    Processing Chain Example
-    ------------------------
-    "wf_mw": {
-        "function": "moving_window_right",
-        "module": "pygama.dsp.processors",
-        "args": ["wf_pz", "96*ns", "wf_mw"],
-        "unit": "ADC",
-        "prereqs": ["wf_pz"]
-    }
+    Examples
+    --------
+    .. code-block :: json
+
+        "wf_mw": {
+            "function": "moving_window_right",
+            "module": "pygama.dsp.processors",
+            "args": ["wf_pz", "96*ns", "wf_mw"],
+            "unit": "ADC",
+            "prereqs": ["wf_pz"]
+        }
     """
     w_out[:] = np.nan
 
@@ -109,15 +113,17 @@ def moving_window_multi(w_in, length, num_mw, w_out):
     w_out : array-like
             The windowed waveform
 
-    Processing Chain Example
-    ------------------------
-    "curr_av": {
-        "function": "moving_window_multi",
-        "module": "pygama.dsp.processors",
-        "args": ["curr", "96*ns", "3", "curr_av"],
-        "unit": "ADC/sample",
-        "prereqs": ["curr"]
-    }
+    Examples
+    --------
+    .. code-block :: json
+
+        "curr_av": {
+            "function": "moving_window_multi",
+            "module": "pygama.dsp.processors",
+            "args": ["curr", "96*ns", "3", "curr_av"],
+            "unit": "ADC/sample",
+            "prereqs": ["curr"]
+        }
     """
     w_out[:] = np.nan
 
@@ -169,15 +175,17 @@ def avg_current(w_in, length, w_out):
     w_out : array-like
             The output derivative
 
-    Processing Chain Example
-    ------------------------
-    "curr": {
-        "function": "avg_current",
-        "module": "pygama.dsp.processors",
-        "args": ["wf_pz", 1, "curr(len(wf_pz)-1, f)"],
-        "unit": "ADC/sample",
-        "prereqs": ["wf_pz"]
-    }
+    Examples
+    --------
+    .. code-block :: json
+
+        "curr": {
+            "function": "avg_current",
+            "module": "pygama.dsp.processors",
+            "args": ["wf_pz", 1, "curr(len(wf_pz)-1, f)"],
+            "unit": "ADC/sample",
+            "prereqs": ["wf_pz"]
+        }
     """
     w_out[:] = np.nan
 

--- a/src/pygama/dsp/_processors/multi_a_filter.py
+++ b/src/pygama/dsp/_processors/multi_a_filter.py
@@ -18,6 +18,7 @@ def multi_a_filter(w_in, vt_maxs_in, va_max_out):
         The array of data within which amplitudes of extrema will be found
     vt_maxs_in : array-like
         The array of max positions for each wf
+
     Returns
     -------
     va_max_out: array-like

--- a/src/pygama/dsp/_processors/multi_a_filter.py
+++ b/src/pygama/dsp/_processors/multi_a_filter.py
@@ -18,11 +18,8 @@ def multi_a_filter(w_in, vt_maxs_in, va_max_out):
         The array of data within which amplitudes of extrema will be found
     vt_maxs_in : array-like
         The array of max positions for each wf
-
-    Returns
-    -------
-    va_max_out: array-like
-        An array of the amplitudes of the maximums of the waveform
+    va_max_out : array-like
+        An array (in-place filled) of the amplitudes of the maximums of the waveform
     """
 
     # Initialize output parameters

--- a/src/pygama/dsp/_processors/multi_t_filter.py
+++ b/src/pygama/dsp/_processors/multi_t_filter.py
@@ -26,7 +26,7 @@ def remove_duplicates(t_in, vt_min_in, t_out):
         The array of indices that we want to remove duplicates from
     vt_min_in : array-like
         List of indices of minima that we want to replace duplicates in t_out with
-    t_out: array-like
+    t_out : array-like
         The array we want to return that will have no duplicate indices in it
     """
     # initialize arrays
@@ -72,11 +72,11 @@ def multi_t_filter(w_in, a_threshold_in, vt_max_in, vt_min_in, t_out):
     ----------
     w_in : array-like
         The array of data within which the list of tp0s will be found
-    a_threshold_in: scalar
+    a_threshold_in : scalar
         Threshold to search for using time_point_thresh
-    vt_maxs_in : array-like
+    vt_max_in : array-like
         The array of max positions for each wf
-    vt_mins_in : array-like
+    vt_min_in : array-like
         The array of min positions for each wf
     t_out : array-like
         Output array of fixed length (padded with nans) that hold the indices of

--- a/src/pygama/dsp/_processors/multi_t_filter.py
+++ b/src/pygama/dsp/_processors/multi_t_filter.py
@@ -2,6 +2,7 @@ import numpy as np
 from numba import guvectorize
 
 from pygama.dsp._processors.time_point_thresh import time_point_thresh
+from pygama.dsp.errors import DSPFatal
 
 
 @guvectorize(["void(float32[:],float32[:],float32[:])",
@@ -77,13 +78,9 @@ def multi_t_filter(w_in, a_threshold_in, vt_max_in, vt_min_in, t_out):
         The array of max positions for each wf
     vt_mins_in : array-like
         The array of min positions for each wf
-
-    Returns
-    -------
     t_out : array-like
-        Array of fixed length (padded with nans) that hold the indices of
+        Output array of fixed length (padded with nans) that hold the indices of
         the identified initial rise times of peaks in the signal
-
     """
 
     # initialize arrays, padded with the elements we want

--- a/src/pygama/dsp/_processors/multi_t_filter.py
+++ b/src/pygama/dsp/_processors/multi_t_filter.py
@@ -9,14 +9,17 @@ from pygama.dsp._processors.time_point_thresh import time_point_thresh
              "(n),(n) -> (n)", nopython=True, cache=True)
 def remove_duplicates(t_in, vt_min_in, t_out):
     """
-    time_point_thresh has issues with afterpulsing in waveforms that causes
-    an aferpulse peak's tp0 to be sent to 0 or the same index as the tp0 for the first pulse.
-    This only happens when the relative minimum between the first pulse and
-    the afterpulse is greater than the threshold. So, we sweep through the array again
-    to ensure there are no duplicate indices. If there are duplicate indices caused by a
-    misidentified tp0 of an afterpulse, we replace its index by that of the corresponding minimum
-    found using the get_multi_local_extrema function. It also checks to make sure that the maximum of a waveform
-    isn't right at index 0.
+    time_point_thresh has issues with afterpulsing in waveforms that causes an
+    aferpulse peak's tp0 to be sent to 0 or the same index as the tp0 for the
+    first pulse.  This only happens when the relative minimum between the first
+    pulse and the afterpulse is greater than the threshold. So, we sweep
+    through the array again to ensure there are no duplicate indices. If there
+    are duplicate indices caused by a misidentified tp0 of an afterpulse, we
+    replace its index by that of the corresponding minimum found using the
+    get_multi_local_extrema function. It also checks to make sure that the
+    maximum of a waveform isn't right at index 0.
+
+    Parameters
     ----------
     t_in : array-like
         The array of indices that we want to remove duplicates from
@@ -63,6 +66,7 @@ def multi_t_filter(w_in, a_threshold_in, vt_max_in, vt_min_in, t_out):
     "get_multi_local_extrema" which returns a list of the maxima and minima in a waveform,
     and then the list of maxima is fed into "time_point_thresh" which returns
     the final times that waveform is less than a specified threshold.
+
     Parameters
     ----------
     w_in : array-like
@@ -73,6 +77,7 @@ def multi_t_filter(w_in, a_threshold_in, vt_max_in, vt_min_in, t_out):
         The array of max positions for each wf
     vt_mins_in : array-like
         The array of min positions for each wf
+
     Returns
     -------
     t_out : array-like

--- a/src/pygama/dsp/_processors/optimize.py
+++ b/src/pygama/dsp/_processors/optimize.py
@@ -36,20 +36,20 @@ def optimize_1pz(w_in, a_baseline_in, t_beg_in, t_end_in, p0_in, val0_out):
 
     Parameters
     ----------
-    w_in         : array-like
-                   The input waveform
-    a_baseline_in: float
-                   The resting baseline
-    t_beg_in     : int
-                   The lower bound's index for the time range over
-                   which to optimize the pole-zero cancellation
-    t_end_in     : int
-                   The upper bound's index for the time range over
-                   which to optimize the pole-zero cancellation
-    p0_in        : float
-                   The initial guess of the optimal time constant
-    val0_out     : float
-                   The output value of the best-fit time constant
+    w_in : array-like
+        The input waveform
+    a_baseline_in : float
+        The resting baseline
+    t_beg_in : int
+        The lower bound's index for the time range over
+        which to optimize the pole-zero cancellation
+    t_end_in : int
+        The upper bound's index for the time range over
+        which to optimize the pole-zero cancellation
+    p0_in : float
+        The initial guess of the optimal time constant
+    val0_out : float
+        The output value of the best-fit time constant
 
     Examples
     --------
@@ -94,28 +94,28 @@ def optimize_2pz(w_in, a_baseline_in, t_beg_in, t_end_in, p0_in, p1_in, p2_in, v
 
     Parameters
     ----------
-    w_in         : array-like
-                   The input waveform
-    a_baseline_in: float
-                   The resting baseline
-    t_beg_in     : int
-                   The lower bound's index for the time range over
-                   which to optimize the pole-zero cancellation
-    t_end_in     : int
-                   The upper bound's index for the time range over
-                   which to optimize the pole-zero cancellation
-    p0_in        : float
-                   The initial guess of the optimal, longer time constant
-    p1_in        : float
-                   The initial guess of the optimal, shorter time constant
-    p2_in        : float
-                   The initial guess of the optimal fraction
-    val0_out     : float
-                   The output value of the best-fit, longer time constant
-    val1_out     : float
-                   The output value of the best-fit, shorter time constant
-    val2_out     : float
-                   The output value of the best-fit fraction
+    w_in : array-like
+        The input waveform
+    a_baseline_in : float
+        The resting baseline
+    t_beg_in : int
+        The lower bound's index for the time range over
+        which to optimize the pole-zero cancellation
+    t_end_in : int
+        The upper bound's index for the time range over
+        which to optimize the pole-zero cancellation
+    p0_in : float
+        The initial guess of the optimal, longer time constant
+    p1_in : float
+        The initial guess of the optimal, shorter time constant
+    p2_in : float
+        The initial guess of the optimal fraction
+    val0_out : float
+        The output value of the best-fit, longer time constant
+    val1_out : float
+        The output value of the best-fit, shorter time constant
+    val2_out : float
+        The output value of the best-fit fraction
 
     Examples
     --------

--- a/src/pygama/dsp/_processors/optimize.py
+++ b/src/pygama/dsp/_processors/optimize.py
@@ -51,15 +51,17 @@ def optimize_1pz(w_in, a_baseline_in, t_beg_in, t_end_in, p0_in, val0_out):
     val0_out     : float
                    The output value of the best-fit time constant
 
-    Processing Chain Example
-    ------------------------
-    "tau0": {
-        "function": "optimize_1pz",
-        "module": "pygama.dsp.processors",
-        "args": ["waveform", "baseline", "0", "20*us", "500*us", "tau0"],
-        "prereqs": ["waveform", "baseline"],
-        "unit": "us"
-    }
+    Examples
+    --------
+    .. code-block :: json
+
+        "tau0": {
+            "function": "optimize_1pz",
+            "module": "pygama.dsp.processors",
+            "args": ["waveform", "baseline", "0", "20*us", "500*us", "tau0"],
+            "prereqs": ["waveform", "baseline"],
+            "unit": "us"
+        }
     """
     val0_out[0] = np.nan
 
@@ -115,15 +117,17 @@ def optimize_2pz(w_in, a_baseline_in, t_beg_in, t_end_in, p0_in, p1_in, p2_in, v
     val2_out     : float
                    The output value of the best-fit fraction
 
-    Processing Chain Example
-    ------------------------
-    "tau1, tau2, frac": {
-        "function": "optimize_2pz",
-        "module": "pygama.dsp.processors",
-        "args": ["waveform", "baseline", "0", "20*us", "500*us", "20*us", "0.02", "tau1", "tau2", "frac"],
-        "prereqs": ["waveform", "baseline"],
-        "unit": "us"
-    }
+    Examples
+    --------
+    .. code-block :: json
+
+        "tau1, tau2, frac": {
+            "function": "optimize_2pz",
+            "module": "pygama.dsp.processors",
+            "args": ["waveform", "baseline", "0", "20*us", "500*us", "20*us", "0.02", "tau1", "tau2", "frac"],
+            "prereqs": ["waveform", "baseline"],
+            "unit": "us"
+        }
     """
     val0_out[0] = np.nan
     val1_out[0] = np.nan

--- a/src/pygama/dsp/_processors/pole_zero.py
+++ b/src/pygama/dsp/_processors/pole_zero.py
@@ -15,11 +15,11 @@ def pole_zero(w_in, t_tau, w_out):
     Parameters
     ----------
     w_in : array-like
-           The input waveform
-    t_tau: float
-           The time constant of the exponential to be deconvolved
-    w_out: array-like
-           The pole-zero cancelled waveform
+        The input waveform
+    t_tau : float
+        The time constant of the exponential to be deconvolved
+    w_out : array-like
+        The pole-zero cancelled waveform
 
     Examples
     --------
@@ -53,16 +53,16 @@ def double_pole_zero(w_in, t_tau1, t_tau2, frac, w_out):
 
     Parameters
     ----------
-    w_in  : array-like
-            The input waveform
-    t_tau1: float
-            The time constant of the first exponential to be deconvolved
-    t_tau2: float
-            The time constant of the second exponential to be deconvolved
-    frac  : float
-            The fraction which the second exponential contributes
+    w_in : array-like
+        The input waveform
+    t_tau1 : float
+        The time constant of the first exponential to be deconvolved
+    t_tau2 : float
+        The time constant of the second exponential to be deconvolved
+    frac : float
+        The fraction which the second exponential contributes
     w_out : array-like
-            The pole-zero cancelled waveform
+        The pole-zero cancelled waveform
 
     Examples
     --------

--- a/src/pygama/dsp/_processors/pole_zero.py
+++ b/src/pygama/dsp/_processors/pole_zero.py
@@ -21,15 +21,17 @@ def pole_zero(w_in, t_tau, w_out):
     w_out: array-like
            The pole-zero cancelled waveform
 
-    Processing Chain Example
-    ------------------------
-    "wf_pz": {
-        "function": "pole_zero",
-        "module": "pygama.dsp.processors",
-        "args": ["wf_bl", "400*us", "wf_pz"],
-        "unit": "ADC",
-        "prereqs": ["wf_bl"]
-    }
+    Examples
+    --------
+    .. code-block :: json
+
+        "wf_pz": {
+            "function": "pole_zero",
+            "module": "pygama.dsp.processors",
+            "args": ["wf_bl", "400*us", "wf_pz"],
+            "unit": "ADC",
+            "prereqs": ["wf_bl"]
+        }
     """
     w_out[:] = np.nan
 
@@ -62,15 +64,17 @@ def double_pole_zero(w_in, t_tau1, t_tau2, frac, w_out):
     w_out : array-like
             The pole-zero cancelled waveform
 
-    Processing Chain Example
-    ------------------------
-    "wf_pz": {
-        "function": "double_pole_zero",
-        "module": "pygama.dsp.processors",
-        "args": ["wf_bl", "400*us", "20*us", "0.02", "wf_pz"],
-        "unit": "ADC",
-        "prereqs": ["wf_bl"]
-    }
+    Examples
+    --------
+    .. code-block :: json
+
+        "wf_pz": {
+            "function": "double_pole_zero",
+            "module": "pygama.dsp.processors",
+            "args": ["wf_bl", "400*us", "20*us", "0.02", "wf_pz"],
+            "unit": "ADC",
+            "prereqs": ["wf_bl"]
+        }
     """
     w_out[:] = np.nan
 

--- a/src/pygama/dsp/_processors/presum.py
+++ b/src/pygama/dsp/_processors/presum.py
@@ -16,9 +16,9 @@ def presum(w_in, w_out):
     Parameters
     ----------
     w_in : array-like
-           The input waveform
-    w_out: array-like
-           The output waveform
+        The input waveform
+    w_out : array-like
+        The output waveform
     """
     w_out[:] = np.nan
 

--- a/src/pygama/dsp/_processors/saturation.py
+++ b/src/pygama/dsp/_processors/saturation.py
@@ -15,14 +15,14 @@ def saturation(w_in, bit_depth_in, n_lo_out, n_hi_out):
 
     Parameters
     ----------
-    w_in        : array-like
-                  The input waveform
-    bit_depth_in: int
-                  The bit depth of the analog-to-digital converter
-    n_lo_out    : int
-                  The output number of samples at the minimum
-    n_hi_out    : int
-                  The output number of samples at the maximum
+    w_in : array-like
+        The input waveform
+    bit_depth_in : int
+        The bit depth of the analog-to-digital converter
+    n_lo_out : int
+        The output number of samples at the minimum
+    n_hi_out : int
+        The output number of samples at the maximum
 
     Examples
     --------

--- a/src/pygama/dsp/_processors/saturation.py
+++ b/src/pygama/dsp/_processors/saturation.py
@@ -24,15 +24,17 @@ def saturation(w_in, bit_depth_in, n_lo_out, n_hi_out):
     n_hi_out    : int
                   The output number of samples at the maximum
 
-    Processing Chain Example
-    ------------------------
-    "sat_lo, sat_hi": {
-        "function": "saturation",
-        "module": "pygama.dsp.processors",
-        "args": ["waveform", "16", "sat_lo", "sat_hi"],
-        "unit": "ADC",
-        "prereqs": ["waveform"]
-    }
+    Examples
+    --------
+    .. code-block :: json
+
+        "sat_lo, sat_hi": {
+            "function": "saturation",
+            "module": "pygama.dsp.processors",
+            "args": ["waveform", "16", "sat_lo", "sat_hi"],
+            "unit": "ADC",
+            "prereqs": ["waveform"]
+        }
     """
     n_lo_out[0] = np.nan
     n_hi_out[0] = np.nan

--- a/src/pygama/dsp/_processors/soft_pileup_corr.py
+++ b/src/pygama/dsp/_processors/soft_pileup_corr.py
@@ -25,15 +25,17 @@ def soft_pileup_corr(w_in, n_in, tau_in, w_out):
     w_out : array-like
             The output waveform with the exponential subtracted
 
-    Processing Chain Example
-    ------------------------
-    "wf_bl": {
-        "function": "soft_pileup_corr",
-        "module": "pygama.dsp.processors",
-        "args": ["waveform", "1000", "500*us", "wf_bl"],
-        "unit": "ADC",
-        "prereqs": ["waveform"]
-    }
+    Examples
+    --------
+    .. code-block :: json
+
+        "wf_bl": {
+            "function": "soft_pileup_corr",
+            "module": "pygama.dsp.processors",
+            "args": ["waveform", "1000", "500*us", "wf_bl"],
+            "unit": "ADC",
+            "prereqs": ["waveform"]
+        }
     """
     w_out[:] = np.nan
 
@@ -88,15 +90,17 @@ def soft_pileup_corr_bl(w_in, n_in, tau_in, B_in, w_out):
     w_out : array-like
             The output waveform with the exponential subtracted
 
-    Processing Chain Example
-    ------------------------
-    "wf_bl": {
-        "function": "soft_pileup_corr_bl",
-        "module": "pygama.dsp.processors",
-        "args": ["waveform", "1000", "500*us", "baseline", "wf_bl"],
-        "unit": "ADC",
-        "prereqs": ["waveform", "baseline"]
-    }
+    Examples
+    --------
+    .. code-block :: json
+
+        "wf_bl": {
+            "function": "soft_pileup_corr_bl",
+            "module": "pygama.dsp.processors",
+            "args": ["waveform", "1000", "500*us", "baseline", "wf_bl"],
+            "unit": "ADC",
+            "prereqs": ["waveform", "baseline"]
+        }
     """
     w_out[:] = np.nan
 

--- a/src/pygama/dsp/_processors/soft_pileup_corr.py
+++ b/src/pygama/dsp/_processors/soft_pileup_corr.py
@@ -15,15 +15,15 @@ def soft_pileup_corr(w_in, n_in, tau_in, w_out):
 
     Parameters
     ----------
-    w_in  : array-like
-            The input waveform
-    n_in  : int
-            The number of samples at the beginning of the waveform
-            to fit to an exponential
-    tau_in: float
-            The fixed, exponential time constant
+    w_in : array-like
+        The input waveform
+    n_in : int
+        The number of samples at the beginning of the waveform
+        to fit to an exponential
+    tau_in : float
+        The fixed, exponential time constant
     w_out : array-like
-            The output waveform with the exponential subtracted
+        The output waveform with the exponential subtracted
 
     Examples
     --------
@@ -78,17 +78,17 @@ def soft_pileup_corr_bl(w_in, n_in, tau_in, B_in, w_out):
 
     Parameters
     ----------
-    w_in  : array-like
-            The input waveform
-    n_in  : int
-            The number of samples at the beginning of the waveform
-            to fit to an exponential
-    tau_in: float
-            The fixed, exponential time constant
-    B_in  : float
-            The fixed, exponential constant
+    w_in : array-like
+        The input waveform
+    n_in : int
+        The number of samples at the beginning of the waveform
+        to fit to an exponential
+    tau_in : float
+        The fixed, exponential time constant
+    B_in : float
+        The fixed, exponential constant
     w_out : array-like
-            The output waveform with the exponential subtracted
+        The output waveform with the exponential subtracted
 
     Examples
     --------

--- a/src/pygama/dsp/_processors/time_point_thresh.py
+++ b/src/pygama/dsp/_processors/time_point_thresh.py
@@ -14,16 +14,16 @@ def time_point_thresh(w_in, a_threshold, t_start, walk_forward, t_out):
 
     Parameters
     ----------
-    w_in        : array-like
-                  The input waveform
+    w_in : array-like
+        The input waveform
     a_threshold : float
-                  The threshold value
-    t_start     : int
-                  The starting index
-    walk_forward: int
-                  The backward (0) or forward (1) search direction
-    t_out       : float
-                  The index where the waveform value crosses the threshold
+        The threshold value
+    t_start : int
+        The starting index
+    walk_forward : int
+        The backward (0) or forward (1) search direction
+    t_out : float
+        The index where the waveform value crosses the threshold
 
     Examples
     --------

--- a/src/pygama/dsp/_processors/time_point_thresh.py
+++ b/src/pygama/dsp/_processors/time_point_thresh.py
@@ -25,15 +25,17 @@ def time_point_thresh(w_in, a_threshold, t_start, walk_forward, t_out):
     t_out       : float
                   The index where the waveform value crosses the threshold
 
-    Processing Chain Example
-    ------------------------
-    "tp_0": {
-        "function": "time_point_thresh",
-        "module": "pygama.dsp.processors",
-        "args": ["wf_atrap", "bl_std", "tp_start", 0, "tp_0"],
-        "unit": "ns",
-        "prereqs": ["wf_atrap", "bl_std", "tp_start"]
-    }
+    Examples
+    --------
+    .. code-block :: json
+
+        "tp_0": {
+            "function": "time_point_thresh",
+            "module": "pygama.dsp.processors",
+            "args": ["wf_atrap", "bl_std", "tp_start", 0, "tp_0"],
+            "unit": "ns",
+            "prereqs": ["wf_atrap", "bl_std", "tp_start"]
+        }
     """
     t_out[0] = np.nan
 

--- a/src/pygama/dsp/_processors/trap_filters.py
+++ b/src/pygama/dsp/_processors/trap_filters.py
@@ -22,15 +22,17 @@ def trap_filter(w_in, rise, flat, w_out):
     w_out: array-like
            The filtered waveform
 
-    Processing Chain Example
-    ------------------------
-    "wf_tf": {
-        "function": "trap_filter",
-        "module": "pygama.dsp.processors",
-        "args": ["wf_pz", "10*us", "3*us", "wf_tf"],
-        "unit": "ADC",
-        "prereqs": ["wf_pz"]
-    }
+    Examples
+    --------
+    .. code-block :: json
+
+        "wf_tf": {
+            "function": "trap_filter",
+            "module": "pygama.dsp.processors",
+            "args": ["wf_pz", "10*us", "3*us", "wf_tf"],
+            "unit": "ADC",
+            "prereqs": ["wf_pz"]
+        }
     """
     w_out[:] = np.nan
 
@@ -75,15 +77,17 @@ def trap_norm(w_in, rise, flat, w_out):
     w_out: array-like
            The normalized, filtered waveform
 
-    Processing Chain Example
-    ------------------------
-    "wf_tf": {
-        "function": "trap_norm",
-        "module": "pygama.dsp.processors",
-        "args": ["wf_pz", "10*us", "3*us", "wf_tf"],
-        "unit": "ADC",
-        "prereqs": ["wf_pz"]
-    }
+    Examples
+    --------
+    .. code-block :: json
+
+        "wf_tf": {
+            "function": "trap_norm",
+            "module": "pygama.dsp.processors",
+            "args": ["wf_pz", "10*us", "3*us", "wf_tf"],
+            "unit": "ADC",
+            "prereqs": ["wf_pz"]
+        }
     """
     w_out[:] = np.nan
 
@@ -130,15 +134,17 @@ def asym_trap_filter(w_in, rise, flat, fall, w_out):
     w_out: array-like
            The normalized, filtered waveform
 
-    Processing Chain Example
-    ------------------------
-    "wf_af": {
-        "function": "asym_trap_filter",
-        "module": "pygama.dsp.processors",
-        "args": ["wf_pz", "128*ns", "64*ns", "2*us", "wf_af"],
-        "unit": "ADC",
-        "prereqs": ["wf_pz"]
-    }
+    Examples
+    --------
+    .. code-block :: json
+
+        "wf_af": {
+            "function": "asym_trap_filter",
+            "module": "pygama.dsp.processors",
+            "args": ["wf_pz", "128*ns", "64*ns", "2*us", "wf_af"],
+            "unit": "ADC",
+            "prereqs": ["wf_pz"]
+        }
     """
     w_out[:] = np.nan
 
@@ -189,15 +195,17 @@ def trap_pickoff(w_in, rise, flat, t_pickoff, a_out):
     a_out    : float
                The output pick-off value of the filtered waveform
 
-    Processing Chain Example
-    ------------------------
-    "ct_corr": {
-        "function": "trap_pickoff",
-        "module": "pygama.dsp.processors",
-        "args": ["wf_pz", "1.5*us", 0, "tp_0", "ct_corr"],
-        "unit": "ADC",
-        "prereqs": ["wf_pz", "tp_0"]
-    }
+    Examples
+    --------
+    .. code-block :: json
+
+        "ct_corr": {
+            "function": "trap_pickoff",
+            "module": "pygama.dsp.processors",
+            "args": ["wf_pz", "1.5*us", 0, "tp_0", "ct_corr"],
+            "unit": "ADC",
+            "prereqs": ["wf_pz", "tp_0"]
+        }
     """
     a_out[0] = np.nan
 

--- a/src/pygama/dsp/_processors/trap_filters.py
+++ b/src/pygama/dsp/_processors/trap_filters.py
@@ -14,13 +14,13 @@ def trap_filter(w_in, rise, flat, w_out):
     Parameters
     ----------
     w_in : array-like
-           The input waveform
+        The input waveform
     rise : int
-           The number of samples averaged in the rise and fall sections
+        The number of samples averaged in the rise and fall sections
     flat : int
-           The delay between the rise and fall sections
-    w_out: array-like
-           The filtered waveform
+        The delay between the rise and fall sections
+    w_out : array-like
+        The filtered waveform
 
     Examples
     --------
@@ -69,13 +69,13 @@ def trap_norm(w_in, rise, flat, w_out):
     Parameters
     ----------
     w_in : array-like
-           The input waveform
+        The input waveform
     rise : int
-           The number of samples averaged in the rise and fall sections
+        The number of samples averaged in the rise and fall sections
     flat : int
-           The delay between the rise and fall sections
-    w_out: array-like
-           The normalized, filtered waveform
+        The delay between the rise and fall sections
+    w_out : array-like
+        The normalized, filtered waveform
 
     Examples
     --------
@@ -124,15 +124,15 @@ def asym_trap_filter(w_in, rise, flat, fall, w_out):
     Parameters
     ----------
     w_in : array-like
-           The input waveform
+        The input waveform
     rise : int
-           The number of samples averaged in the rise section
+        The number of samples averaged in the rise section
     flat : int
-           The delay between the rise and fall sections
+        The delay between the rise and fall sections
     fall : int
-           The number of samples averaged in the fall section
-    w_out: array-like
-           The normalized, filtered waveform
+        The number of samples averaged in the fall section
+    w_out : array-like
+        The normalized, filtered waveform
 
     Examples
     --------
@@ -184,16 +184,16 @@ def trap_pickoff(w_in, rise, flat, t_pickoff, a_out):
 
     Parameters
     ----------
-    w_in     : array-like
-               The input waveform
-    rise     : int
-               The number of samples averaged in the rise and fall sections
-    flat     : int
-               The delay between the rise and fall sections
-    t_pickoff: float
-               The waveform index to pick off
-    a_out    : float
-               The output pick-off value of the filtered waveform
+    w_in : array-like
+        The input waveform
+    rise : int
+        The number of samples averaged in the rise and fall sections
+    flat : int
+        The delay between the rise and fall sections
+    t_pickoff : float
+        The waveform index to pick off
+    a_out : float
+        The output pick-off value of the filtered waveform
 
     Examples
     --------

--- a/src/pygama/dsp/_processors/wiener_filter.py
+++ b/src/pygama/dsp/_processors/wiener_filter.py
@@ -13,10 +13,10 @@ def wiener_filter(file_name_array):
     Parameters
     ----------
     file_name_array : string
-            Array with path to an lh5 file containing the time domain version
-            of the superpulse in one column and noise waveform in another,
-            the superpulse group must be titled 'spms/processed/superpulse' and
-            the noise waveform must be called 'spms/processed/noise_wf'
+        Array with path to an lh5 file containing the time domain version
+        of the superpulse in one column and noise waveform in another,
+        the superpulse group must be titled 'spms/processed/superpulse' and
+        the noise waveform must be called 'spms/processed/noise_wf'
 
     Examples
     --------
@@ -102,9 +102,9 @@ def wiener_filter(file_name_array):
         Parameters
         ----------
         fft_w_in : array-like
-               The fourier transform input waveform
-        fft_w_out: array-like
-               The filtered waveform, in the frequency domain
+            The fourier transform input waveform
+        fft_w_out : array-like
+            The filtered waveform, in the frequency domain
         """
         fft_w_out[:] = np.nan
 

--- a/src/pygama/dsp/_processors/wiener_filter.py
+++ b/src/pygama/dsp/_processors/wiener_filter.py
@@ -1,31 +1,24 @@
 import numpy as np
 from numba import guvectorize
 
-from pygama import lh5
+import pygama.lgdo.lh5_store as lh5
 from pygama.dsp.errors import DSPFatal
 
 
-def Wiener_filter(file_name_array):
+def wiener_filter(file_name_array):
     """
-    Apply a Wiener filter to the waveform.  Note that this convolution is performed in the frequency domain
+    Apply a wiener filter to the waveform.  Note that this convolution is performed in the frequency domain
 
-    Initialization Parameters
-    -------------------------
+    Parameters
+    ----------
     file_name_array : string
             Array with path to an lh5 file containing the time domain version of the superpulse in one column and noise waveform in another,
             the superpulse group must be titled 'spms/processed/superpulse' and the noise waveform must be called 'spms/processed/noise_wf'
 
-    Parameters
-    ----------
-    fft_w_in : array-like
-           The fourier transform input waveform
-    fft_w_out: array-like
-           The filtered waveform, in the frequency domain
-
     Processing Chain Example
     ------------------------
     "wf_wiener": {
-        "function": "Wiener_filter",
+        "function": "wiener_filter",
         "module": "pygama.dsp.processors",
         "args": ["wf_bl_fft", "wf_wiener(2000,f)"],
         "unit": "dB",
@@ -34,7 +27,7 @@ def Wiener_filter(file_name_array):
     }
     """
 
-    sto = lh5.Store()
+    sto = lh5.LH5Store()
 
     # Check that the file is valid and the data is in the correct format
 
@@ -71,7 +64,7 @@ def Wiener_filter(file_name_array):
     if np.argmax(superpulse) <= 0 or np.argmax(superpulse) > len(superpulse):
         raise DSPFatal('The index of the maximum of the superpulse must occur within the waveform')
 
-    # Transform these to the frequency domain to eventually create the Wiener filter
+    # Transform these to the frequency domain to eventually create the wiener filter
 
     fft_superpulse = np.fft.fft(superpulse)
     fft_noise_wf = np.fft.fft(noise_wf)
@@ -86,7 +79,7 @@ def Wiener_filter(file_name_array):
 
         return fft_superpulse/np.fft.fft(delta)
 
-    # Now create the Wiener filter in the frequency domain
+    # Now create the wiener filter in the frequency domain
 
     fft_PSF = PSF(superpulse, fft_superpulse)
     PSD_noise_wf = fft_noise_wf*np.conj(fft_noise_wf)
@@ -94,12 +87,20 @@ def Wiener_filter(file_name_array):
 
     w_filter = (np.conj(fft_PSF))/((fft_PSF*np.conj(fft_PSF))+(PSD_noise_wf/PSD_superpulse))
 
-    # Create a factory function that performs the convolution with the Wiener filter, the output is still in the frequency domain
+    # Create a factory function that performs the convolution with the wiener filter, the output is still in the frequency domain
 
     @guvectorize(["void(complex64[:], complex64[:])",
                   "void(complex128[:], complex128[:])"],
                  "(n)->(n)", forceobj=True)
-    def Wiener_out(fft_w_in, fft_w_out):
+    def wiener_out(fft_w_in, fft_w_out):
+        """
+        Parameters
+        ----------
+        fft_w_in : array-like
+               The fourier transform input waveform
+        fft_w_out: array-like
+               The filtered waveform, in the frequency domain
+        """
         fft_w_out[:] = np.nan
 
         if np.isnan(fft_w_in).any():
@@ -110,4 +111,4 @@ def Wiener_filter(file_name_array):
 
         fft_w_out[:] = fft_w_in * w_filter
 
-    return Wiener_out
+    return wiener_out

--- a/src/pygama/dsp/_processors/wiener_filter.py
+++ b/src/pygama/dsp/_processors/wiener_filter.py
@@ -6,25 +6,30 @@ from pygama.dsp.errors import DSPFatal
 
 
 def wiener_filter(file_name_array):
-    """
-    Apply a wiener filter to the waveform.  Note that this convolution is performed in the frequency domain
+    """Apply a wiener filter to the waveform.
+
+    Note that this convolution is performed in the frequency domain
 
     Parameters
     ----------
     file_name_array : string
-            Array with path to an lh5 file containing the time domain version of the superpulse in one column and noise waveform in another,
-            the superpulse group must be titled 'spms/processed/superpulse' and the noise waveform must be called 'spms/processed/noise_wf'
+            Array with path to an lh5 file containing the time domain version
+            of the superpulse in one column and noise waveform in another,
+            the superpulse group must be titled 'spms/processed/superpulse' and
+            the noise waveform must be called 'spms/processed/noise_wf'
 
-    Processing Chain Example
-    ------------------------
-    "wf_wiener": {
-        "function": "wiener_filter",
-        "module": "pygama.dsp.processors",
-        "args": ["wf_bl_fft", "wf_wiener(2000,f)"],
-        "unit": "dB",
-        "prereqs": ["wf_bl_fft"],
-        "init_args": ["/path/to/file/wiener.lh5"]
-    }
+    Examples
+    --------
+    .. code-block :: json
+
+        "wf_wiener": {
+            "function": "wiener_filter",
+            "module": "pygama.dsp.processors",
+            "args": ["wf_bl_fft", "wf_wiener(2000,f)"],
+            "unit": "dB",
+            "prereqs": ["wf_bl_fft"],
+            "init_args": ["/path/to/file/wiener.lh5"]
+        }
     """
 
     sto = lh5.LH5Store()

--- a/src/pygama/dsp/_processors/windower.py
+++ b/src/pygama/dsp/_processors/windower.py
@@ -19,11 +19,11 @@ def windower(w_in, t0_in, w_out):
     Parameters
     ----------
     w_in : array-like
-           The input waveform
-    t0_in: int
-           The starting index of the window
-    w_out: array-like
-           The windowed waveform
+        The input waveform
+    t0_in : int
+        The starting index of the window
+    w_out : array-like
+        The windowed waveform
     """
     w_out[:] = np.nan
 

--- a/src/pygama/dsp/build_dsp.py
+++ b/src/pygama/dsp/build_dsp.py
@@ -27,10 +27,12 @@ def build_dsp(f_raw, f_dsp, dsp_config, lh5_tables=None, database=None,
     f_raw : str
         Name of raw LH5 file to read from
     f_dsp : str
-        Name of dsp LH% file to write to
+        Name of dsp LH5 file to write to
     dsp_config : str
         Name of json file containing ProcessingChain config. See
         pygama.processing_chain.build_processing_chain for details
+    lh5_tables
+        DOC_ME
     database : str (optional)
         Name of json file containing a parameter database. See
         pygama.processing_chain.build_processing_chain for details
@@ -51,6 +53,8 @@ def build_dsp(f_raw, f_dsp, dsp_config, lh5_tables=None, database=None,
         0: Silent except for exceptions thrown
         1: Minimal information printed (default)
         2: Verbose output for debugging purposes
+    chan_config
+        DOC_ME
     """
     t_start = time.time()
 

--- a/src/pygama/dsp/processing_chain.py
+++ b/src/pygama/dsp/processing_chain.py
@@ -269,13 +269,12 @@ class ProcessingChain:
         """
         Parameters
         ----------
-
-        block_width: int
+        block_width : int
             number of entries to simultaneously process.
-        buffer_len: int
+        buffer_len : int
             length of input and output buffers. Should be a multiple of
             block_width
-        verbosity: int
+        verbosity : int
             integer indicating the verbosity level. 0: Print nothing (except
             errors...); 1: Print basic warnings (default); 2: Print basic debug
             info
@@ -1140,7 +1139,8 @@ def build_processing_chain(lh5_in, dsp_config, db_dict = None,
     lh5_in : lgdo.Table
         HDF5 table from which raw data is read. At least one row of entries
         should be read in prior to calling this!
-    dsp_config: dict or str
+
+    dsp_config : dict or str
         A dict or json filename containing the recipes for computing DSP
         parameter from raw parameters. The format is as follows: ::
 
@@ -1173,19 +1173,22 @@ def build_processing_chain(lh5_in, dsp_config, db_dict = None,
                }
             }
 
-    outputs: [str, ...], optional
+    outputs : [str, ...], optional
         List of parameters to put in the output lh5 table. If None,
         use the parameters in the 'outputs' list from config
-    db_dict: dict, optional
+
+    db_dict : dict, optional
         A nested dict pointing to values for db args. e.g. if a processor
         uses arg db.trap.risetime, it will look up db_dict['trap']['risetime']
         and use the found value. If no value is found, use the default
         defined in the config file.
+
     verbosity : int, optional
         0: Print nothing (except errors...)
         1: Print basic warnings (default)
         2: Print basic debug info
         3: Print friggin' everything!
+
     block_width : int, optional
         number of entries to process at once. To optimize performance,
         a multiple of 16 is preferred, but if performance is not an issue

--- a/src/pygama/dsp/processors.py
+++ b/src/pygama/dsp/processors.py
@@ -2,15 +2,15 @@ r"""
 Contains a list of DSP processors, implemented using Numba's
 :func:`numba.guvectorize` to implement NumPy's :class:`numpy.ufunc` interface.
 In other words, all of the functions are void functions whose outputs are given
-as parameters.  The :class:`ufunc` interface provides additional information
-about the function signatures that enables broadcasting the arrays and SIMD
-processing. Thanks to the :class:`ufunc` interface, they can also be called to
-return a NumPy array, but if this is done, memory will be allocated for this
-array, slowing things down.
+as parameters.  The :class:`~numpy.ufunc` interface provides additional
+information about the function signatures that enables broadcasting the arrays
+and SIMD processing. Thanks to the :class:`~numpy.ufunc` interface, they can
+also be called to return a NumPy array, but if this is done, memory will be
+allocated for this array, slowing things down.
 
-The pygama processors use the :class:`ufunc` framework, which is designed to
-encourage highly performant python practices. These functions have several
-advantages:
+The pygama processors use the :class:`~numpy.ufunc` framework, which is
+designed to encourage highly performant python practices. These functions have
+several advantages:
 
 1. They work with :class:`numpy.array`. NumPy arrays are arrays of same-typed
    objects that are stored adjacently in memory (equivalent to a dynamically
@@ -20,7 +20,7 @@ advantages:
 
 2. They perform vectorized operations. Vectorization causes commands to
    perform the same operation on all components of an array. For example, the
-   :class:`ufunc` ``np.add(a, b, out=c)`` (equivalently ``c=a+b``) is
+   :class:`~numpy.ufunc` ``np.add(a, b, out=c)`` (equivalently ``c=a+b``) is
    equivalent to: ::
 
        for i in range(len(c)): c[i] = a[i] + b[i]
@@ -28,7 +28,7 @@ advantages:
    Loops are slow in python since it is an interpreted language; vectorized
    commands remove the loop and only call the Python interpreter once.
 
-   Furthermore, :class:`ufunc`\ s are capable of `broadcasting
+   Furthermore, :class:`~numpy.ufunc`\ s are capable of `broadcasting
    <https://docs.scipy.org/doc/numpy/reference/ufuncs.html#broadcasting>`_
    their dimensions. This involves a safety check to ensure the dimensions of
    ``a`` and ``b`` are compatible sizes. It also will automatically replicate a
@@ -36,27 +36,27 @@ advantages:
    a vector quantity. This is useful, as it allows us to process multiple
    waveforms at once.
 
-   One of the biggest advantages of vectorized :class:`ufunc`\ s is that many of
-   them will take advantage of SIMD (same input-multiple data) vectorization on
-   a vector-CPU. Modern CPUs typically have 256- or 512-bit wide processing
-   units, which can accommodate multiple 32- or 64-bit numbers. Programming
-   with these, however, is quite difficult and requires specialized commands to
-   be called.  Luckily for us, many NumPy :class`ufunc`\ s will automatically use
-   these for us, speeding up our code!
+   One of the biggest advantages of vectorized :class:`~numpy.ufunc`\ s is that
+   many of them will take advantage of SIMD (same input-multiple data)
+   vectorization on a vector-CPU. Modern CPUs typically have 256- or 512-bit
+   wide processing units, which can accommodate multiple 32- or 64-bit numbers.
+   Programming with these, however, is quite difficult and requires specialized
+   commands to be called.  Luckily for us, many NumPy :class`~numpy.ufunc`\ s
+   will automatically use these for us, speeding up our code!
 
-3. :class:`ufunc`\ s are capable of calculating their output in place, meaning
-   they can place calculated values in pre-allocated memory rather than
+3. :class:`~numpy.ufunc`\ s are capable of calculating their output in place,
+   meaning they can place calculated values in pre-allocated memory rather than
    allocating and returning new values. This is important because memory
    allocation is one of the slowest processes computers can perform, and should
-   be avoided. With :class:`ufunc`\ s, this can be done using the out keyword in
-   arguments (ex ``numpy.add(a, b, out=c)``, or more succinctly, ``numpy.add(a,
-   b, c)``).  While this may seem counterintuitive at first, the alternative
-   (``c = np.add(a,b)`` or ``c = a+b``) causes an entirely new array to be
-   allocated, with c pointing at that. These array allocations can add up very
-   quickly: ``e = a*b + c*d``, for example, would allocate 3 different arrays:
-   one for ``a*b``, one for ``c*d``, and one for the sum of those two. As we
-   write :class:`ufunc`\ s, it is important that we try to use functions that
-   operate in place as much as possible!
+   be avoided. With :class:`~numpy.ufunc`\ s, this can be done using the out
+   keyword in arguments (ex ``numpy.add(a, b, out=c)``, or more succinctly,
+   ``numpy.add(a, b, c)``).  While this may seem counterintuitive at first, the
+   alternative (``c = np.add(a,b)`` or ``c = a+b``) causes an entirely new
+   array to be allocated, with c pointing at that. These array allocations can
+   add up very quickly: ``e = a*b + c*d``, for example, would allocate 3
+   different arrays: one for ``a*b``, one for ``c*d``, and one for the sum of
+   those two. As we write :class:`~numpy.ufunc`\ s, it is important that we try
+   to use functions that operate in place as much as possible!
 """
 
 from ._processors.bl_subtract import bl_subtract
@@ -76,4 +76,4 @@ from ._processors.moving_windows import (
 )
 from ._processors.multi_a_filter import multi_a_filter
 from ._processors.pulse_injector import inject_exp_pulse, inject_sig_pulse
-from ._processors.Wiener_filter import Wiener_filter
+from ._processors.wiener_filter import wiener_filter

--- a/src/pygama/flow/__init__.py
+++ b/src/pygama/flow/__init__.py
@@ -1,3 +1,5 @@
 """
 Subpackage description
 """
+
+from .datagroup import DataGroup

--- a/src/pygama/flow/datagroup.py
+++ b/src/pygama/flow/datagroup.py
@@ -4,13 +4,10 @@ import json
 import os
 from collections import OrderedDict
 from pathlib import Path
-from pprint import pprint
 from string import Formatter
 
 import pandas as pd
 from parse import parse
-
-import pygama.utils as pu
 
 
 class DataGroup:

--- a/src/pygama/flow/datagroup.py
+++ b/src/pygama/flow/datagroup.py
@@ -23,6 +23,7 @@ class DataGroup:
     """
     def __init__(self, config=None, nfiles=None, load=False):
         """
+        DOCME
         """
         # master table
         self.fileDB = None
@@ -41,6 +42,7 @@ class DataGroup:
 
     def set_config(self, config):
         """
+        DOCME
         """
         with open(config) as f:
             self.config = json.load(f)
@@ -273,6 +275,7 @@ class DataGroup:
 
     def load_df(self, fname=None):
         """
+        DOCME
         """
         if fname is None: fname = self.f_fileDB
         self.fileDB = pd.read_hdf(fname, key='file_keys')

--- a/src/pygama/hit/hit_to_evt.py
+++ b/src/pygama/hit/hit_to_evt.py
@@ -8,7 +8,7 @@ import h5py
 import numpy as np
 import pandas as pd
 
-import pygama.lh5 as lh5
+import pygama.lgdo.lh5_store as lh5
 
 
 def hit_to_evt(f_hit:str, f_evt:str=None, lh5_tables:list=None, copy_cols:list=None,
@@ -124,7 +124,7 @@ def hit_to_evt(f_hit:str, f_evt:str=None, lh5_tables:list=None, copy_cols:list=N
     if os.path.exists(f_evt):
         os.remove(f_evt)
 
-    sto = lh5.Store()
+    sto = lh5.LH5Store()
     col_dict = {col : lh5.Array(tcm[col].values, attrs={'units':''}) for col in tcm.columns}
     tb_tcm = lh5.Table(size=len(tcm), col_dict=col_dict)
     tb_name = 'events'

--- a/src/pygama/hit/hit_to_evt.py
+++ b/src/pygama/hit/hit_to_evt.py
@@ -35,6 +35,8 @@ def hit_to_evt(f_hit:str, f_evt:str=None, lh5_tables:list=None, copy_cols:list=N
         Specify the list of columns to copy into the output file.  For a DSP
         file, it should be all columns by default, while for a RAW file, we
         probably do NOT want to copy the waveforms into the output file.
+    overwrite : bool
+        overwrite existing output files
     evt_tb_name : str (optional)
         Specify the name of the output table instead of automatically setting it.
     builder_config : dict (optional)

--- a/src/pygama/lgdo/__init__.py
+++ b/src/pygama/lgdo/__init__.py
@@ -6,25 +6,25 @@ general strategy for the implementation is to dress standard Python and NumPy
 objects with an ``attr`` dictionary holding LGDO metadata, plus some convenience
 functions. The basic data object classes are:
 
-* :class:`Scalar`: typed Python scalar. Access data via the :attr:`value`
+* :class:`.Scalar`: typed Python scalar. Access data via the :attr:`value`
   attribute
-* :class:`Array`: basic NumPy :class:`ndarray`. Access data via the :attr:`nda`
-  attribute.
-* :class:`FixedSizeArray`: basic NumPy :class:`ndarray`. Access data via the
+* :class:`.Array`: basic NumPy :class:`ndarray`. Access data via the
   :attr:`nda` attribute.
-* :class:`ArrayOfEqualSizedArrays`: multi-dimensional NumPy :class:`ndarray`.
+* :class:`.FixedSizeArray`: basic NumPy :class:`ndarray`. Access data via the
+  :attr:`nda` attribute.
+* :class:`.ArrayOfEqualSizedArrays`: multi-dimensional NumPy :class:`ndarray`.
   Access data via the :attr:`nda` attribute.
-* :class:`VectorOfVectors`: a variable length array of variable length arrays.
-  Implemented as a pair of :class:`Arrays`: :attr:`flattened_data` holding the
+* :class:`.VectorOfVectors`: a variable length array of variable length arrays.
+  Implemented as a pair of :class:`.Array`: :attr:`flattened_data` holding the
   raw data, and :attr:`cumulative_length` whose ith element is the sum of the
   lengths of the vectors with ``index <= i``
-* :class:`Struct`: a dictionary containing LGDO objects. Derives from
+* :class:`.Struct`: a dictionary containing LGDO objects. Derives from
   :class:`dict`
-* :class:`Table`: a :class:`Struct` whose elements ("columns") are all array
+* :class:`.Table`: a :class:`.Struct` whose elements ("columns") are all array
   types with the same length (number of rows)
 
 Currently the primary on-disk format for LGDO object is LEGEND HDF5 (LH5) files. IO
-is done via the class :class:`pygama.lh5_store.LH5Store`. LH5 files can also be
+is done via the class :class:`.lh5_store.LH5Store`. LH5 files can also be
 browsed easily in python like any `HDF5 <https://www.hdfgroup.org>`_ file using
 `h5py <https://www.h5py.org>`_.
 """

--- a/src/pygama/lgdo/array.py
+++ b/src/pygama/lgdo/array.py
@@ -35,7 +35,7 @@ class Array:
         dtype : numpy dtype (optional)
             Specifies the type of the data in the array. Required if nda is
             None, otherwise unused.
-        fill_val: scalar or None
+        fill_val : scalar or None
             If None, memory is allocated without initialization. Otherwise, the
             array is allocated with all elements set to the corresponding fill
             value. If nda is not None, this parameter is ignored

--- a/src/pygama/lgdo/array.py
+++ b/src/pygama/lgdo/array.py
@@ -4,11 +4,11 @@ from .lgdo_utils import *
 
 
 class Array:
-    """
-    Holds an ndarray and attributes
+    """Holds an ndarray and attributes
 
     Array (and the other various array types) holds an "nda" instead of deriving
     from ndarray for the following reasons:
+
     - it keeps management of the nda totally under the control of the user. The
       user can point it to another object's buffer, grab the nda and toss the
       Array, etc.
@@ -17,6 +17,7 @@ class Array:
       standard, reusable, and (we expect) performant python
     - it allows the first axis of the nda to be treated as "special" for storage
       in Tables
+
     """
 
 
@@ -24,7 +25,6 @@ class Array:
         """
         Parameters
         ----------
-
         nda : ndarray (optional)
             An ndarray to be used for this object's internal array. Note: the
             array is used directly, not copied. If not supplied, internal memory

--- a/src/pygama/lgdo/arrayofequalsizedarrays.py
+++ b/src/pygama/lgdo/arrayofequalsizedarrays.py
@@ -21,8 +21,26 @@ class ArrayOfEqualSizedArrays(Array):
         dims : tuple of ints (optional)
             specifies the dimensions required for building the
             ArrayOfEqualSizedArrays' datatype attribute
+        nda : ndarray (optional)
+            An ndarray to be used for this object's internal array. Note: the
+            array is used directly, not copied. If not supplied, internal memory
+            is newly allocated based on the shape and dtype arguments.
+        shape : tuple of ints (optional)
+            A numpy-format shape specification for shape of the internal
+            ndarray. Required if nda is None, otherwise unused.
+        dtype : numpy dtype (optional)
+            Specifies the type of the data in the array. Required if nda is
+            None, otherwise unused.
+        fill_val : scalar or None
+            If None, memory is allocated without initialization. Otherwise, the
+            array is allocated with all elements set to the corresponding fill
+            value. If nda is not None, this parameter is ignored
+        attrs : dict (optional)
+            A set of user attributes to be carried along with this lgdo
 
-        See Array.__init__ for optional args
+        See Also
+        --------
+        :class:`.Array`
         """
         self.dims = dims
         super().__init__(nda=nda, shape=shape, dtype=dtype, fill_val=fill_val, attrs=attrs)

--- a/src/pygama/lgdo/lh5_store.py
+++ b/src/pygama/lgdo/lh5_store.py
@@ -687,8 +687,6 @@ def ls(lh5_file, lh5_group=''):
         name of file
     lh5_group : str
         group to search
-    lh5_st : LH5Store
-        lh5_st object to use for searching
 
     Returns
     -------

--- a/src/pygama/lgdo/lh5_store.py
+++ b/src/pygama/lgdo/lh5_store.py
@@ -22,12 +22,18 @@ from .waveform_table import WaveformTable
 
 class LH5Store:
     def __init__(self, base_path='', keep_open=False):
+        """
+        DOCME
+        """
         self.base_path = base_path
         self.keep_open = keep_open
         self.files = {}
 
 
     def gimme_file(self, lh5_file, mode='r', verbosity=0):
+        """
+        DOCME
+        """
         if isinstance(lh5_file, h5py.File): return lh5_file
         if lh5_file in self.files.keys(): return self.files[lh5_file]
         if self.base_path != '': full_path = self.base_path + '/' + lh5_file
@@ -48,6 +54,9 @@ class LH5Store:
 
 
     def gimme_group(self, group, base_group, grp_attrs=None, overwrite=False, verbosity=0):
+        """
+        DOCME
+        """
         if not isinstance(group, h5py.Group):
             if group in base_group: group = base_group[group]
             else:
@@ -783,9 +792,7 @@ def load_dfs(f_list, par_list, lh5_group='', idx_list=None, verbose=True):
     optionally the group path, return a pandas DataFrame with all values for
     each parameter.
 
-    Parameters
-    ----------
-    See load_nda for parameter specification
+    See :func:`load_nda` for parameter specification
 
     Returns
     -------
@@ -813,7 +820,7 @@ class LH5Iterator:
     This can also be used as an iterator: ::
 
         for lh5_obj, entry, n_rows in LH5Iterator(...):
-            do the thing!
+            # do the thing!
 
     This is intended for if you are reading a large quantity of data but
     want to limit your memory usage (particularly when reading in waveforms!).
@@ -821,7 +828,8 @@ class LH5Iterator:
     reallocation of memory; this means that if you want to hold on to data
     between reads, you will have to copy it somewhere!
     """
-    def __init__(self, lh5_files, group, base_path='', entry_list=None, entry_mask=None, field_mask=None, buffer_len=3200):
+    def __init__(self, lh5_files, group, base_path='', entry_list=None,
+                 entry_mask=None, field_mask=None, buffer_len=3200):
         """
         Parameters
         ----------
@@ -829,7 +837,9 @@ class LH5Iterator:
             File or files to read from. May include wildcards and env vars
         group : str
             HDF5 group to read
-        selection_list : list-like or nested list-like of ints (optional)
+        base_path : str
+            HDF5 path to prepend
+        entry_list : list-like or nested list-like of ints (optional)
             List of entry numbers to read. If a nested list is provided,
             expect one top-level list for each file, containing a list of
             local entries. If a list of ints is provided, use global entries

--- a/src/pygama/lgdo/lh5_store.py
+++ b/src/pygama/lgdo/lh5_store.py
@@ -499,16 +499,17 @@ class LH5Store:
         starting from start_row in obj.
 
         wo_modes:
-            'write_safe' or 'w': only proceed with writing if the object does
-                not already exist in the file
-            'append' or 'a': append along axis 0 (the first dimension) of
-                array-like objects and array-like subfields of structs. Scalar
-                objects get overwritten
-            'overwrite' or 'o': replace data in the file if present, starting
-                from write_start. Note: overwriting with write_start = end of
-                array is the same as append
-            'overwrite_file' or 'of': delete file if present prior to writing to
-                it. write_start should be 0 (it's ignored)
+
+          - 'write_safe' or 'w': only proceed with writing if the object does
+            not already exist in the file
+          - 'append' or 'a': append along axis 0 (the first dimension) of
+            array-like objects and array-like subfields of structs. Scalar
+            objects get overwritten
+          - 'overwrite' or 'o': replace data in the file if present, starting
+            from write_start. Note: overwriting with write_start = end of
+            array is the same as append
+          - 'overwrite_file' or 'of': delete file if present prior to writing to
+            it. write_start should be 0 (it's ignored)
 
         """
         if wo_mode == 'write_safe':  wo_mode = 'w'
@@ -803,13 +804,16 @@ class LH5Iterator:
     at a time. This also accepts an entry list/mask to enable event selection,
     and a field mask.
 
-    This class can be used either for random access:
+    This class can be used either for random access: ::
+
         lh5_obj, n_rows = lh5_it.read(entry)
+
     to read the block of entries starting at entry. In case of multiple files
     or the use of an event selection, entry refers to a global event index
     across files and does not count events that are excluded by the selection.
 
-    This can also be used as an iterator:
+    This can also be used as an iterator: ::
+
         for lh5_obj, entry, n_rows in LH5Iterator(...):
             do the thing!
 

--- a/src/pygama/lgdo/scalar.py
+++ b/src/pygama/lgdo/scalar.py
@@ -7,9 +7,8 @@ class Scalar:
     """
     Holds just a value and some attributes (datatype, units, ...)
 
-    #TODO: do scalars need proper numpy dtypes?
+    TODO: do scalars need proper numpy dtypes?
     """
-
 
     def __init__(self, value, attrs={}):
         """
@@ -33,12 +32,10 @@ class Scalar:
                 print('type(value): ', type(value).__name__)
         else: self.attrs['datatype'] = get_element_type(self.value)
 
-
     def datatype_name(self):
         """The name for this lgdo's datatype attribute"""
         if hasattr(self.value, 'datatype_name'): return self.value.datatype_name
         else: return get_element_type(self.value)
-
 
     def form_datatype(self):
         """Return this lgdo's datatype attribute string"""

--- a/src/pygama/lgdo/table.py
+++ b/src/pygama/lgdo/table.py
@@ -36,8 +36,6 @@ class Table(Struct):
         attrs : dict (optional)
             A set of user attributes to be carried along with this lgdo
 
-        Initialization
-        --------------
         self.loc is initialized to 0
         """
         super().__init__(obj_dict=col_dict, attrs=attrs)

--- a/src/pygama/lgdo/table.py
+++ b/src/pygama/lgdo/table.py
@@ -36,6 +36,8 @@ class Table(Struct):
         attrs : dict (optional)
             A set of user attributes to be carried along with this lgdo
 
+        Notes
+        -----
         self.loc is initialized to 0
         """
         super().__init__(obj_dict=col_dict, attrs=attrs)

--- a/src/pygama/lgdo/waveform_table.py
+++ b/src/pygama/lgdo/waveform_table.py
@@ -11,6 +11,7 @@ class WaveformTable(Table):
     An lgdo for storing blocks of (1D) time-series data.
 
     A WaveformTable is an lgdo Table with the 3 columns t0, dt, and values:
+
     * t0[i] is a time offset (relative to a user-defined global reference) for
       the sample in values[i][0]. Implemented as an lgdo Array with optional
       attribute "units"

--- a/src/pygama/math/histogram.py
+++ b/src/pygama/math/histogram.py
@@ -43,7 +43,7 @@ def get_hist(data, bins=None, range=None, dx=None, wts=None):
     ----------
     data : array like
         The array of data to be histogrammed
-    bins: int, array, or str (optional)
+    bins : int, array, or str (optional)
         int: the number of bins to be used in the histogram
         array: an array of bin edges to use
         str: the name of the np.histogram automatic binning algorithm to use
@@ -208,12 +208,12 @@ def range_slice(x_min, x_max, hist, bins, var=None):
     return hist[i_min:i_max], bins[i_min:i_max+1], var
 
 
-
 def get_fwhm(hist, bins, var=None, mx=None, dmx=0, bl=0, dbl=0, method='bins_over_f', n_slope=3):
-    """
-    Estimate the FWHM of data in a histogram
+    """Estimate the FWHM of data in a histogram
 
-    See get_fwfm for parameters and return values
+    See Also
+    --------
+    get_fwfm : for parameters and return values
     """
     if len(bins) == len(hist):
         print("note: this function has been updated to require bins rather",
@@ -234,8 +234,8 @@ def get_fwfm(fraction, hist, bins, var=None, mx=None, dmx=0, bl=0, dbl=0, method
         The fractional amplitude at which to evaluate the full width
     hist : array-like
         The histogram data array containing the peak
-    bin_centers : array-like
-        An array of bin centers for the histogram
+    bins : array-like
+        An array of bin edges for the histogram
     var : array-like (optional)
         An array of histogram variances. Used with the 'fit_slopes' method
     mx : float or tuple(float, float) (optional)
@@ -259,6 +259,8 @@ def get_fwfm(fraction, hist, bins, var=None, mx=None, dmx=0, bl=0, dbl=0, method
             when stats are moderate but requires enough bins that dx traversed
             by n_slope bins is approximately linear. Incorporates bin variances
             in fit and final uncertainties if provided.
+    n_slope : int
+        DOCME
 
     Returns
     -------

--- a/src/pygama/math/histogram.py
+++ b/src/pygama/math/histogram.py
@@ -16,13 +16,13 @@ they will help you if you need to do something trickier than is provided (e.g.
 
 import matplotlib.pyplot as plt
 import numpy as np
-from pylab import rcParams
+from matplotlib import rcParams
 
 import pygama.math.utils as pgu
 
 
 def get_hist(data, bins=None, range=None, dx=None, wts=None):
-    """ return hist, bins, var after binning data
+    """return hist, bins, var after binning data
 
     This is just a wrapper for numpy.histogram, with optional weights for each
     element and proper computing of variances.
@@ -62,12 +62,14 @@ def get_hist(data, bins=None, range=None, dx=None, wts=None):
 
     Returns
     -------
-    hist, bins, var : tuple (array, array, array)
-        hist : the values in each bin of the histogram
-        bins : an array of bin edges: bins[i] is the lower edge of the ith bin.
-               Note: it includes the upper edge of the last bin and does not
-               include underflow or overflow bins. So len(bins) = len(hist) + 1
-        var : array of variances in each bin of the histogram
+    hist : array
+        the values in each bin of the histogram
+    bins : array
+        an array of bin edges: bins[i] is the lower edge of the ith bin.
+        Note: it includes the upper edge of the last bin and does not
+        include underflow or overflow bins. So len(bins) = len(hist) + 1
+    var : array
+        array of variances in each bin of the histogram
     """
     if bins is None:
         bins = 100 # override np.histogram default of just 10

--- a/src/pygama/math/peak_fitting.py
+++ b/src/pygama/math/peak_fitting.py
@@ -15,22 +15,33 @@ kwd = {"parallel": False, "fastmath": True}
 def fit_hist(func, hist, bins, var=None, guess=None,
              poissonLL=False, integral=None, method=None, bounds=None):
     """
-    DEPRECATED USE FIT_BINNED
+    .. deprecated:: 0.8
+        Replaced by :func:`.fit_binned`. Will be removed in future releases.
 
     do a binned fit to a histogram (nonlinear least squares).
     can either do a poisson log-likelihood fit (jason's favourite) or
     use curve_fit w/ an arbitrary function.
 
-    - hist, bins, var : as in return value of pygama.histograms.get_hist()
-    - guess : initial parameter guesses. Should be optional -- we can
-      auto-guess for many common functions. But not yet implemented.
-    - poissonLL : use Poisson stats instead of the Gaussian approximation in
-      each bin. Requires integer stats. You must use parameter bounds to make
-      sure that func does not go negative over the x-range of the histogram.
-    - method, bounds : options to pass to scipy.optimize.minimize
+    Parameters
+    ----------
+    func
+        function to be fitted
+    hist, bins, var
+        as in return value of pygama.histograms.get_hist()
+    guess
+        initial parameter guesses. Should be optional -- we can auto-guess for
+        many common functions. But not yet implemented.
+    poissonLL
+        use Poisson stats instead of the Gaussian approximation in each bin.
+        Requires integer stats. You must use parameter bounds to make sure that
+        func does not go negative over the x-range of the histogram.
+    integral
+        DOCME
+    method, bounds
+        options to pass to :func:`scipy.optimize.minimize`
 
     Returns
-    ------
+    -------
     coeff, cov_matrix : tuple(array, matrix)
     """
 
@@ -53,11 +64,11 @@ def fit_binned(func, hist, bins, var=None, guess=None,
     func : the function to fit, if using LL as method needs to be a cdf
     hist, bins, var : histogrammed data
     guess : initial guess parameters
-    cost_func: cost function to use
-    Extended: run extended or non extended fit
-    simplex: whether to include a round of simpson minimisation before main minimisation
+    cost_func : cost function to use
+    Extended : run extended or non extended fit
+    simplex : whether to include a round of simpson minimisation before main minimisation
     bounds : list of tuples with bounds can be None, e.g. [(0,None), (0,10)]
-    fixed: list of parameter indices to fix
+    fixed : list of parameter indices to fix
 
     Returns
     -------
@@ -132,9 +143,6 @@ def fit_unbinned(func, data, guess=None,
     simplex : whether to include a round of simpson minimisation before main minimisation
     bounds : list of tuples with bounds can be None, e.g. [(0,None), (0,10)]
     fixed : list of parameter indices to fix
-
-    Returns
-    ------
     coeff, cov_matrix : tuple(array, matrix)
     """
     if guess is None:
@@ -305,7 +313,6 @@ def gauss_mode_width_max(hist, bins, var=None, mode_guess=None, n_bins=5,
           underlying function in the vicinity of the max is given by max /
           sigma^2
         - maximum : the estimated maximum value of the peak
-
     cov : 3x3 matrix of floats
         The covariance matrix for the 3 parameters in pars
     """
@@ -336,9 +343,9 @@ def gauss_mode_width_max(hist, bins, var=None, mode_guess=None, n_bins=5,
 def gauss_mode_max(hist, bins, var=None, mode_guess=None, n_bins=5, poissonLL=False, inflate_errors=False, gof_method='var'):
     """Alias for gauss_mode_width_max that just returns the max and mode
 
-    Parameters
+    See Also
     --------
-    See gauss_mode_width_max
+    gauss_mode_width_max
 
     Returns
     -------
@@ -383,6 +390,8 @@ def taylor_mode_max(hist, bins, var=None, mode_guess=None, n_bins=5, poissonLL=F
     n_bins : int
         The number of bins (including the max bin) to be used in the fit. Also
         used for searching for a max near mode_guess
+    poissonLL
+        DOCME
 
     Returns
     -------
@@ -1015,7 +1024,7 @@ def double_gauss_pdf(x,  n_sig1,  mu1, sigma1, n_sig2, mu2,sigma2,n_bkg,hstep,
 
      - two gaussian peaks (two lines)
      - one step
-     """
+    """
     bkg = n_bkg*step_pdf(x, mu1, sigma1, hstep, lower_range, upper_range)
     if np.any(bkg<0):
         return 0, np.zeros_like(x)
@@ -1034,7 +1043,7 @@ def extended_double_gauss_pdf(x,  n_sig1,  mu1, sigma1, n_sig2, mu2,sigma2,n_bkg
 
      - two gaussian peaks (two lines)
      - one step
-     """
+    """
 
     if components == False:
         pdf = double_gauss_pdf(x,  n_sig1,  mu1, sigma1, n_sig2, mu2,sigma2,n_bkg,hstep,

--- a/src/pygama/math/peak_fitting.py
+++ b/src/pygama/math/peak_fitting.py
@@ -60,8 +60,10 @@ def fit_binned(func, hist, bins, var=None, guess=None,
     fixed: list of parameter indices to fix
 
     Returns
-    ------
-    coeff, error cov_matrix : tuple(array, array, matrix)
+    -------
+    coeff : array
+    error : array
+    cov_matrix : array
     """
 
 
@@ -283,8 +285,8 @@ def gauss_mode_width_max(hist, bins, var=None, mode_guess=None, n_bins=5,
     n_bins : int (optional)
         The number of bins (including the max bin) to be used in the fit. Also
         used for searching for a max near mode_guess
-    poissonLL : bool (optional)
-        Flag passed to fit_hist()
+    cost_func : str (optional)
+        Passed to fit_binned()
     inflate_errors : bool (optional)
         If true, the parameter uncertainties are inflated by sqrt(chi2red)
         if it is greater than 1

--- a/src/pygama/math/utils.py
+++ b/src/pygama/math/utils.py
@@ -52,12 +52,14 @@ def tqdm_range(start, stop, step=1, verbose=False, text=None, bar_length=20, uni
     Uses tqdm.trange which wraps around the python range and also has the option
     to display a progress
 
-    Example:
+    For example:
+    .. code-block :: python
 
         for start_row in range(0, tot_n_rows, buffer_len):
             ...
 
-            Can be converted to the following
+    Can be converted to the following
+    .. code-block :: python
 
         for start_row in tqdm_range(0, tot_n_rows, buffer_len, verbose):
             ...
@@ -76,6 +78,8 @@ def tqdm_range(start, stop, step=1, verbose=False, text=None, bar_length=20, uni
         text to display in front of the progress bar
     bar_length : str
         horizontal length of the bar in cursor spaces
+    unit : str
+        physical units to be displayed
 
     Returns
     -------

--- a/src/pygama/pargen/data_cleaning.py
+++ b/src/pygama/pargen/data_cleaning.py
@@ -10,7 +10,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 from scipy import stats
 
-from .peak_fitting import *
+from pygama.math.peak_fitting import *
 
 
 def gaussian_cut(data, cut_sigma=3, plotAxis=None):

--- a/src/pygama/pargen/dsp_optimize.py
+++ b/src/pygama/pargen/dsp_optimize.py
@@ -32,7 +32,7 @@ def run_one_dsp(tb_data, dsp_config, db_dict=None, fom_function=None, verbosity=
         optimization will be based. Should accept verbosity as a second argument
     verbosity : int (optional)
         verbosity for the processing chain and fom_function calls
-    fom_kwargs:
+    fom_kwargs
         any keyword arguments to pass to the fom
 
     Returns
@@ -269,7 +269,7 @@ def run_grid_multiprocess_parallel(tb_data, dsp_config, grid, fom_function, db_d
         Specifies the DSP to be performed for this iteration (see
         build_processing_chain()) and the list of output variables to appear in
         the output table
-    grid: pargrid, list of pargrids
+    grid : pargrid, list of pargrids
         Grids to run optimization on
     db_dict : dict (optional)
         DSP parameters database. See build_processing_chain for formatting info
@@ -281,7 +281,9 @@ def run_grid_multiprocess_parallel(tb_data, dsp_config, grid, fom_function, db_d
         or a list of fom to run different fom on each grid.
     verbosity : int (optional)
         verbosity for the processing chain and fom_function calls
-    fom_kwargs:
+    processes : int
+        DOCME
+    fom_kwargs
         any keyword arguments to pass to the fom,
         if multiple grids given will need to be a list of the fom_kwargs for each grid
 

--- a/src/pygama/pargen/dsp_optimize.py
+++ b/src/pygama/pargen/dsp_optimize.py
@@ -5,7 +5,7 @@ from pprint import pprint
 
 import numpy as np
 
-from .build_processing_chain import build_processing_chain
+from pygama.dsp import build_processing_chain
 
 
 def run_one_dsp(tb_data, dsp_config, db_dict=None, fom_function=None, verbosity=0, fom_kwargs=None):
@@ -14,8 +14,8 @@ def run_one_dsp(tb_data, dsp_config, db_dict=None, fom_function=None, verbosity=
 
     Optionally returns a value for optimization
 
-    Parameters:
-    -----------
+    Parameters
+    ----------
     tb_data : lh5 Table
         An input table of lh5 data. Typically a selection is made prior to
         sending tb_data to this function: optimization typically doesn't have to
@@ -35,8 +35,8 @@ def run_one_dsp(tb_data, dsp_config, db_dict=None, fom_function=None, verbosity=
     fom_kwargs:
         any keyword arguments to pass to the fom
 
-    Returns:
-    --------
+    Returns
+    -------
     figure_of_merit : float
         If fom_function is not None, returns figure-of-merit value for the DSP iteration
     tb_out : lh5 Table
@@ -145,11 +145,13 @@ def run_grid(tb_data, dsp_config, grid, fom_function, db_dict=None, verbosity=1,
     """Extract a table of optimization values for a grid of DSP parameters
     The grid argument defines a list of parameters and values over which to run
     the DSP defined in dsp_config on tb_data. At each point, a scalar
-    figure-of-merit is extracted
+    figure-of-merit is extracted.
+
     Returns a N-dimensional ndarray of figure-of-merit values, where the array
     axes are in the order they appear in grid.
-    Parameters:
-    -----------
+
+    Parameters
+    ----------
     tb_data : lh5 Table
         An input table of lh5 data. Typically a selection is made prior to
         sending tb_data to this function: optimization typically doesn't have to
@@ -167,13 +169,11 @@ def run_grid(tb_data, dsp_config, grid, fom_function, db_dict=None, verbosity=1,
         DSP parameters database. See build_processing_chain for formatting info
     verbosity : int (optional)
         verbosity for the processing chain and fom_function calls
-
-    **fom_kwargs :
+    **fom_kwargs
         Any keyword arguments for fom_function
 
-
-    Returns:
-    --------
+    Returns
+    -------
     grid_values : ndarray of floats
         An N-dimensional numpy ndarray whose Mth axis corresponds to the Mth row
         of the grid argument
@@ -254,12 +254,13 @@ def run_grid_multiprocess_parallel(tb_data, dsp_config, grid, fom_function, db_d
                           processes=5, fom_kwargs=None):
 
     """
-    run one iteration of DSP on tb_data with multiprocessing, can handle multiple grids if they are the same dimensions
+    run one iteration of DSP on tb_data with multiprocessing, can handle
+    multiple grids if they are the same dimensions
 
     Optionally returns a value for optimization
 
-    Parameters:
-    -----------
+    Parameters
+    ----------
     tb_data : lh5 Table
         An input table of lh5 data. Typically a selection is made prior to
         sending tb_data to this function: optimization typically doesn't have to
@@ -284,8 +285,8 @@ def run_grid_multiprocess_parallel(tb_data, dsp_config, grid, fom_function, db_d
         any keyword arguments to pass to the fom,
         if multiple grids given will need to be a list of the fom_kwargs for each grid
 
-    Returns:
-    --------
+    Returns
+    -------
     figure_of_merit : float
         If fom_function is not None, returns figure-of-merit value for the DSP iteration
     tb_out : lh5 Table

--- a/src/pygama/pargen/ecal_th.py
+++ b/src/pygama/pargen/ecal_th.py
@@ -10,10 +10,9 @@ import scipy.stats
 from matplotlib.backends.backend_pdf import PdfPages
 from scipy.optimize import curve_fit
 
-import pygama.pargen.energy_cal as cal
-
 import pygama.math.histogram as pgh
 import pygama.math.peak_fitting as pgf
+import pygama.pargen.energy_cal as cal
 
 
 def fwhm_slope(x, m0, m1):

--- a/src/pygama/pargen/ecal_th.py
+++ b/src/pygama/pargen/ecal_th.py
@@ -10,11 +10,10 @@ import scipy.stats
 from matplotlib.backends.backend_pdf import PdfPages
 from scipy.optimize import curve_fit
 
-import pygama.analysis.calibration as cal
+import pygama.pargen.energy_cal as cal
 
-#import pygama.genpar_tmp.cuts as cut
-import pygama.analysis.histograms as pgh
-import pygama.analysis.peak_fitting as pgf
+import pygama.math.histogram as pgh
+import pygama.math.peak_fitting as pgf
 
 
 def fwhm_slope(x, m0, m1):
@@ -25,8 +24,6 @@ def fwhm_slope(x, m0, m1):
 
 
 def energy_cal_th(files, energy_params,  save_path, lh5_path='raw',n_events=15000):
-
-
     """
     This is an example script for calibrating Th data.
     """

--- a/src/pygama/pargen/energy_cal.py
+++ b/src/pygama/pargen/energy_cal.py
@@ -26,7 +26,7 @@ def hpge_find_E_peaks(hist, bins, var, peaks_keV, n_sigma=5, deg=0, Etol_keV=Non
 
     Parameters
     ----------
-    hist, bins, var: array, array, array
+    hist, bins, var : array, array, array
         Histogram of uncalibrated energies, see pgh.get_hist()
         var cannot contain any zero entries.
     peaks_keV : array
@@ -41,6 +41,8 @@ def hpge_find_E_peaks(hist, bins, var, peaks_keV, n_sigma=5, deg=0, Etol_keV=Non
         number used to replace zeros of var to avoid divide-by-zero in
         hist/sqrt(var). Default value is 1. Usually when var = 0 its because
         hist = 0, and any value here is fine.
+    verbose : bool
+        print debug messages
 
     Returns
     -------
@@ -84,7 +86,7 @@ def hpge_get_E_peaks(hist, bins, var, cal_pars, peaks_keV, n_sigma=3, Etol_keV=5
 
     Parameters
     ----------
-    hist, bins, var: array, array, array
+    hist, bins, var : array, array, array
         Histogram of uncalibrated energies, see pgh.get_hist()
         var cannot contain any zero entries.
     cal_pars : array
@@ -99,6 +101,8 @@ def hpge_get_E_peaks(hist, bins, var, cal_pars, peaks_keV, n_sigma=3, Etol_keV=5
         number used to replace zeros of var to avoid divide-by-zero in
         hist/sqrt(var). Default value is 1. Usually when var = 0 its because
         hist = 0, and any value here is fine.
+    verbose : bool
+        print debug messages
 
     Returns
     -------
@@ -154,13 +158,13 @@ def hpge_fit_E_peak_tops(hist, bins, var, peak_locs, n_to_fit=7,
 
     Parameters
     ----------
-    hist, bins, var: array, array, array
+    hist, bins, var : array, array, array
         Histogram of uncalibrated energies, see pgh.get_hist()
     peak_locs : array
         locations of peaks in hist. Must be accurate two within +/- 2*n_to_fit
     n_to_fit : int
         number of hist bins near the peak top to include in the gaussian fit
-    poissonLL : bool (optional)
+    cost_func : bool (optional)
         Flag passed to gauss_mode_width_max()
     inflate_errors : bool (optional)
         Flag passed to gauss_mode_width_max()
@@ -196,7 +200,7 @@ def get_hpge_E_peak_par_guess(hist, bins, var, func):
 
     Parameters
     ----------
-    hist, bins, var: array, array, array
+    hist, bins, var : array, array, array
         Histogram of uncalibrated energies, see pgh.get_hist(). Should be
         windowed around the peak.
     func : function
@@ -342,16 +346,16 @@ def hpge_fit_E_peaks(E_uncal, mode_guesses, wwidths, n_bins=50, funcs=pgf.gauss_
         array of number of bins to use for the fit window histogramming
     funcs : function or array of functions
         funcs to be used to fit each region
-    method: str
-            default is unbinned fit can specify to use binned fit method instead
+    method : str
+        default is unbinned fit can specify to use binned fit method instead
     gof_funcs : function or array of functions
-            functions to use for calculation goodness of fit if unspecified will use same func as fit
+        functions to use for calculation goodness of fit if unspecified will use same func as fit
     uncal_is_int : bool
         if True, attempts will be made to avoid picket-fencing when binning
         E_uncal
     simplex : bool determining whether to do a round of simpson minimisation before gradient minimisation
     n_events : int number of events to use for unbinned fit
-    allowed_p_val: lower limit on p_val of fit
+    allowed_p_val : lower limit on p_val of fit
 
     Returns
     -------
@@ -526,8 +530,8 @@ def hpge_fit_E_cal_func(mus, mu_vars, Es_keV, E_scale_pars, deg=0):
 
 
 def hpge_E_calibration(E_uncal, peaks_keV, guess_keV, deg=0, uncal_is_int=False, range_keV=None,
-                        funcs=pgf.gauss_step_cdf, gof_funcs = None, method = 'unbinned', gof_func =None,
-                        n_events=15000, simplex=False, allowed_p_val=0.05, verbose=True):
+                       funcs=pgf.gauss_step_cdf, gof_funcs = None, method = 'unbinned', gof_func =None,
+                       n_events=15000, simplex=False, allowed_p_val=0.05, verbose=True):
     """Calibrate HPGe data to a set of known peaks
 
     Parameters
@@ -543,18 +547,28 @@ def hpge_E_calibration(E_uncal, peaks_keV, guess_keV, deg=0, uncal_is_int=False,
         degree of the polynomial for the E_cal function E_keV = poly(E_uncal).
         deg = 0 corresponds to a simple scaling E_keV = scale * E_uncal.
         Otherwise follows the convention in np.polyfit
-    method: str
-            default is unbinned fit can specify to use binned fit method instead
-    gof_funcs : function or array of functions
-            functions to use for calculation goodness of fit if unspecified will use same func as fit
     uncal_is_int : bool
         if True, attempts will be made to avoid picket-fencing when binning
         E_uncal
     range_keV : float, tuple, array of floats, or array of tuples of floats
         ranges around which the peak fitting is performed
         if tuple(s) are supplied, they provide the left and right ranges
-    n_events : int number of events to use for unbinned fit
-    allowed_p_val: lower limit on p_val of fit
+    funcs
+        DOCME
+    gof_funcs : function or array of functions
+        functions to use for calculation goodness of fit if unspecified will use same func as fit
+    method : str
+        default is unbinned fit can specify to use binned fit method instead
+    gof_func
+        DOCME
+    n_events : int
+        number of events to use for unbinned fit
+    simplex : bool
+        DOCME
+    allowed_p_val
+        lower limit on p_val of fit
+    verbose : bool
+        print debug statements
 
     Returns
     -------

--- a/src/pygama/pargen/energy_cal.py
+++ b/src/pygama/pargen/energy_cal.py
@@ -496,8 +496,8 @@ def hpge_fit_E_cal_func(mus, mu_vars, Es_keV, E_scale_pars, deg=0):
         variances in the mus
     Es_keV : array
         energies to fit to, in keV
-    k
-        hpge_fit_E_scale)
+    E_scale_pars : array
+        ???
     deg : int
         degree for energy scale fit. deg=0 corresponds to a simple scaling
         mu = scale * E. Otherwise deg follows the definition in np.polyfit

--- a/src/pygama/pargen/energy_cal.py
+++ b/src/pygama/pargen/energy_cal.py
@@ -1,5 +1,5 @@
-"""
-routines for automatic calibration.
+"""routines for automatic calibration.
+
 - hpge_find_E_peaks (Find uncalibrated E peaks whose E spacing matches the pattern in peaks_keV)
 - hpge_get_E_peaks (Get uncalibrated E peaks at the energies of peaks_keV)
 - hpge_fit_E_peaks (fits the energy peals)
@@ -19,10 +19,11 @@ import pygama.math.utils as pgu
 
 
 def hpge_find_E_peaks(hist, bins, var, peaks_keV, n_sigma=5, deg=0, Etol_keV=None, var_zero=1, verbose=False):
-    """ Find uncalibrated E peaks whose E spacing matches the pattern in peaks_keV
+    """Find uncalibrated E peaks whose E spacing matches the pattern in peaks_keV
     Note: the specialization here to units "keV" in peaks and Etol is
     unnecessary. However it is kept so that the default value for Etol_keV has
     an unambiguous interpretation.
+
     Parameters
     ----------
     hist, bins, var: array, array, array
@@ -40,6 +41,7 @@ def hpge_find_E_peaks(hist, bins, var, peaks_keV, n_sigma=5, deg=0, Etol_keV=Non
         number used to replace zeros of var to avoid divide-by-zero in
         hist/sqrt(var). Default value is 1. Usually when var = 0 its because
         hist = 0, and any value here is fine.
+
     Returns
     -------
     detected_peak_locations : list
@@ -78,7 +80,8 @@ def hpge_find_E_peaks(hist, bins, var, peaks_keV, n_sigma=5, deg=0, Etol_keV=Non
 
 
 def hpge_get_E_peaks(hist, bins, var, cal_pars, peaks_keV, n_sigma=3, Etol_keV=5, var_zero=1, verbose = False):
-    """ Get uncalibrated E peaks at the energies of peaks_keV
+    """Get uncalibrated E peaks at the energies of peaks_keV
+
     Parameters
     ----------
     hist, bins, var: array, array, array
@@ -96,6 +99,7 @@ def hpge_get_E_peaks(hist, bins, var, cal_pars, peaks_keV, n_sigma=3, Etol_keV=5
         number used to replace zeros of var to avoid divide-by-zero in
         hist/sqrt(var). Default value is 1. Usually when var = 0 its because
         hist = 0, and any value here is fine.
+
     Returns
     -------
     got_peak_locations : list
@@ -146,7 +150,8 @@ def hpge_get_E_peaks(hist, bins, var, cal_pars, peaks_keV, n_sigma=3, Etol_keV=5
 
 def hpge_fit_E_peak_tops(hist, bins, var, peak_locs, n_to_fit=7,
                          cost_func = 'Least Squares', inflate_errors=False, gof_method='var'):
-    """ Fit gaussians to the tops of peaks
+    """Fit gaussians to the tops of peaks
+
     Parameters
     ----------
     hist, bins, var: array, array, array
@@ -161,6 +166,7 @@ def hpge_fit_E_peak_tops(hist, bins, var, peak_locs, n_to_fit=7,
         Flag passed to gauss_mode_width_max()
     gof_method : str (optional)
         method flag passed to gauss_mode_width_max()
+
     Returns
     -------
     pars_list : list of array
@@ -186,7 +192,8 @@ def hpge_fit_E_peak_tops(hist, bins, var, peak_locs, n_to_fit=7,
 
 
 def get_hpge_E_peak_par_guess(hist, bins, var, func):
-    """ Get parameter guesses for func fit to peak in hist
+    """Get parameter guesses for func fit to peak in hist
+
     Parameters
     ----------
     hist, bins, var: array, array, array
@@ -320,7 +327,8 @@ def get_hpge_E_bounds(func):
 def hpge_fit_E_peaks(E_uncal, mode_guesses, wwidths, n_bins=50, funcs=pgf.gauss_step_cdf,
                      method = 'unbinned', gof_funcs=None, n_events=15000, allowed_p_val= 0.05,
                      uncal_is_int=False, simplex=False):
-    """ Fit the Energy peaks specified using the function given
+    """Fit the Energy peaks specified using the function given
+
     Parameters
     ----------
     E_uncal : array
@@ -344,6 +352,7 @@ def hpge_fit_E_peaks(E_uncal, mode_guesses, wwidths, n_bins=50, funcs=pgf.gauss_
     simplex : bool determining whether to do a round of simpson minimisation before gradient minimisation
     n_events : int number of events to use for unbinned fit
     allowed_p_val: lower limit on p_val of fit
+
     Returns
     -------
     pars : list of array
@@ -442,8 +451,9 @@ def hpge_fit_E_peaks(E_uncal, mode_guesses, wwidths, n_bins=50, funcs=pgf.gauss_
 
 
 def hpge_fit_E_scale(mus, mu_vars, Es_keV, deg=0):
-    """ Find best fit of poly(E) = mus +/- sqrt(mu_vars)
+    """Find best fit of poly(E) = mus +/- sqrt(mu_vars)
     Compare to hpge_fit_E_cal_func which fits for E = poly(mu)
+
     Parameters
     ----------
     mus : array
@@ -455,6 +465,7 @@ def hpge_fit_E_scale(mus, mu_vars, Es_keV, deg=0):
     deg : int
         degree for energy scale fit. deg=0 corresponds to a simple scaling
         mu = scale * E. Otherwise deg follows the definition in np.polyfit
+
     Returns
     -------
     pars : array
@@ -472,10 +483,11 @@ def hpge_fit_E_scale(mus, mu_vars, Es_keV, deg=0):
 
 
 def hpge_fit_E_cal_func(mus, mu_vars, Es_keV, E_scale_pars, deg=0):
-    """ Find best fit of E = poly(mus +/- sqrt(mu_vars))
+    """Find best fit of E = poly(mus +/- sqrt(mu_vars))
     This is an inversion of hpge_fit_E_scale.
     E uncertainties are computed from mu_vars / dmu/dE where mu = poly(E) is the
     E_scale function
+
     Parameters
     ----------
     mus : array
@@ -489,6 +501,7 @@ def hpge_fit_E_cal_func(mus, mu_vars, Es_keV, E_scale_pars, deg=0):
     deg : int
         degree for energy scale fit. deg=0 corresponds to a simple scaling
         mu = scale * E. Otherwise deg follows the definition in np.polyfit
+
     Returns
     -------
     pars : array
@@ -515,7 +528,8 @@ def hpge_fit_E_cal_func(mus, mu_vars, Es_keV, E_scale_pars, deg=0):
 def hpge_E_calibration(E_uncal, peaks_keV, guess_keV, deg=0, uncal_is_int=False, range_keV=None,
                         funcs=pgf.gauss_step_cdf, gof_funcs = None, method = 'unbinned', gof_func =None,
                         n_events=15000, simplex=False, allowed_p_val=0.05, verbose=True):
-    """ Calibrate HPGe data to a set of known peaks
+    """Calibrate HPGe data to a set of known peaks
+
     Parameters
     ----------
     E_uncal : array
@@ -541,6 +555,7 @@ def hpge_E_calibration(E_uncal, peaks_keV, guess_keV, deg=0, uncal_is_int=False,
         if tuple(s) are supplied, they provide the left and right ranges
     n_events : int number of events to use for unbinned fit
     allowed_p_val: lower limit on p_val of fit
+
     Returns
     -------
     pars, cov : array, 2D array
@@ -738,13 +753,14 @@ def hpge_E_calibration(E_uncal, peaks_keV, guess_keV, deg=0, uncal_is_int=False,
 
 
 def poly_match(xx, yy, deg=-1, rtol=1e-5, atol=1e-8):
-    """
-    Find the polynomial function best matching pol(xx) = yy
+    """Find the polynomial function best matching pol(xx) = yy
+
     Finds the poly fit of xx to yy that obtains the most matches between pol(xx)
     and yy in the np.isclose() sense. If multiple fits give the same number of
     matches, the fit with the best gof is used, where gof is computed only among
     the matches.
     Assumes that the relationship between xx and yy is monotonic
+
     Parameters
     ----------
     xx : array-like
@@ -763,6 +779,7 @@ def poly_match(xx, yy, deg=-1, rtol=1e-5, atol=1e-8):
     atol : float
         the absolute tolerance to be sent to np.isclose(). Has the same units
         as yy.
+
     Returns
     -------
     pars: None or array of floats
@@ -884,11 +901,12 @@ def poly_match(xx, yy, deg=-1, rtol=1e-5, atol=1e-8):
 
 
 def get_i_local_extrema(data, delta):
-    """
-    Get lists of indices of the local maxima and minima of data
+    """Get lists of indices of the local maxima and minima of data
+
     The "local" extrema are those maxima / minima that have heights / depths of
     at least delta.
     Converted from MATLAB script at: http://billauer.co.il/peakdet.html
+
     Parameters
     ----------
     data : array-like
@@ -896,6 +914,7 @@ def get_i_local_extrema(data, delta):
     delta : scalar
         the absolute level by which data must vary (in one direction) about an
         extremum in order for it to be tagged
+
     Returns
     -------
     imaxes, imins : 2-tuple ( array, array )
@@ -948,11 +967,11 @@ def get_i_local_minima(data, delta): return get_i_local_extrema(data, delta)[1]
 
 def get_most_prominent_peaks(energySeries, xlo, xhi, xpb,
                              max_num_peaks=np.inf, test=False):
-    """
-    find the most prominent peaks in a spectrum by looking for spikes in derivative of spectrum
-    energySeries: array of measured energies
-    max_num_peaks = maximum number of most prominent peaks to find
-    return a histogram around the most prominent peak in a spectrum of a given percentage of width
+    """find the most prominent peaks in a spectrum by looking for spikes in
+    derivative of spectrum energySeries: array of measured energies
+    max_num_peaks = maximum number of most prominent peaks to find return a
+    histogram around the most prominent peak in a spectrum of a given
+    percentage of width
     """
     nb = int((xhi-xlo)/xpb)
     hist, bin_edges = np.histogram(energySeries, range=(xlo, xhi), bins=nb)

--- a/src/pygama/pargen/mse_psd.py
+++ b/src/pygama/pargen/mse_psd.py
@@ -8,8 +8,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.colors import LogNorm
 
-from pygama.analysis.peak_fitting import *
-from pygama.utils import get_bin_centers
+from pygama.math.peak_fitting import *
+from pygama.math.histogram import get_bin_centers
 
 
 def get_avse_cut(e_cal, current, plotFigure=None):

--- a/src/pygama/pargen/mse_psd.py
+++ b/src/pygama/pargen/mse_psd.py
@@ -8,8 +8,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.colors import LogNorm
 
-from pygama.math.peak_fitting import *
 from pygama.math.histogram import get_bin_centers
+from pygama.math.peak_fitting import *
 
 
 def get_avse_cut(e_cal, current, plotFigure=None):

--- a/src/pygama/raw/__init__.py
+++ b/src/pygama/raw/__init__.py
@@ -1,12 +1,11 @@
 """
 The primary function for data conversion into raw lh5 files is
-:func:`pygama.raw.build_raw.build_raw`. This is a one-to many function: one
-input DAQ file can generate one or more output raw files. Control of which data
-ends up in which files, and in which HDF5 groups inside of each file, is
-controlled via :mod:`pygama.raw.raw_buffer` (see below). If no raw buffers
-specification is specified, all decoded data should be written to a single
-output file, with all fields from each hardware decoder in their own output
-table.
+:func:`.build_raw`. This is a one-to many function: one input DAQ file can
+generate one or more output raw files. Control of which data ends up in which
+files, and in which HDF5 groups inside of each file, is controlled via
+:mod:`.raw_buffer` (see below). If no raw buffers specification is specified,
+all decoded data should be written to a single output file, with all fields
+from each hardware decoder in their own output table.
 
 Currently we support the following hardware:
 
@@ -20,3 +19,5 @@ Partial support is in place but requires updating for
 * SIS3316 read out with LLaMA-DAQ
 * CAEN DT57XX digitizers read out with CoMPASS
 """
+
+from .build_raw import build_raw

--- a/src/pygama/raw/build_raw.py
+++ b/src/pygama/raw/build_raw.py
@@ -42,6 +42,7 @@ def build_raw(in_stream, in_stream_type=None, out_spec=None, buffer_size=8192,
         Options are 'ORCA', 'FlashCams', 'LlamaDaq', 'Compass', 'MGDO'
     out_spec : str or json dict or RawBufferLibrary or None
         Specification for the output stream.
+
         - If None, uses '{in_stream}.hdf5' as the output filename.
         - If a str not ending in '.json', interpreted as the output filename.
         - If a str ending in '.json', interpreted as a filename containing
@@ -51,6 +52,7 @@ def build_raw(in_stream, in_stream_type=None, out_spec=None, buffer_size=8192,
           used to build a RawBufferLibrary
         - If a RawBufferLibrary, the mapping of data to output file / group is
           taken from that.
+
     buffer_size : int
         Default size to use for data buffering
     n_max : int

--- a/src/pygama/raw/build_raw.py
+++ b/src/pygama/raw/build_raw.py
@@ -37,9 +37,11 @@ def build_raw(in_stream, in_stream_type=None, out_spec=None, buffer_size=8192,
         The name of the input stream to be converted. Typically a filename,
         including path. Can use environment variables. Some streamers may be
         able to (eventually) accept e.g. streaming over a port as an input.
+
     in_stream_type : str
         Type of stream used to write the input file.
         Options are 'ORCA', 'FlashCams', 'LlamaDaq', 'Compass', 'MGDO'
+
     out_spec : str or json dict or RawBufferLibrary or None
         Specification for the output stream.
 
@@ -55,13 +57,17 @@ def build_raw(in_stream, in_stream_type=None, out_spec=None, buffer_size=8192,
 
     buffer_size : int
         Default size to use for data buffering
+
     n_max : int
         Maximum number of "row" of data to process from the input file
+
     overwrite : bool
         Sets whether to overwrite the output file(s) if it (they) already exist
+
     verbosity : int
         Sets the verbosity level. 0 gives the minimum output level.
-    kwargs : kwargs
+
+    **kwargs : kwargs
         Sent to RawBufferLibrary generation as kw_dict
     """
 

--- a/src/pygama/raw/data_streamer.py
+++ b/src/pygama/raw/data_streamer.py
@@ -62,8 +62,8 @@ class DataStreamer(ABC):
         -------
         header_data: list(RawBuffer), int
             header_data is a list of RawBuffer's containing any file header
-                data, ready for writing to file or further processing. It's not
-                a RawBufferList since the buffers may have a different format
+            data, ready for writing to file or further processing. It's not a
+            RawBufferList since the buffers may have a different format
         """
         # call super().initialize([args]) to run this default code
         # after loading header info, then follow it with the return call.
@@ -144,14 +144,16 @@ class DataStreamer(ABC):
         Parameters
         ----------
         chunk_mode_override: 'any_full', 'only_full', 'single_packet', or None
-            None : do not override self.chunk_mode
-            'any_full' : returns all raw buffers with data as soon as any one
-                buffer gets full
-            'only_full' : returns only those raw buffers that became full (or
-                nearly full) during the read. This minimizes the number of write calls.
-            'single_packet' : returns all raw buffers with data after a single
-                read is performed. This is useful for streaming data out as soon
-                as it is read in (e.g. for diagnostics or in-line analysis)
+
+            - None : do not override self.chunk_mode
+            - 'any_full' : returns all raw buffers with data as soon as any one
+              buffer gets full
+            - 'only_full' : returns only those raw buffers that became full (or
+              nearly full) during the read. This minimizes the number of write calls.
+            - 'single_packet' : returns all raw buffers with data after a single
+              read is performed. This is useful for streaming data out as soon
+              as it is read in (e.g. for diagnostics or in-line analysis)
+
         rp_max : int
             maximum number of packets to read before returning anyway, even if
             one of the other conditions is not met

--- a/src/pygama/raw/data_streamer.py
+++ b/src/pygama/raw/data_streamer.py
@@ -143,8 +143,7 @@ class DataStreamer(ABC):
 
         Parameters
         ----------
-        chunk_mode_override: 'any_full', 'only_full', 'single_packet', or None
-
+        chunk_mode_override : 'any_full', 'only_full', 'single_packet', or None
             - None : do not override self.chunk_mode
             - 'any_full' : returns all raw buffers with data as soon as any one
               buffer gets full
@@ -153,7 +152,6 @@ class DataStreamer(ABC):
             - 'single_packet' : returns all raw buffers with data after a single
               read is performed. This is useful for streaming data out as soon
               as it is read in (e.g. for diagnostics or in-line analysis)
-
         rp_max : int
             maximum number of packets to read before returning anyway, even if
             one of the other conditions is not met

--- a/src/pygama/raw/fc/fc_event_decoder.py
+++ b/src/pygama/raw/fc/fc_event_decoder.py
@@ -8,6 +8,7 @@ class FCEventDecoder(DataDecoder):
     """
     def __init__(self, *args, **kwargs):
         """
+        DOCME
         """
         # these are read for every event (decode_event)
         self.decoded_values = {
@@ -160,7 +161,7 @@ class FCEventDecoder(DataDecoder):
         fcio : fcio reader object
             The interface to the fcio data. Enters this function after a call to
             fcio.get_record() so that data for packet_id ready to be read out
-        lgdo_tables : lgdo.Table or dict
+        evt_rbkd : lgdo.Table or dict
             A single table for reading out all data, or a dict of tables keyed
             by channel number (i.e. as returned by raw_groups.build_tables())
         packet_id : int

--- a/src/pygama/raw/fc/fc_status_decoder.py
+++ b/src/pygama/raw/fc/fc_status_decoder.py
@@ -11,6 +11,7 @@ class FCStatusDecoder(DataDecoder):
     """
     def __init__(self, *args, **kwargs):
         """
+        DOCME
         """
         self.decoded_values = {
             'status': { # 0: Errors occurred, 1: no errors

--- a/src/pygama/raw/fc/fc_streamer.py
+++ b/src/pygama/raw/fc/fc_streamer.py
@@ -48,6 +48,10 @@ class FCStreamer(DataStreamer):
             library of buffers for this stream
         buffer_size : int
             length of tables to be read out in read_chunk
+        chunk_mode : str
+            DOCME
+        out_stream : str
+            DOCME
         verbosity : int
             verbosity level for the initialize function
 

--- a/src/pygama/raw/raw_buffer.py
+++ b/src/pygama/raw/raw_buffer.py
@@ -175,8 +175,8 @@ class RawBufferList(list):
         values : list
             The list of values of RawBuffer.attribute
 
-        Example
-        -------
+        Examples
+        --------
         >>> output_file_list = rbl.get_list_of('out_stream')
         """
         values = []
@@ -264,14 +264,16 @@ class RawBufferLibrary(dict):
         ----------
         attribute : str
             The RawBuffer attribute queried to make the list
+        unique : bool
+            Remove duplicates
 
         Returns
         -------
         values : list
             The list of values of RawBuffer.attribute
 
-        Example
-        -------
+        Examples
+        --------
         >>> output_file_list = rbl.get_list_of('out_stream')
         """
         values = []
@@ -348,6 +350,10 @@ def write_to_lh5_and_clear(raw_buffers, lh5_store=None, wo_mode='append', verbos
     lh5_store : LH5Store or None
         Allows user to send in a store holding a collection of already open
         files (saves some time opening / closing files)
+    wo_mode : str
+        write mode, see also :meth:`.lgdo.lh5_store.LH5Store.write_object`
+    verbosity : bool
+        print debug messages
     """
     if lh5_store is None: lh5_store = lgdo.LH5Store()
     for rb in raw_buffers:

--- a/src/pygama/raw/raw_buffer.py
+++ b/src/pygama/raw/raw_buffer.py
@@ -1,59 +1,62 @@
-"""
-raw_buffer.py: manages data buffering for raw data conversion
+r"""
+:mod:`.raw_buffer` manages data buffering for raw data conversion
 
 Manages LGDO buffers and their corresponding output streams. Allows for
 one-to-many mapping of input sreams to output streams.
 
 Primary Classes
 ---------------
-RawBuffer: an lgdo (e.g. a table) along with buffer metadata, such as the
+:class:`.RawBuffer`: an LGDO (e.g. a table) along with buffer metadata, such as the
 current write location, the list of keys (e.g. channels) that write to it, the
 output stream it is associated with (if any), etc. Each data_decoder is
-associated with a RawBuffer of a particular format.
+associated with a :class:`.RawBuffer` of a particular format.
 
-RawBufferList: a collection of RawBuffers with lgdo's that all have the same
-structure (same type, same fields, etc). A data_decoder will write its output to
-a RawBufferList.
+:class:`.RawBufferList`: a collection of :class:`RawBuffer` with LGDO's that
+all have the same structure (same type, same fields, etc). A data_decoder will
+write its output to a :class:`.RawBufferList`.
 
-RawBufferLibrary: a collection (dict) of RawBufferLists, e.g. one for each
-data_decoder. Keyed by the decoder name.
+:class:`.RawBufferLibrary`: a collection (dict) of :class:`RawBufferList`\ s,
+e.g. one for each data_decoder. Keyed by the decoder name.
 
-RawBuffers support a json short-hand notation, see
-RawBufferLibrary.set_from_json_dict() for full specification.
+:class:`.RawBuffer` supports a JSON short-hand notation, see
+:meth:`.RawBufferLibrary.set_from_json_dict` for full specification.
 
-Example json yielding a valid RawBufferLibrary is below. In the example, the
-user would call RawBufferLibrary.set_from_json_dict(json_dict, kw_dict) with
-kw_dict containing an entry for 'file_key'. The other keywords {key} and {name}
-are understood by and filled in during set_from_json_dict() unless overloaded in
-kw_dict. Note the use of the wildcard "*": this will match all other decoder
-names / keys.
+Example JSON yielding a valid :class:`.RawBufferLibrary` is below. In the
+example, the user would call ``RawBufferLibrary.set_from_json_dict(json_dict,
+kw_dict)`` with ``kw_dict`` containing an entry for ``'file_key'``. The other
+keywords ``{key}`` and ``{name}`` are understood by and filled in during
+:meth:`.RawBufferLibrary.set_from_json_dict` unless overloaded in ``kw_dict``.
+Note the use of the wildcard ``*``: this will match all other decoder names /
+keys.
 
-{
-  "FCEventDecoder" : {
-    "g{key:0>3d}" : {
-      "key_list" : [ [24,64] ],
-      "out_stream" : "$DATADIR/{file_key}_geds.lh5:/geds"
-    },
-    "spms" : {
-      "key_list" : [ [6,23] ],
-      "out_stream" : "$DATADIR/{file_key}_spms.lh5:/spms"
-    },
-    "puls" : {
-      "key_list" : [ 0 ],
-      "out_stream" : "$DATADIR/{file_key}_auxs.lh5:/auxs"
-    },
-    "muvt" : {
-      "key_list" : [ 1, 5 ],
-      "out_stream" : "$DATADIR/{file_key}_auxs.lh5:/auxs"
+.. code-block :: json
+
+    {
+      "FCEventDecoder" : {
+        "g{key:0>3d}" : {
+          "key_list" : [ [24,64] ],
+          "out_stream" : "$DATADIR/{file_key}_geds.lh5:/geds"
+        },
+        "spms" : {
+          "key_list" : [ [6,23] ],
+          "out_stream" : "$DATADIR/{file_key}_spms.lh5:/spms"
+        },
+        "puls" : {
+          "key_list" : [ 0 ],
+          "out_stream" : "$DATADIR/{file_key}_auxs.lh5:/auxs"
+        },
+        "muvt" : {
+          "key_list" : [ 1, 5 ],
+          "out_stream" : "$DATADIR/{file_key}_auxs.lh5:/auxs"
+        }
+      },
+      "*" : {
+        "{name}" : {
+          "key_list" : [ "*" ],
+          "out_stream" : "$DATADIR/{file_key}_{name}.lh5"
+        }
+      }
     }
-  },
-  "*" : {
-    "{name}" : {
-      "key_list" : [ "*" ],
-      "out_stream" : "$DATADIR/{file_key}_{name}.lh5"
-    }
-  }
-}
 
 later: could initially make field "lgdo" a dict of args for lgdo.__init__(),
 e.g. to have object-specific buffer sizes
@@ -65,7 +68,7 @@ from pygama import lgdo
 
 
 class RawBuffer:
-    '''
+    """
     A RawBuffer is in essence a an lgdo object (typically a Table) to which
     decoded data will be written, along with some meta-data distinguishing
     what data goes into it, and where the lgdo gets written out. Also holds on
@@ -89,7 +92,7 @@ class RawBuffer:
         Socket example: '198.0.0.100:8000'
     out_name : str (optional)
         the name / identifier of the object in the output stream
-    '''
+    """
 
 
     def __init__(self, lgdo=None, key_list=[], out_stream='', out_name=''):
@@ -120,18 +123,18 @@ class RawBuffer:
 
 
 class RawBufferList(list):
-    '''
+    """
     A RawBufferList holds a collection of RawBuffers of identical structure
     (same format lgdo's with the same fields).
-    '''
+    """
 
 
     def get_keyed_dict(self, default=None):
-        ''' returns a dict of RawBuffers built from the buffers' key_lists
+        """ returns a dict of RawBuffers built from the buffers' key_lists
 
         Different keys may point to the same buffer. Requires the buffers in the
         RawBufferList to have non-overlapping key lists.
-        '''
+        """
         keyed_dict = {}
         for rb in self:
             for key in rb.key_list: keyed_dict[key] = rb
@@ -139,12 +142,12 @@ class RawBufferList(list):
 
 
     def set_from_json_dict(self, json_dict, kw_dict={}):
-        ''' set up a RawBufferList from a dict written in json shorthand
+        """set up a RawBufferList from a dict written in json shorthand
 
         See RawBufferLibrary.set_from_json_dict() for details
 
-        Note: json_dict is changed by this function
-        '''
+        Note: ``json_dict`` is changed by this function
+        """
         expand_rblist_json_dict(json_dict, kw_dict)
         for name in json_dict:
             rb = RawBuffer()
@@ -174,7 +177,7 @@ class RawBufferList(list):
 
         Example
         -------
-        output_file_list = rbl.get_list_of('out_stream')
+        >>> output_file_list = rbl.get_list_of('out_stream')
         """
         values = []
         for rb in self:
@@ -189,32 +192,36 @@ class RawBufferList(list):
 
 
 class RawBufferLibrary(dict):
-    '''
+    """
     A RawBufferLibrary is a collection of RawBufferLists associated with the
     names of decoders that can write to them
-    '''
+    """
     def __init__(self, json_dict=None, kw_dict={}):
         if json_dict is not None:
             self.set_from_json_dict(json_dict, kw_dict)
 
 
     def set_from_json_dict(self, json_dict, kw_dict={}):
-        ''' set up a RawBufferLibrary from a dict written in json shorthand
+        """ set up a RawBufferLibrary from a dict written in json shorthand
 
         Basic structure:
-        {
-        "list_name" : {
-          "name" : {
-              "key_list" : [ key1, key2, ... ],
-              "out_stream" : "out_stream_str",
-              "out_name" : "out_name_str" (optional)
-          }
-        }
+
+        .. code-block :: js
+
+            {
+            "list_name" : {
+              "name" : {
+                  "key_list" : [ "key1", "key2", "..." ],
+                  "out_stream" : "out_stream_str",
+                  "out_name" : "out_name_str" // (optional)
+              }
+            }
 
         By default "name" is used for the RawBuffer's "out_name" attribute, but
         this can be overridden if desired by providing an explicit "out_name"
 
         Allowed shorthands, in order of expansion:
+
         * key_list may have entries that are 2-integer lists corresponding to
           the first and last integer keys in a contiguous range (e.g. of
           channels) that get stored to the same buffer. These simply get
@@ -243,7 +250,7 @@ class RawBufferLibrary(dict):
         kw_dict : dict
             dict of keyword-value pairs for substitutions into the out_stream
             and out_name fields
-        '''
+        """
         for list_name in json_dict:
             if list_name not in self: self[list_name] = RawBufferList()
             self[list_name].set_from_json_dict(json_dict[list_name], kw_dict)
@@ -265,7 +272,7 @@ class RawBufferLibrary(dict):
 
         Example
         -------
-        output_file_list = rbl.get_list_of('out_stream')
+        >>> output_file_list = rbl.get_list_of('out_stream')
         """
         values = []
         for rb_list in self.values():
@@ -279,7 +286,7 @@ class RawBufferLibrary(dict):
 
 
 def expand_rblist_json_dict(json_dict, kw_dict):
-    """ Expand shorthands in json_dict representing a RawBufferList
+    """Expand shorthands in json_dict representing a RawBufferList
 
     See RawBufferLibrary.set_from_json_dict() for details
 
@@ -331,7 +338,7 @@ def expand_rblist_json_dict(json_dict, kw_dict):
 
 
 def write_to_lh5_and_clear(raw_buffers, lh5_store=None, wo_mode='append', verbosity=0):
-    ''' Write a list of RawBuffers to lh5 files and then clears them
+    """Write a list of RawBuffers to lh5 files and then clears them
 
     Parameters
     ----------
@@ -341,7 +348,7 @@ def write_to_lh5_and_clear(raw_buffers, lh5_store=None, wo_mode='append', verbos
     lh5_store : LH5Store or None
         Allows user to send in a store holding a collection of already open
         files (saves some time opening / closing files)
-    '''
+    """
     if lh5_store is None: lh5_store = lgdo.LH5Store()
     for rb in raw_buffers:
         if rb.lgdo is None or rb.loc == 0: continue # no data to write

--- a/src/pygama/vis/__init__.py
+++ b/src/pygama/vis/__init__.py
@@ -1,3 +1,5 @@
 """
 Subpackage description
 """
+
+from .waveform_browser import WaveformBrowser

--- a/src/pygama/vis/waveform_browser.py
+++ b/src/pygama/vis/waveform_browser.py
@@ -23,8 +23,6 @@ class WaveformBrowser:
     drawing transformed waveforms defined using build_dsp style json files,
     drawing horizontal and vertical lines at the values of calculated
     parameters, and filling a legend with calculated parameters.
-
-
     """
 
     def __init__(self, files_in, lh5_group, base_path = '',
@@ -68,17 +66,21 @@ class WaveformBrowser:
         styles : (default None)
             line colors and other style parameters to cycle through when
             drawing waveforms. Can be given as:
+
             - dict of lists: e.g. {'color':['r', 'g', 'b'], 'linestyle':['-', '--', '.']}
             - name of predefined style; see matplotlib.style documentation
             - None: use current matplotlib rcparams style
+
             If a single style cycle is given, use for all lines; if a list is
             given, match to lines list.
         legend : str or [strs] (default None)
             Formatting string and values to include in the legend. This can
             be a list of values (one for each drawn object). If just a name
             is given, it will be auto-formatted to 3 digits. Otherwise,
-            formatting strings in brackets can be used:
+            formatting strings in brackets can be used: ::
+
               "{energy:0.1f} keV, {timestamp:d} ns"
+
             Names will be searched in the input file, DSP processed parameters,
             or auxiliary data-table
         legend_opts : dict (default None)
@@ -87,10 +89,12 @@ class WaveformBrowser:
             number of events to draw simultaneously when calling DrawNext
         x_lim : tuple-pair of float, pint.Quantity or str (default auto)
             range of x-values and units passes as tuple.
+
             - None: Get range from first waveform drawn
             - pint.Quantity: set value and x-unit
             - float: get unit from first waveform drawn
             - str: convert to pint.Quanity (e.g. ('0*us', '10*us'))
+
         x_unit : pint.Unit or str (default auto)
             unit of x-axis
         norm : str (default None)

--- a/src/pygama/vis/waveform_browser.py
+++ b/src/pygama/vis/waveform_browser.py
@@ -37,32 +37,41 @@ class WaveformBrowser:
         """
         Parameters
         ----------
-        file_in : str
+        files_in : str
             name of file or list of names to browse. Can use wildcards
+
         lh5_group : str
             name of LH5 group in file to browse
+
         base_path : str
             base path for file. See LH5Store
+
         entry_list : list-like or nested list-like (optional)
             List of event indices to draw. If it is a nested list, use local
             indices for each file, otherwise use global indices
+
         entry_mask : array-like or list of array-likes (optional)
             Boolean mask indicating which events to draw. If a nested list, use
             a mask for each file, else use a global mask. Cannot be used with
             entry_list...
+
         dsp_config : str (optional)
             name of DSP config json file containing a list of processors that
             can be applied to waveforms
+
         database : str or dict-like (optional)
             dict or JSON file with database of processing parameters
+
         aux_values : pandas dataframe (optional)
             table of auxiliary values that are one-to-one with the input
             waveforms that can be drawn or placed in the legend
+
         lines : str or [strs] (default 'waveform')
             name(s) of objects to draw 2D lines for. Waveforms will be drawn
             as a time-series. Scalar quantities will be drawn as horizontal
             or vertical lines, depending on units. Vectors will be drawn
             as multiple horizontal/vertical lines
+
         styles : (default None)
             line colors and other style parameters to cycle through when
             drawing waveforms. Can be given as:
@@ -73,6 +82,7 @@ class WaveformBrowser:
 
             If a single style cycle is given, use for all lines; if a list is
             given, match to lines list.
+
         legend : str or [strs] (default None)
             Formatting string and values to include in the legend. This can
             be a list of values (one for each drawn object). If just a name
@@ -83,12 +93,15 @@ class WaveformBrowser:
 
             Names will be searched in the input file, DSP processed parameters,
             or auxiliary data-table
+
         legend_opts : dict (default None)
             dict containing additional kwargs for matplotlib.legend
+
         n_drawn : int (default 1)
             number of events to draw simultaneously when calling DrawNext
-        x_lim : tuple-pair of float, pint.Quantity or str (default auto)
-            range of x-values and units passes as tuple.
+
+        x_lim, y_lim : tuple-pair of float, pint.Quantity or str (default auto)
+            range of x- or y-values and units passes as tuple.
 
               - None: Get range from first waveform drawn
               - pint.Quantity: set value and x-unit
@@ -97,16 +110,23 @@ class WaveformBrowser:
 
         x_unit : pint.Unit or str (default auto)
             unit of x-axis
+
         norm : str (default None)
             name of parameter (probably energy) to use to normalize WFs
             useful when drawing multiple WFs
+
         align : str (default None)
             name of parameter to use for x-offset; useful, e.g., for aligning
             multiple waveforms at a particular timepoint
+
         buffer_len : int (default 16)
             number of waveforms to keep in memory at a time
+
         block_width : int (default 16)
             block width for processing chain
+
+        verbosity : bool
+            print debug messages
         """
         self.verbosity = verbosity
 
@@ -244,7 +264,7 @@ class WaveformBrowser:
 
     def save_figure(self, f_out, *args, **kwargs):
         """ Write figure to file named f_out. See matplotlib.pyplot.savefig
-        for args and kwargs """
+        for args and kwargs"""
         self.fig.savefig(f_out)
 
     def set_figure(self, fig, ax=None):

--- a/src/pygama/vis/waveform_browser.py
+++ b/src/pygama/vis/waveform_browser.py
@@ -67,9 +67,9 @@ class WaveformBrowser:
             line colors and other style parameters to cycle through when
             drawing waveforms. Can be given as:
 
-            - dict of lists: e.g. {'color':['r', 'g', 'b'], 'linestyle':['-', '--', '.']}
-            - name of predefined style; see matplotlib.style documentation
-            - None: use current matplotlib rcparams style
+              - dict of lists: e.g. {'color':['r', 'g', 'b'], 'linestyle':['-', '--', '.']}
+              - name of predefined style; see matplotlib.style documentation
+              - None: use current matplotlib rcparams style
 
             If a single style cycle is given, use for all lines; if a list is
             given, match to lines list.
@@ -90,10 +90,10 @@ class WaveformBrowser:
         x_lim : tuple-pair of float, pint.Quantity or str (default auto)
             range of x-values and units passes as tuple.
 
-            - None: Get range from first waveform drawn
-            - pint.Quantity: set value and x-unit
-            - float: get unit from first waveform drawn
-            - str: convert to pint.Quanity (e.g. ('0*us', '10*us'))
+              - None: Get range from first waveform drawn
+              - pint.Quantity: set value and x-unit
+              - float: get unit from first waveform drawn
+              - str: convert to pint.Quanity (e.g. ('0*us', '10*us'))
 
         x_unit : pint.Unit or str (default auto)
             unit of x-axis
@@ -103,8 +103,10 @@ class WaveformBrowser:
         align : str (default None)
             name of parameter to use for x-offset; useful, e.g., for aligning
             multiple waveforms at a particular timepoint
-        buffer_len (default 16): number of waveforms to keep in memory at a time
-        block_width (default 16): block width for processing chain
+        buffer_len : int (default 16)
+            number of waveforms to keep in memory at a time
+        block_width : int (default 16)
+            block width for processing chain
         """
         self.verbosity = verbosity
 


### PR DESCRIPTION
This PR adds some pre-commit functionality to check whether docstrings are correctly formatted according to NumPy's conventions. I also went through all existing docstrings and fixed many formatting issues. The remaining Sphinx errors come from the `raw.orca` subpackage, which is currently being refactored by @jasondet so I will not touch it.

Since this PR concerns docstring formatting only, I will proceed to merge soon if nobody complains.