### PR TITLE
Use `logging` module in `pygama.raw`, add CLI

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,7 @@ author = The LEGEND collaboration
 maintainer = The LEGEND collaboration
 license = Apache-2.0
 license_file = LICENSE
+license_files = LICENSE
 classifiers =
     Development Status :: 4 - Beta
     Intended Audience :: Developers
@@ -52,6 +53,10 @@ zip_safe = False
 
 [options.packages.find]
 where = src
+
+[options.entry_points]
+console_scripts =
+    pygama = pygama.cli:pygama_cli
 
 [options.extras_require]
 all =

--- a/src/pygama/__init__.py
+++ b/src/pygama/__init__.py
@@ -4,3 +4,7 @@ Check out the `online documentation <https://legend-exp.github.io/pygama>`_
 """
 
 from pygama._version import version as __version__
+
+__all__ = [
+    "__version__"
+]

--- a/src/pygama/cli.py
+++ b/src/pygama/cli.py
@@ -1,0 +1,84 @@
+import sys
+import argparse
+import numpy as np
+import logging
+
+import pygama
+from pygama.raw import build_raw
+from pygama.dsp import build_dsp
+
+
+def pygama_cli():
+    parser = argparse.ArgumentParser(
+        prog='pygama',
+        description="pygama's command-line interface")
+
+    # global options
+    parser.add_argument('--version', '-v', action='store_true',
+                        help="""Print pygama version and exit""")
+    parser.add_argument('--verbose', action='store_true',
+                        help="""Increase the program verbosity""")
+
+    subparsers = parser.add_subparsers()
+
+    # build_raw interface
+    parser_d2r = subparsers.add_parser(
+        'daq2raw', description="""Convert data into LEGEND HDF5 (LH5) raw format""")
+    parser_d2r.add_argument('in_stream', nargs='+',
+                            help="""Input stream. Can be a single file, a list
+                            of files or any other input type supported by the
+                            selected streamer""")
+    parser_d2r.add_argument('--stream-type', '-t', nargs=1,
+                            help="""Input stream type name. Use this if the
+                            stream type cannot be automatically deduced by
+                            pygama""")
+    parser_d2r.add_argument('--out-spec', '-o', nargs=1,
+                            help="""Specification for the output stream. HDF5
+                            or JSON file name""")
+    parser_d2r.add_argument('--buffer_size', '-b', type=int, default=8192,
+                            help="""Set buffer size""")
+    parser_d2r.add_argument('--max-rows', '-n', type=int, default=np.inf,
+                            help="""Maximum number of rows of data to process
+                            from the input file""")
+    parser_d2r.add_argument('--overwrite', '-w', action='store_true',
+                            help="""Overwrite output files""")
+
+    parser_d2r.set_defaults(func=build_raw_cli)
+
+    # TODO: build_dsp interface
+    parser_r2d = subparsers.add_parser(
+        'raw2dsp', description="""Process LH5 raw files and produce a
+        dsp file using a JSON configuration""")
+
+    parser_r2d.set_defaults(func=build_dsp_cli)
+
+    if len(sys.argv) < 2:
+        parser.print_usage(sys.stderr)
+        sys.exit(1)
+
+    args = parser.parse_args()
+
+    if args.verbose:
+        logging.basicConfig(level=logging.DEBUG,
+                            format="%(name)s [%(levelname)s] %(message)s")
+    if args.version:
+        print(pygama.__version__)
+        sys.exit()
+
+    args.func(args)
+
+
+def build_raw_cli(args):
+    for stream in args.in_stream:
+        build_raw(stream, in_stream_type=args.stream_type,
+                  out_spec=args.out_spec, buffer_size=args.buffer_size,
+                  n_max=args.max_rows, overwrite=args.overwrite)
+
+
+def build_dsp_cli(args):
+    for file in args.files:
+        build_dsp(file, args.output, args.jsonconfig, lh5_tables=args.group,
+                  database=args.dbfile, verbose=args.verbose,
+                  outputs=args.outpar, n_max=args.nevents,
+                  write_mode=args.writemode, buffer_len=args.chunk,
+                  block_width=args.block)

--- a/src/pygama/raw/data_decoder.py
+++ b/src/pygama/raw/data_decoder.py
@@ -26,7 +26,7 @@ class DataDecoder(ABC):
     DataDecoder and define how data gets formatted into lgdo's
 
     Subclasses should define a method for decoding data to a buffer like
-    decode_packet(packet, raw_buffer_list, packet_id, verbosity=0)
+    decode_packet(packet, raw_buffer_list, packet_id)
     This function should return the number of bytes read
 
     Garbage collection writes binary data as an array of uint32s to a
@@ -66,9 +66,8 @@ class DataDecoder(ABC):
         """
         if key is None:
             return self.decoded_values if hasattr(self, 'decoded_values') else None
