### PR TITLE
Fixed Double Pole Zero Filter

### DIFF
--- a/src/pygama/dsp/_processors/pole_zero.py
+++ b/src/pygama/dsp/_processors/pole_zero.py
@@ -51,7 +51,7 @@ def double_pole_zero(w_in, t_tau1, t_tau2, frac, w_out):
     Apply a double pole-zero cancellation using the provided time
     constant to the waveform. This algorithm is a IIR filter to deconvolve the function
     s(x) = A[frac*exp(-t/t_tau2) + (1-frac)*exp(-t/t_tau1)] into a single step function
-    of amplitude A. See the June 1st analysis and simulations call for more details. 
+    of amplitude A. See the June 1st analysis and simulations call for more details.
     https://indico.legend-exp.org/event/840/
 
     Parameters
@@ -82,7 +82,7 @@ def double_pole_zero(w_in, t_tau1, t_tau2, frac, w_out):
     w_out[:] = np.nan
 
     if np.isnan(w_in).any() or np.isnan(t_tau1) or np.isnan(t_tau2) or np.isnan(frac):
-        return 
+        return
     if (len(w_in)<=3):
         raise DSPFatal('The length of the waveform must be larger than 3 for the filter to work safely')
 
@@ -94,4 +94,3 @@ def double_pole_zero(w_in, t_tau1, t_tau2, frac, w_out):
 
     for i in range(2, len(w_in), 1):
         w_out[i] = -(frac*b-frac*a-b-1)*w_out[i-1] + (frac*b-frac*a-b)*w_out[i-2] + w_in[i] - (a+b)*w_in[i-1] + (a*b)*w_in[i-2]
-

--- a/src/pygama/dsp/_processors/pole_zero.py
+++ b/src/pygama/dsp/_processors/pole_zero.py
@@ -49,10 +49,7 @@ def pole_zero(w_in, t_tau, w_out):
 def double_pole_zero(w_in, t_tau1, t_tau2, frac, w_out):
     """
     Apply a double pole-zero cancellation using the provided time
-    constant to the waveform. This algorithm is a IIR filter to deconvolve the function
-    s(x) = A[frac*exp(-t/t_tau2) + (1-frac)*exp(-t/t_tau1)] into a single step function
-    of amplitude A. See the June 1st analysis and simulations call for more details.
-    https://indico.legend-exp.org/event/840/
+    constants to the waveform. 
 
     Parameters
     ----------
@@ -78,6 +75,26 @@ def double_pole_zero(w_in, t_tau1, t_tau2, frac, w_out):
             "unit": "ADC",
             "prereqs": ["wf_bl"]
         }
+
+    Notes
+    -----
+    This algorithm is an IIR filter to deconvolve the function
+
+    .. math:: s(t) = A[frac*\\exp\\left(-\\frac{t}{t_{tau2}}\\right) + (1-frac)*\\exp\\left(-\\frac{t}{t_{tau1}}\\right)]
+
+    into a single step function of amplitude A. 
+    This filter is derived by z-transforming the input (:math:`s(t)`) and output (step function) 
+    signals, and then determining the transfer function. For shorthand, define :math:`a=\\exp\\left(-\\frac{1}{t_{tau1}}\\right)`
+    and :math:`b=\\exp\\left(-\\frac{1}{t_{tau2}}\\right)`, the transfer function is then: 
+
+    .. math:: H(z) =  \\frac{1-(a+b)z^{-1}+abz^{-2}}{1+(fb-fa-b-1)z^{-1}-(fb-fa-b)z^{-2}}
+
+    By equating the transfer function to the ratio of output to input waveforms :math:`H(z) = \\frac{w_{out}(z)}{w_{in}(z)}`
+    and then taking the inverse z-transform yields the filter as run in the function, where f is the frac parameter: 
+
+    .. math:: 
+        w_{out}[n] = &w_{in}[n]-(a+b)w_{in}[n-1]+(ab)w_{in}[n-2]\\\\
+        &-(fb-fa-b-1)w_{out}[n-1]+(fb-fa-b)w_{out}[n-2]
     """
     w_out[:] = np.nan
 
@@ -89,8 +106,8 @@ def double_pole_zero(w_in, t_tau1, t_tau2, frac, w_out):
     a = np.exp(-1 / t_tau1)
     b = np.exp(-1 / t_tau2)
 
-    transfer_denom_1 = -1*(frac*b-frac*a-b-1)
-    transfer_denom_2 = frac*b-frac*a-b
+    transfer_denom_1 = (frac*b-frac*a-b-1)
+    transfer_denom_2 = -1*(frac*b-frac*a-b)
     transfer_num_1 = -1*(a+b)
     transfer_num_2 = a*b
 
