### PR TITLE
Friendly `build_raw` command line interface

### DIFF
--- a/src/pygama/cli.py
+++ b/src/pygama/cli.py
@@ -1,7 +1,7 @@
 import argparse
 import logging
-import sys
 import os
+import sys
 
 import numpy as np
 

--- a/src/pygama/cli.py
+++ b/src/pygama/cli.py
@@ -1,6 +1,7 @@
 import argparse
 import logging
 import sys
+import os
 
 import numpy as np
 
@@ -15,9 +16,9 @@ def pygama_cli():
         description="pygama's command-line interface")
 
     # global options
-    parser.add_argument('--version', '-v', action='store_true',
+    parser.add_argument('--version', action='store_true',
                         help="""Print pygama version and exit""")
-    parser.add_argument('--verbose', action='store_true',
+    parser.add_argument('--verbose', '-v', action='store_true',
                         help="""Increase the program verbosity""")
 
     subparsers = parser.add_subparsers()
@@ -29,11 +30,11 @@ def pygama_cli():
                             help="""Input stream. Can be a single file, a list
                             of files or any other input type supported by the
                             selected streamer""")
-    parser_d2r.add_argument('--stream-type', '-t', nargs=1,
+    parser_d2r.add_argument('--stream-type', '-t',
                             help="""Input stream type name. Use this if the
                             stream type cannot be automatically deduced by
                             pygama""")
-    parser_d2r.add_argument('--out-spec', '-o', nargs=1,
+    parser_d2r.add_argument('--out-spec', '-o',
                             help="""Specification for the output stream. HDF5
                             or JSON file name""")
     parser_d2r.add_argument('--buffer_size', '-b', type=int, default=8192,
@@ -62,6 +63,10 @@ def pygama_cli():
     if args.verbose:
         logging.basicConfig(level=logging.DEBUG,
                             format="%(name)s [%(levelname)s] %(message)s")
+    else:
+        logging.basicConfig(level=logging.INFO,
+                            format="%(name)s [%(levelname)s] %(message)s")
+
     if args.version:
         print(pygama.__version__)
         sys.exit()
@@ -71,9 +76,11 @@ def pygama_cli():
 
 def build_raw_cli(args):
     for stream in args.in_stream:
+        basename = os.path.splitext(os.path.basename(stream))[0]
         build_raw(stream, in_stream_type=args.stream_type,
                   out_spec=args.out_spec, buffer_size=args.buffer_size,
-                  n_max=args.max_rows, overwrite=args.overwrite)
+                  n_max=args.max_rows, overwrite=args.overwrite,
+                  orig_basename=basename)
 
 
 def build_dsp_cli(args):

--- a/src/pygama/raw/build_raw.py
+++ b/src/pygama/raw/build_raw.py
@@ -209,7 +209,7 @@ def build_raw(in_stream, in_stream_type=None, out_spec=None, buffer_size=8192,
             log.info(f"output file: {out_file} (not written)")
     else:
         log.info("output files:")
-        unique_outfilenames = set([file.split(':', 1)[0] for file in out_files])
+        unique_outfilenames = {file.split(':', 1)[0] for file in out_files}
         for out_file in unique_outfilenames:
             if os.path.exists(out_file):
                 file_size = os.stat(out_file).st_size

--- a/tests/raw/configs/orca-out-spec-cli.json
+++ b/tests/raw/configs/orca-out-spec-cli.json
@@ -1,0 +1,8 @@
+{
+    "ORFlashCamADCWaveformDecoder": {
+        "g{key}": {
+            "key_list": [[0, 3]],
+            "out_stream": "/tmp/{orig_basename}.lh5"
+        }
+    }
+}

--- a/tests/raw/test_cli.py
+++ b/tests/raw/test_cli.py
@@ -1,6 +1,6 @@
-from pathlib import Path
 import os
 import subprocess
+from pathlib import Path
 
 config_dir = Path(__file__).parent/'configs'
 

--- a/tests/raw/test_cli.py
+++ b/tests/raw/test_cli.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import os
 import subprocess
 
 config_dir = Path(__file__).parent/'configs'
@@ -10,8 +11,10 @@ def test_build_raw_cli(lgnd_test_data):
         'pygama', 'build-raw',
         '--overwrite',
         '--stream-type', 'ORCA',
-        '--out-spec', f'{config_dir}/orca-out-spec.json',
+        '--out-spec', f'{config_dir}/orca-out-spec-cli.json',
         '--max-rows', '10',
         '--buffer_size', '8192',
         lgnd_test_data.get_path('orca/fc/L200-comm-20220519-phy-geds.orca')
     ])
+
+    assert os.path.exists('/tmp/L200-comm-20220519-phy-geds.lh5')

--- a/tests/raw/test_cli.py
+++ b/tests/raw/test_cli.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+import subprocess
+
+config_dir = Path(__file__).parent/'configs'
+
+
+def test_build_raw_cli(lgnd_test_data):
+    subprocess.check_call(['pygama', 'build-raw', '--help'])
+    subprocess.check_call([
+        'pygama', 'build-raw',
+        '--overwrite',
+        '--stream-type', 'ORCA',
+        '--out-spec', f'{config_dir}/orca-out-spec.json',
+        '--max-rows', '10',
+        '--buffer_size', '8192',
+        lgnd_test_data.get_path('orca/fc/L200-comm-20220519-phy-geds.orca')
+    ])


### PR DESCRIPTION
I implemented a special keyword `orig_basename` that gets substituted in the config dictionary by the name of the original DAQ file (without extension). This makes it easier to quickly convert DAQ files on the command line. Example:
```console
$ cat orca-out-spec-cli.json
{
    "ORFlashCamADCWaveformDecoder": {
        "g{key}": {
            "key_list": [[0, 3]],
            "out_stream": "/tmp/{orig_basename}.lh5"
        }
    }
}
$ pygama build-raw -w -o orca-out-spec.json legend-testdata/data/orca/fc/L200-comm-20220519-phy-geds.orca
pygama.raw.build_raw [INFO] time elapsed: 0.04 sec
pygama.raw.build_raw [INFO] output file: /tmp/L200-comm-20220519-phy-geds.lh5 (682.289 KB)
pygama.raw.build_raw [INFO] total converted: 988.125 KB
pygama.raw.build_raw [INFO] conversion speed: 26.420 MBps
```
What do you think @jasondet? There was no way to re-use the original filename in `out_stream` otherwise.