-        name = type(self).__name__
-        print("You need to implement key-specific get_decoded_values for", name)
-        return None
+
+        raise NotImplementedError("you need to implement key-specific get_decoded_values for", type(self).__name__)
 
 
     def make_lgdo(self, key=None, size=None):
@@ -94,9 +93,7 @@ class DataDecoder(ABC):
         """
 
         if not hasattr(self, 'decoded_values'):
-            name = type(self).__name__
-            print(name, 'Error: no decoded_values available for setting up table')
-            return None
+            raise AttributeError(type(self).__name__, ':no decoded_values available for setting up table')
 
         data_obj = lgdo.Table(size=size)
         dec_vals = self.get_decoded_values(key)
@@ -107,9 +104,8 @@ class DataDecoder(ABC):
 
             # get the dtype
             if 'dtype' not in attrs:
-                name = type(self).__name__
-                print(name, 'Error: must specify dtype for', field)
-                continue
+                raise AttributeError(type(self).__name__, ': must specify dtype for', field)
+
             dtype = attrs.pop('dtype')
 
             # no datatype: just a "normal" array
@@ -158,8 +154,8 @@ class DataDecoder(ABC):
                 continue
 
             # if we get here, got a bad datatype
-            name = type(self).__name__
-            print(name, 'Error: do not know how to make a', datatype, 'for', field)
+            raise RuntimeError(type(self).__name__, ': do not know how to make a', datatype, 'for', field)
+
         return data_obj
 
 

--- a/src/pygama/raw/data_streamer.py
+++ b/src/pygama/raw/data_streamer.py
@@ -1,6 +1,9 @@
+import logging
 from abc import ABC
 
 from .raw_buffer import RawBuffer, RawBufferLibrary, RawBufferList
+
+log = logging.getLogger(__name__)
 
 
 class DataStreamer(ABC):
@@ -29,7 +32,7 @@ class DataStreamer(ABC):
 
 
     def open_stream(self, stream_name, rb_lib=None, buffer_size=8192,
-                    chunk_mode='any_full', out_stream='', verbosity=0):
+                    chunk_mode='any_full', out_stream=''):
         """ Open and initialize a data stream
 
         Open the stream, read in the header, set up the buffers
@@ -56,8 +59,6 @@ class DataStreamer(ABC):
             sets the mode use for read_chunk
         out_stream : str
             optional name of output stream for default rb_lib generation
-        verbosity : int
-            verbosity level for the initialize function
 
         Returns
         -------
@@ -123,11 +124,11 @@ class DataStreamer(ABC):
         if '*' in rb_lib: rb_lib.pop('*')
         for dec_name in rb_lib.keys():
             if dec_name not in dec_names:
-                print(f"Warning: no decoder named {dec_name} requested by rb_lib")
+                log.warning("no decoder named {dec_name} requested by rb_lib")
 
 
 
-    def read_packet(self, verbosity=0):
+    def read_packet(self):
         """
         Reads a single packet's worth of data in to the rb_lib
 
@@ -146,7 +147,7 @@ class DataStreamer(ABC):
         return True
 
 
-    def read_chunk(self, chunk_mode_override=None, rp_max=1000000, clear_full_buffers=True, verbosity=0):
+    def read_chunk(self, chunk_mode_override=None, rp_max=1000000, clear_full_buffers=True):
         """
         Reads a chunk of data into raw buffers
 
@@ -177,8 +178,6 @@ class DataStreamer(ABC):
             automatically clear any buffers that report themselves as being full
             prior to reading the chunk. Set to False if clearing manually for a
             minor speed-up
-        verbosity : int
-            verbosity level for the initialize function
 
         Returns
         -------
@@ -194,7 +193,6 @@ class DataStreamer(ABC):
         self.any_full = False
 
         chunk_mode = self.chunk_mode if chunk_mode_override is None else chunk_mode_override