@@ -99,4 +116,5 @@ def double_pole_zero(w_in, t_tau1, t_tau2, frac, w_out):
     w_out[2] = w_in[2]
 
     for i in range(2, len(w_in), 1):
-        w_out[i] = transfer_denom_1*w_out[i-1] + transfer_denom_2*w_out[i-2] + w_in[i] + transfer_num_1*w_in[i-1] + transfer_num_2*w_in[i-2]
+        w_out[i] = w_in[i] + transfer_num_1*w_in[i-1] + transfer_num_2*w_in[i-2]\
+            - transfer_denom_1*w_out[i-1] - transfer_denom_2*w_out[i-2] 

--- a/src/pygama/dsp/_processors/pole_zero.py
+++ b/src/pygama/dsp/_processors/pole_zero.py
@@ -56,16 +56,16 @@ def double_pole_zero(w_in, t_tau1, t_tau2, frac, w_out):
 
     Parameters
     ----------
-    w_in  : array-like
-            The input waveform
-    t_tau1: float
-            The time constant of the first exponential to be deconvolved
-    t_tau2: float
-            The time constant of the second exponential to be deconvolved
-    frac  : float
-            The fraction which the second exponential contributes
+    w_in : array-like
+        The input waveform
+    t_tau1 : float
+        The time constant of the first exponential to be deconvolved
+    t_tau2 : float
+        The time constant of the second exponential to be deconvolved
+    frac : float
+        The fraction which the second exponential contributes
     w_out : array-like
-            The pole-zero cancelled waveform
+        The pole-zero cancelled waveform
 
     Examples
     --------
@@ -79,7 +79,7 @@ def double_pole_zero(w_in, t_tau1, t_tau2, frac, w_out):
             "prereqs": ["wf_bl"]
         }
     """
-    w_out[:] = np.nan 
+    w_out[:] = np.nan
 
     if np.isnan(w_in).any() or np.isnan(t_tau1) or np.isnan(t_tau2) or np.isnan(frac):
         return 

--- a/src/pygama/dsp/_processors/pole_zero.py
+++ b/src/pygama/dsp/_processors/pole_zero.py
@@ -49,7 +49,7 @@ def pole_zero(w_in, t_tau, w_out):
 def double_pole_zero(w_in, t_tau1, t_tau2, frac, w_out):
     """
     Apply a double pole-zero cancellation using the provided time
-    constants to the waveform. 
+    constants to the waveform.
 
     Parameters
     ----------
@@ -82,17 +82,17 @@ def double_pole_zero(w_in, t_tau1, t_tau2, frac, w_out):
 
     .. math:: s(t) = A[frac*\\exp\\left(-\\frac{t}{t_{tau2}}\\right) + (1-frac)*\\exp\\left(-\\frac{t}{t_{tau1}}\\right)]
 
-    into a single step function of amplitude A. 
-    This filter is derived by z-transforming the input (:math:`s(t)`) and output (step function) 
+    into a single step function of amplitude A.
+    This filter is derived by z-transforming the input (:math:`s(t)`) and output (step function)
     signals, and then determining the transfer function. For shorthand, define :math:`a=\\exp\\left(-\\frac{1}{t_{tau1}}\\right)`
-    and :math:`b=\\exp\\left(-\\frac{1}{t_{tau2}}\\right)`, the transfer function is then: 
+    and :math:`b=\\exp\\left(-\\frac{1}{t_{tau2}}\\right)`, the transfer function is then:
 
     .. math:: H(z) =  \\frac{1-(a+b)z^{-1}+abz^{-2}}{1+(fb-fa-b-1)z^{-1}-(fb-fa-b)z^{-2}}
 
     By equating the transfer function to the ratio of output to input waveforms :math:`H(z) = \\frac{w_{out}(z)}{w_{in}(z)}`
-    and then taking the inverse z-transform yields the filter as run in the function, where f is the frac parameter: 
+    and then taking the inverse z-transform yields the filter as run in the function, where f is the frac parameter:
 
