### PR TITLE
Docs building fix: add `pygama._version` as mock import

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -36,6 +36,7 @@ html_theme = 'sphinx_rtd_theme'
 # list here pygama dependencies that are not required for building docs and
 # could be unmet at build time
 autodoc_mock_imports = [
+    'pygama._version',
     'pandas',
     # 'numpy',
     'matplotlib',


### PR DESCRIPTION
The bug was breaking auto-generated API docs for `refactor`.