-        if verbosity>1: print(f'reading chunk with chunk_mode {chunk_mode}')
 
         read_one_packet = (chunk_mode == 'single_packet')
         only_full = (chunk_mode == 'only_full')
@@ -202,7 +200,7 @@ class DataStreamer(ABC):
         n_packets = 0
         still_has_data = True
         while True:
-            still_has_data = self.read_packet(verbosity=verbosity-1)
+            still_has_data = self.read_packet()
             if not still_has_data: break
             n_packets += 1
             if read_one_packet or n_packets > rp_max: break
@@ -239,7 +237,7 @@ class DataStreamer(ABC):
         rb_lib = RawBufferLibrary()
         decoders = self.get_decoder_list()
         if len(decoders) == 0:
-            print(f'No decoders returned by get_decoder_list() for {type(self).__name__}')
+            log.warning(f'no decoders returned by get_decoder_list() for {type(self).__name__}')
             return rb_lib
         for decoder in decoders:
             dec_name = type(decoder).__name__

--- a/src/pygama/raw/fc/fc_config_decoder.py
+++ b/src/pygama/raw/fc/fc_config_decoder.py
@@ -1,4 +1,8 @@
+import logging
+
 from pygama import lgdo
+
+log = logging.getLogger(__name__)
 
 from ..data_decoder import *
 
@@ -36,7 +40,7 @@ class FCConfigDecoder(DataDecoder):
         ]
         for name in config_names:
             if name in self.config:
-                print(f'warning: {name} already in self.config. skipping...')
+                log.warning(f'{name} already in self.config. skipping...')
                 continue
             value = np.int32(getattr(fcio, name)) # all config fields are int32
             self.config.add_field(name, lgdo.Scalar(value))

--- a/src/pygama/raw/fc/fc_status_decoder.py
+++ b/src/pygama/raw/fc/fc_status_decoder.py
@@ -69,7 +69,7 @@ class FCStatusDecoder(DataDecoder):
 
 
 
-    def decode_packet(self, fcio, status_rb, packet_id, verbosity=0):
+    def decode_packet(self, fcio, status_rb, packet_id):
         """
         access FC status (temp., log, ...)
         """

--- a/src/pygama/raw/raw_buffer.py
+++ b/src/pygama/raw/raw_buffer.py
@@ -347,7 +347,7 @@ def expand_rblist_json_dict(json_dict, kw_dict):
             info['out_stream'] = os.path.expandvars(info['out_stream'])
 
 
-def write_to_lh5_and_clear(raw_buffers, lh5_store=None, wo_mode='append', verbosity=0):
+def write_to_lh5_and_clear(raw_buffers, lh5_store=None, wo_mode='append'):
     """Write a list of RawBuffers to lh5 files and then clears them
 
     Parameters
@@ -360,8 +360,6 @@ def write_to_lh5_and_clear(raw_buffers, lh5_store=None, wo_mode='append', verbos
         files (saves some time opening / closing files)
     wo_mode : str
         write mode, see also :meth:`.lgdo.lh5_store.LH5Store.write_object`
-    verbosity : bool
-        print debug messages
     """
     if lh5_store is None: lh5_store = lgdo.LH5Store()
     for rb in raw_buffers:
@@ -377,6 +375,6 @@ def write_to_lh5_and_clear(raw_buffers, lh5_store=None, wo_mode='append', verbos
         # write if requested...
         if filename != '':
             lh5_store.write_object(rb.lgdo, rb.out_name, filename, group=group,
-                                   n_rows=rb.loc, wo_mode=wo_mode, verbosity=verbosity)
+                                   n_rows=rb.loc, wo_mode=wo_mode)
         # and clear
         rb.loc = 0


### PR DESCRIPTION
* Verbosity in `raw` is now managed through the logging module, allowing for a much advanced user configuration. Will do the same for the rest of pygama in future PRs
* Add command line interface, accessible through the `pygama` shell command. Available for `build_raw` only at the moment. Will add `build_dsp` etc in future PRs
* `pygama --verbose ...` increases the verbosity level. In user scripts, verbosity must be configured by the user via the `logging` module, for example:
```py
import logging
logging.basicConfig(level=logging.DEBUG, format="%(name)s [%(levelname)s] %(message)s")

import pygama
...
```