### PR TITLE
Add more high-level `raw` tests

### DIFF
--- a/src/pygama/raw/build_raw.py
+++ b/src/pygama/raw/build_raw.py
@@ -11,10 +11,7 @@ from pygama.math.utils import sizeof_fmt
 
 from .fc.fc_streamer import FCStreamer
 from .orca.orca_streamer import OrcaStreamer
-from .raw_buffer import (
-    RawBufferLibrary,
-    write_to_lh5_and_clear,
-)
+from .raw_buffer import RawBufferLibrary, write_to_lh5_and_clear
 
 
 def build_raw(in_stream, in_stream_type=None, out_spec=None, buffer_size=8192,

--- a/src/pygama/raw/build_raw.py
+++ b/src/pygama/raw/build_raw.py
@@ -1,7 +1,6 @@
 import glob
 import json
 import os
-import sys
 import time
 
 import numpy as np
@@ -13,23 +12,17 @@ from pygama.math.utils import sizeof_fmt
 from .fc.fc_streamer import FCStreamer
 from .orca.orca_streamer import OrcaStreamer
 from .raw_buffer import (
-    RawBuffer,
     RawBufferLibrary,
-    RawBufferList,
     write_to_lh5_and_clear,
 )
-
-#from stream_llama import *
-#from stream_compass import *
-#from stream_fc import *
 
 
 def build_raw(in_stream, in_stream_type=None, out_spec=None, buffer_size=8192,
               n_max=np.inf, overwrite=True, verbosity=2, **kwargs):
-    """ Convert data into LEGEND hdf5 `raw` format.
+    """Convert data into LEGEND HDF5 "raw" format.
 
-    Takes an input stream (in_stream) of a given type (in_stream_type) and
-    writes to output file(s) according to the user's a specification (out_spec).
+    Takes an input stream of a given type and writes to output file(s)
+    according to the user's a specification.
 
     Parameters
     ----------
@@ -38,28 +31,27 @@ def build_raw(in_stream, in_stream_type=None, out_spec=None, buffer_size=8192,
         including path. Can use environment variables. Some streamers may be
         able to (eventually) accept e.g. streaming over a port as an input.
 
-    in_stream_type : str
+    in_stream_type : {None, 'ORCA', 'FlashCams', 'LlamaDaq', 'Compass', 'MGDO'}
         Type of stream used to write the input file.
-        Options are 'ORCA', 'FlashCams', 'LlamaDaq', 'Compass', 'MGDO'
 
-    out_spec : str or json dict or RawBufferLibrary or None
+    out_spec : str or dict or RawBufferLibrary or None
         Specification for the output stream.
 
-        - If None, uses '{in_stream}.hdf5' as the output filename.
-        - If a str not ending in '.json', interpreted as the output filename.
-        - If a str ending in '.json', interpreted as a filename containing
-          json-shorthand for the output specification (see raw_buffer.py)
-        - If a json dict, should be a dict loaded from the json shorthand
-          notation for RawBufferLibraries (see raw_buffer.py), which is then
-          used to build a RawBufferLibrary
-        - If a RawBufferLibrary, the mapping of data to output file / group is
-          taken from that.
+        - If None, uses ``{in_stream}.hdf5`` as the output filename.
+        - If a str not ending in ``.json``, interpreted as the output filename.
+        - If a str ending in ``.json``, interpreted as a filename containing
+          json-shorthand for the output specification (see :mod:`.raw_buffer`)
+        - If a JSON dict, should be a dict loaded from the json shorthand
+          notation for RawBufferLibraries (see :mod:`.raw_buffer`), which is
+          then used to build a :class:`.RawBufferLibrary`
+        - If a :class:`.RawBufferLibrary`, the mapping of data to output file /
+          group is taken from that.
 
     buffer_size : int
         Default size to use for data buffering
 
     n_max : int
-        Maximum number of "row" of data to process from the input file
+        Maximum number of rows of data to process from the input file
 
     overwrite : bool
         Sets whether to overwrite the output file(s) if it (they) already exist
@@ -68,7 +60,7 @@ def build_raw(in_stream, in_stream_type=None, out_spec=None, buffer_size=8192,
         Sets the verbosity level. 0 gives the minimum output level.
 
     **kwargs : kwargs
-        Sent to RawBufferLibrary generation as kw_dict
+        Sent to :class:`.RawBufferLibrary` generation as ``kw_dict``
     """
 
     # convert any environment variables in in_stream so that we can check for readability
@@ -76,25 +68,26 @@ def build_raw(in_stream, in_stream_type=None, out_spec=None, buffer_size=8192,
     # later: fix if in_stream is not a file
     # (e.g. a socket, which exists if open and has size = np.inf)
     if not os.path.exists(in_stream):
-        print(f'Error: file {in_stream} not found')
-        return
+        raise FileNotFoundError(f'file {in_stream} not found')
+
     in_stream_size = os.stat(in_stream).st_size
 
     # try to guess the input stream type if it's not provided
     if in_stream_type is None:
         i_ext = in_stream.split('/')[-1].rfind('.')
         if i_ext == -1:
-            if OrcaStreamer.is_orca_stream(in_stream): in_stream_type = 'ORCA'
+            if OrcaStreamer.is_orca_stream(in_stream):
+                in_stream_type = 'ORCA'
             else:
-                print('unknown file type. Specify in_stream_type')
-                return
+                raise RuntimeError('unknown file type. Specify in_stream_type')
         else:
             ext = in_stream.split('/')[-1][i_ext+1:]
-            if ext == 'fcio': in_stream_type = 'FlashCam'
-            if ext == 'gz' and OrcaStreamer.is_orca_stream(in_stream): in_stream_type = 'ORCA'
+            if ext == 'fcio':
+                in_stream_type = 'FlashCam'
+            elif ext == 'gz' and OrcaStreamer.is_orca_stream(in_stream):
+                in_stream_type = 'ORCA'
             else:
-                print(f'unknown file extension {ext}. Specify in_stream_type')
-                return
+                raise RuntimeError(f'unknown file extension {ext}. Specify in_stream_type')
 
     # procss out_spec and setup rb_lib if specified
     rb_lib = None
@@ -111,13 +104,11 @@ def build_raw(in_stream, in_stream_type=None, out_spec=None, buffer_size=8192,
         out_spec += '.lh5'
     # by now, out_spec should be a str or a RawBufferLibrary
     if not isinstance(out_spec, str) and not isinstance(out_spec, RawBufferLibrary):
-        print(f'Error: unknown out_spec type {type(out_spec).__name__}')
-        return
+        raise TypeError(f'unknown out_spec type {type(out_spec).__name__}')
 
     # modify buffer_size if necessary for n_max
     if buffer_size < 1:
-        print(f'Error: bad buffer_size {buffer_size}')
-        return
+        raise ValueError(f'bad buffer_size {buffer_size}')
     if buffer_size > n_max: buffer_size = n_max
 
     # output start of processing info if verbosity > 0
@@ -147,17 +138,13 @@ def build_raw(in_stream, in_stream_type=None, out_spec=None, buffer_size=8192,
     elif in_stream_type == 'FlashCam':
         streamer = FCStreamer()
     elif in_stream_type == 'LlamaDaq':
-        print(f'Error: LlamaDaq streaming not yet implemented')
-        return
+        raise NotImplementedError(f'LlamaDaq streaming not yet implemented')
     elif in_stream_type == 'Compass':
-        print(f'Error: Compass streaming not yet implemented')
-        return
+        raise NotImplementedError(f'Compass streaming not yet implemented')
     elif in_stream_type == 'MGDO':
-        print(f'Error: MGDO streaming not yet implemented')
-        return
+        raise NotImplementedError(f'MGDO streaming not yet implemented')
     else:
-        print(f'Error: Unknown input stream type {in_stream_type}')
-        return
+        raise NotImplementedError(f'unknown input stream type {in_stream_type}')
 
     # initialize the stream and read header. Also initializes rb_lib
     if verbosity > 1: progress_bar.update(0)
@@ -177,11 +164,10 @@ def build_raw(in_stream, in_stream_type=None, out_spec=None, buffer_size=8192,
         out_file_glob = glob.glob(out_file)
         if len(out_file_glob) == 0: continue
         if len(out_file_glob) > 1:
-            print(f'Error: got multiple matches for out_file {out_file}: {out_file_glob}')
-            return
+            raise RuntimeError(f'got multiple matches for out_file {out_file}: {out_file_glob}')
         if not overwrite:
-            print(f'Error: file {out_file_glob[0]} exists. Use option overwrite to proceed.')
-            return
+            raise RuntimeError(f'file {out_file_glob[0]} exists. Use option overwrite to proceed.')
+
         os.remove(out_file_glob[0])
 
     # Write header data

--- a/src/pygama/raw/fc/fc_streamer.py
+++ b/src/pygama/raw/fc/fc_streamer.py
@@ -24,6 +24,8 @@ class FCStreamer(DataStreamer):
         self.status_decoder = FCStatusDecoder()
         self.event_decoder = FCEventDecoder()
         self.event_tables = {}
+        self.event_rbkd = None
+        self.status_rb = None
 
 
 

--- a/src/pygama/raw/raw_buffer.py
+++ b/src/pygama/raw/raw_buffer.py
@@ -304,12 +304,12 @@ def expand_rblist_json_dict(json_dict, kw_dict):
     buffer_names = list(json_dict.keys())
     for name in buffer_names:
         if name == '':
-            print("Error: name can't be ''")
-            return
+            raise ValueError("buffer name can't be empty")
+
         info = json_dict[name] # changes to info will change json_dict[name]
         # make sure we have a key list
         if 'key_list' not in info:
-            print(f'expand_json_dict: {name} is missing key_list')
+            raise ValueError(f"'{name}' is missing key_list")
             continue
 
         # find and expand any ranges in the key_list
@@ -340,7 +340,10 @@ def expand_rblist_json_dict(json_dict, kw_dict):
             kw_dict['key'] = info['key_list'][0]
         if 'out_stream' in info:
             if name != '*' and '{name' in info['out_stream']: kw_dict['name'] = name
-            info['out_stream'] = info['out_stream'].format(**kw_dict)
+            try:
+                info['out_stream'] = info['out_stream'].format(**kw_dict)
+            except KeyError as msg:
+                raise KeyError(f"variable {msg} dereferenced in 'out_stream' not defined in kw_dict")
             info['out_stream'] = os.path.expandvars(info['out_stream'])
 
 

--- a/tests/raw/configs/fc-out-spec.json
+++ b/tests/raw/configs/fc-out-spec.json
@@ -1,0 +1,8 @@
+{
+    "FCEventDecoder": {
+        "spms": {
+            "key_list": [[2, 4]],
+            "out_stream": "/tmp/L200-comm-20211130-phy-spms.lh5"
+        }
+    }
+}

--- a/tests/raw/test_build_raw.py
+++ b/tests/raw/test_build_raw.py
@@ -1,8 +1,10 @@
+import os.path
+from pathlib import Path
+
+import pytest
+
 import pygama.raw as raw
 from pygama.lgdo.lh5_store import LH5Store, ls
-import os.path
-import pytest
-from pathlib import Path
 
 config_dir = Path(__file__).parent/'configs'
 

--- a/tests/raw/test_build_raw.py
+++ b/tests/raw/test_build_raw.py
@@ -1,0 +1,75 @@
+import pygama.raw as raw
+from pygama.lgdo.lh5_store import LH5Store, ls
+import os.path
+import pytest
+from pathlib import Path
+
+config_dir = Path(__file__).parent/'configs'
+
+
+def test_build_raw_basics(lgnd_test_data):
+    with pytest.raises(FileNotFoundError):
+        raw.build_raw(in_stream='non-existent-file')
+
+    with pytest.raises(FileNotFoundError):
+        raw.build_raw(in_stream=lgnd_test_data.get_path('fcio/L200-comm-20211130-phy-spms.fcio'),
+                      out_spec='non-existent-file.json')
+
+
+def test_build_raw_fc(lgnd_test_data):
+    raw.build_raw(in_stream=lgnd_test_data.get_path('fcio/L200-comm-20211130-phy-spms.fcio'))
+
+    assert lgnd_test_data.get_path('fcio/L200-comm-20211130-phy-spms.lh5') != ''
+
+    out_file = '/tmp/L200-comm-20211130-phy-spms.lh5'
+
+    raw.build_raw(in_stream=lgnd_test_data.get_path('fcio/L200-comm-20211130-phy-spms.fcio'),
+                  out_spec=out_file)
+
+    assert os.path.exists('/tmp/L200-comm-20211130-phy-spms.lh5')
+
+
+def test_build_raw_fc_out_spec(lgnd_test_data):
+    out_file = '/tmp/L200-comm-20211130-phy-spms.lh5'
+    out_spec = {
+      'FCEventDecoder': {
+        'spms': {
+          'key_list': [[2, 4]],
+          'out_stream': out_file
+        }
+      }
+    }
+
+    raw.build_raw(in_stream=lgnd_test_data.get_path('fcio/L200-comm-20211130-phy-spms.fcio'),
+                  out_spec=out_spec, n_max=10)
+
+    store = LH5Store()
+    lh5_obj, n_rows = store.read_object('/spms', out_file)
+    assert n_rows == 10
+    assert (lh5_obj['channel'].nda == [2, 3, 4, 2, 3, 4, 2, 3, 4, 2]).all()
+
+    raw.build_raw(in_stream=lgnd_test_data.get_path('fcio/L200-comm-20211130-phy-spms.fcio'),
+                  out_spec=f'{config_dir}/fc-out-spec.json', n_max=10)
+
+
+def test_build_raw_fc_channelwise_out_spec(lgnd_test_data):
+    out_file = '/tmp/L200-comm-20211130-phy-spms.lh5'
+    out_spec = {
+      'FCEventDecoder': {
+        's{key}': {
+          'key_list': [[0, 6]],
+          'out_stream': out_file
+        }
+      }
+    }
+
+    raw.build_raw(in_stream=lgnd_test_data.get_path('fcio/L200-comm-20211130-phy-spms.fcio'),
+                  out_spec=out_spec)
+
+    assert ls(out_file) == ['s0', 's1', 's2', 's3', 's4', 's5']
+
+
+def test_build_raw_overwrite(lgnd_test_data):
+    with pytest.raises(RuntimeError):
+        raw.build_raw(in_stream=lgnd_test_data.get_path('fcio/L200-comm-20211130-phy-spms.fcio'),
+                      overwrite=False)

--- a/tests/raw/test_raw_buffer.py
+++ b/tests/raw/test_raw_buffer.py
@@ -1,44 +1,71 @@
 import json
 
-import pytest
-
 import pygama.raw.raw_buffer as prb
-from pygama.raw.fc.fc_event_decoder import FCEventDecoder
 
 
-def test_rb_json_load():
+def test_raw_buffer_list():
+    rbl = prb.RawBufferList()
+    rbl.set_from_json_dict(
+        {
+            "g{key:0>3d}": {
+                "key_list": [[3, 6]],
+                "out_stream": "$DATADIR/{file_key}_geds.lh5"
+            }
+        },
+        kw_dict={'file_key': 'run0'}
+    )
+    assert len(rbl) == 4
+    assert rbl[1].out_stream == '$DATADIR/run0_geds.lh5'
+    assert rbl.get_list_of('out_name') == ['g003', 'g004', 'g005', 'g006']
+    assert rbl.get_list_of('key_list') == [[3], [4], [5], [6]]
 
-    rb_json = '''
+    rbl.clear()
+    rbl.set_from_json_dict(
+        {
+            "spms": {
+                "key_list": [[3, 6]],
+                "out_stream": "$DATADIR/{file_key}_geds.lh5",
+                "out_name": "testspms"
+            }
+        },
+        kw_dict={'file_key': 'run0'}
+    )
+    assert rbl.get_list_of('out_name') == ['testspms']
+    assert rbl.get_list_of('key_list') == [[3, 4, 5, 6]]
+
+
+def test_raw_buffer_lib_json_load():
+
+    rb_json = """
     {
-      "FlashCamEventDecoder" : {
+      "FCEventDecoder" : {
         "g{key:0>3d}" : {
-          "key_list" : [ [24,64] ],
+          "key_list" : [[24, 64]],
           "out_stream" : "$DATADIR/{file_key}_geds.lh5:/geds"
         },
         "spms" : {
-          "key_list" : [ [6,23] ],
+          "key_list" : [[6, 23]],
           "out_stream" : "$DATADIR/{file_key}_spms.lh5"
         },
         "puls" : {
-          "key_list" : [ 0 ],
+          "key_list" : [0],
           "out_stream" : "$DATADIR/{file_key}_auxs.lh5:/auxs"
         },
         "muvt" : {
-          "key_list" : [ 1, 5 ],
+          "key_list" : [1, 5],
           "out_stream" : "$DATADIR/{file_key}_auxs.lh5:/auxs"
         }
       },
       "*" : {
         "{name}" : {
-          "key_list" : [ "*" ],
+          "key_list" : ["*"],
           "out_stream" : "$DATADIR/{file_key}_others.lh5"
         }
       }
     }
-    '''
+    """
     json_dict = json.loads(rb_json)
-    kw_dict = {'file_key': 'run0'}
-    rblib = prb.RawBufferLibrary(json_dict=json_dict, kw_dict=kw_dict)
-    rb_keyed = rblib['FlashCamEventDecoder'].get_keyed_dict()
+    rblib = prb.RawBufferLibrary(json_dict=json_dict, kw_dict={'file_key': 'run0'})
+    rb_keyed = rblib['FCEventDecoder'].get_keyed_dict()
     name = rb_keyed[41].out_name
     assert name == 'g041'


### PR DESCRIPTION
I replaced some `print('error'); return` with exception raising. We should try to do this more consistently.