-    .. math:: 
+    .. math::
         w_{out}[n] = &w_{in}[n]-(a+b)w_{in}[n-1]+(ab)w_{in}[n-2]\\\\
         &-(fb-fa-b-1)w_{out}[n-1]+(fb-fa-b)w_{out}[n-2]
     """
@@ -117,4 +117,4 @@ def double_pole_zero(w_in, t_tau1, t_tau2, frac, w_out):
 
     for i in range(2, len(w_in), 1):
         w_out[i] = w_in[i] + transfer_num_1*w_in[i-1] + transfer_num_2*w_in[i-2]\
-            - transfer_denom_1*w_out[i-1] - transfer_denom_2*w_out[i-2] 
+            - transfer_denom_1*w_out[i-1] - transfer_denom_2*w_out[i-2]

--- a/src/pygama/dsp/_processors/pole_zero.py
+++ b/src/pygama/dsp/_processors/pole_zero.py
@@ -49,20 +49,23 @@ def pole_zero(w_in, t_tau, w_out):
 def double_pole_zero(w_in, t_tau1, t_tau2, frac, w_out):
     """
     Apply a double pole-zero cancellation using the provided time
-    constant to the waveform.
+    constant to the waveform. This algorithm is a IIR filter to deconvolve the function
+    s(x) = A[frac*exp(-t/t_tau2) + (1-frac)*exp(-t/t_tau1)] into a single step function
+    of amplitude A. See the June 1st analysis and simulations call for more details. 
+    https://indico.legend-exp.org/event/840/
 
     Parameters
     ----------
-    w_in : array-like
-        The input waveform
-    t_tau1 : float
-        The time constant of the first exponential to be deconvolved
-    t_tau2 : float
-        The time constant of the second exponential to be deconvolved
-    frac : float
-        The fraction which the second exponential contributes
+    w_in  : array-like
+            The input waveform
+    t_tau1: float
+            The time constant of the first exponential to be deconvolved
+    t_tau2: float
+            The time constant of the second exponential to be deconvolved
+    frac  : float
+            The fraction which the second exponential contributes
     w_out : array-like
-        The pole-zero cancelled waveform
+            The pole-zero cancelled waveform
 
     Examples
     --------
@@ -76,19 +79,19 @@ def double_pole_zero(w_in, t_tau1, t_tau2, frac, w_out):
             "prereqs": ["wf_bl"]
         }
     """
-    w_out[:] = np.nan
+    w_out[:] = np.nan 
 
     if np.isnan(w_in).any() or np.isnan(t_tau1) or np.isnan(t_tau2) or np.isnan(frac):
-        return
+        return 
+    if (len(w_in)<=3):
+        raise DSPFatal('The length of the waveform must be larger than 3 for the filter to work safely')
 
-    const1 = 1 / t_tau1
-    const2 = 1 / t_tau2
+    a = np.exp(-1 / t_tau1)
+    b = np.exp(-1 / t_tau2)
     w_out[0] = w_in[0]
-    e1 = w_in[0]
-    e2 = w_in[0]
-    e3 = 0
-    for i in range(1, len(w_in), 1):
-        e1 += w_in[i] - e2 + e2 * const1
-        e3 += w_in[i] - e2 - e3 * const2
-        e2  = w_in[i]
-        w_out[i] = e1 - frac * e3
+    w_out[1] = w_in[1]
+    w_out[2] = w_in[2]
+
+    for i in range(2, len(w_in), 1):
+        w_out[i] = -(frac*b-frac*a-b-1)*w_out[i-1] + (frac*b-frac*a-b)*w_out[i-2] + w_in[i] - (a+b)*w_in[i-1] + (a*b)*w_in[i-2]
+

--- a/src/pygama/dsp/_processors/pole_zero.py
+++ b/src/pygama/dsp/_processors/pole_zero.py
@@ -88,9 +88,15 @@ def double_pole_zero(w_in, t_tau1, t_tau2, frac, w_out):
 
     a = np.exp(-1 / t_tau1)
     b = np.exp(-1 / t_tau2)
+
+    transfer_denom_1 = -1*(frac*b-frac*a-b-1)
+    transfer_denom_2 = frac*b-frac*a-b
+    transfer_num_1 = -1*(a+b)
+    transfer_num_2 = a*b
+
     w_out[0] = w_in[0]
     w_out[1] = w_in[1]
     w_out[2] = w_in[2]
 
     for i in range(2, len(w_in), 1):
-        w_out[i] = -(frac*b-frac*a-b-1)*w_out[i-1] + (frac*b-frac*a-b)*w_out[i-2] + w_in[i] - (a+b)*w_in[i-1] + (a*b)*w_in[i-2]
+        w_out[i] = transfer_denom_1*w_out[i-1] + transfer_denom_2*w_out[i-2] + w_in[i] + transfer_num_1*w_in[i-1] + transfer_num_2*w_in[i-2]


### PR DESCRIPTION
Fixed an issue in the double pole-zero filter where a single pole-zero correction was not recreated when the `frac` parameter was set to 0 or 1. 