### PR TITLE
Added ArrayOfEqualSizedArray support to ProcessingChain and WaveformBrowser

### DIFF
--- a/src/pygama/dsp/processing_chain.py
+++ b/src/pygama/dsp/processing_chain.py
@@ -396,6 +396,8 @@ class ProcessingChain:
                                           dtype=var.dtype)
             elif len(var.shape) == 0:
                 buff = lgdo.Array(shape=(self._buffer_len), dtype=var.dtype)
+            elif len(var.shape) > 0:
+                buff = lgdo.ArrayOfEqualSizedArrays(shape=(self._buffer_len, *var.shape), dtype=var.dtype)
             else:
                 buff = np.ndarray((self._buffer_len,) + var.shape, var.dtype)
 
@@ -404,6 +406,8 @@ class ProcessingChain:
             out_man = NumpyIOManager(buff, var)
         elif isinstance(buff, lgdo.Array):
             out_man = LGDOArrayIOManager(buff, var)
+        elif isinstance(buff, lgdo.ArrayOfEqualSizedArrays):
+            out_man = LGDOArrayOfEqualSizedArraysIOManager(buff, var)
         elif isinstance(buff, lgdo.WaveformTable):
             out_man = LGDOWaveformIOManager(buff, var)
         else:
@@ -450,6 +454,8 @@ class ProcessingChain:
                                           dtype=var.dtype)
             elif len(var.shape) == 0:
                 buff = lgdo.Array(shape=(self._buffer_len), dtype=var.dtype)
+            elif len(var.shape) > 0:
+                buff = lgdo.ArrayOfEqualSizedArrays(shape=(self._buffer_len, *var.shape), dtype=var.dtype)
             else:
                 buff = np.ndarray((self._buffer_len,) + var.shape, var.dtype)
 
@@ -458,6 +464,8 @@ class ProcessingChain:
             out_man = NumpyIOManager(buff, var)
         elif isinstance(buff, lgdo.Array):
             out_man = LGDOArrayIOManager(buff, var)
+        elif isinstance(buff, lgdo.ArrayOfEqualSizedArrays):
+            out_man = LGDOArrayOfEqualSizedArraysIOManager(buff, var)
         elif isinstance(buff, lgdo.WaveformTable):
             out_man = LGDOWaveformIOManager(buff, var)
         else:
@@ -1045,6 +1053,7 @@ class IOManager(metaclass=ABCMeta):
 
 # Ok, this one's not LGDO
 class NumpyIOManager(IOManager):
+    """IO Manager for buffers that are numpy arrays"""
     def __init__(self, io_buf: np.array, var: ProcChainVar):
         assert isinstance(io_buf, np.ndarray) \
             and isinstance(var, ProcChainVar)
@@ -1078,8 +1087,55 @@ class NumpyIOManager(IOManager):
 
 
 class LGDOArrayIOManager(IOManager):
-    def __init__(self, io_array: np.array, var: ProcChainVar) -> None:
+    """IO Manager for buffers that are lgdo Arrays"""
+    def __init__(self, io_array: lgdo.Array, var: ProcChainVar) -> None:
         assert isinstance(io_array, lgdo.Array) \
+            and isinstance(var, ProcChainVar)
+
+        unit = io_array.attrs.get('units', None)
+        var.update_auto(dtype=io_array.dtype,
+                        shape=io_array.nda.shape[1:],
+                        unit=unit)
+
+        if var.shape != io_array.nda.shape[1:] or var.dtype != io_array.dtype:
+            raise ProcessingChainError(
+                f"LGDO object "
+                f"{self.io_buf.form_datatype()}@{self.raw_buf.data} is "
+                f"incompatible with {str(self.var)}")
+
+        if isinstance(var.unit, CoordinateGrid):
+            if unit is None:
+                unit = var.unit.period.u
+            elif ureg.is_compatible_with(var.unit.period, unit):
+                unit = ureg.Quantity(unit).u
+            else:
+                raise ProcessingChainError(
+                    f"LGDO array and variable {var} have incompatible units "
+                    f"({var.unit.period.u} and {unit})")
+
+        if unit is None and var.unit is not None:
+            io_array.attrs['units'] = str(var.unit)
+
+        self.io_array = io_array
+        self.raw_buf = io_array.nda
+        self.var = var
+        self.raw_var = var.get_buffer(unit)
+
+    def read(self, start: int, end: int) -> None:
+        np.copyto(self.raw_var[0:end-start, ...],
+                  self.raw_buf[start:end, ...], 'unsafe')
+
+    def write(self, start: int, end: int) -> None:
+        np.copyto(self.raw_buf[start:end, ...],
+                  self.raw_var[0:end-start, ...], 'unsafe')
+
+    def __str__(self) -> str:
+        return f'{self.var} linked to {self.io_array}'
+
+class LGDOArrayOfEqualSizedArraysIOManager(IOManager):
+    """IO Manager for buffers that are numpy ArrayOfEqualSizedArrays"""
+    def __init__(self, io_array: np.ArrayOfEqualSizedArrays, var: ProcChainVar) -> None:
+        assert isinstance(io_array, lgdo.ArrayOfEqualSizedArrays) \
             and isinstance(var, ProcChainVar)
 
         unit = io_array.attrs.get('units', None)

--- a/src/pygama/dsp/processing_chain.py
+++ b/src/pygama/dsp/processing_chain.py
@@ -404,10 +404,10 @@ class ProcessingChain:
         # Add the buffer to the input buffers list
         if isinstance(buff, np.ndarray):
             out_man = NumpyIOManager(buff, var)
-        elif isinstance(buff, lgdo.Array):
-            out_man = LGDOArrayIOManager(buff, var)
         elif isinstance(buff, lgdo.ArrayOfEqualSizedArrays):
             out_man = LGDOArrayOfEqualSizedArraysIOManager(buff, var)
+        elif isinstance(buff, lgdo.Array):
+            out_man = LGDOArrayIOManager(buff, var)
         elif isinstance(buff, lgdo.WaveformTable):
             out_man = LGDOWaveformIOManager(buff, var)
         else:
@@ -462,10 +462,10 @@ class ProcessingChain:
         # Add the buffer to the output buffers list
         if isinstance(buff, np.ndarray):
             out_man = NumpyIOManager(buff, var)
-        elif isinstance(buff, lgdo.Array):
-            out_man = LGDOArrayIOManager(buff, var)
         elif isinstance(buff, lgdo.ArrayOfEqualSizedArrays):
             out_man = LGDOArrayOfEqualSizedArraysIOManager(buff, var)
+        elif isinstance(buff, lgdo.Array):
+            out_man = LGDOArrayIOManager(buff, var)
         elif isinstance(buff, lgdo.WaveformTable):
             out_man = LGDOWaveformIOManager(buff, var)
         else:

--- a/src/pygama/vis/waveform_browser.py
+++ b/src/pygama/vis/waveform_browser.py
@@ -349,10 +349,16 @@ class WaveformBrowser:
             # Get the data; note this is implicitly copying it!
             data = self.lh5_out.get(name, None)
             if isinstance(data, lh5.WaveformTable):
-                y = data.values.nda[i_tb,:]/norm - ref_time
+                y = data.values.nda[i_tb,:]/norm
                 dt = data.dt.nda[i_tb] * float(ureg(data.dt_units)/self.x_unit)
-                t0 = data.t0.nda[i_tb] * float(ureg(data.t0_units)/self.x_unit)
+                t0 = data.t0.nda[i_tb] * float(ureg(data.t0_units)/self.x_unit) - ref_time
                 x = np.linspace(t0, t0+dt*(data.wf_len-1), data.wf_len)
+                lines.append(Line2D(x, y))
+                self._update_auto_limit(x, y)
+
+            elif isinstance(data, lh5.ArrayOfEqualSizedArrays):
+                y = data.nda[i_tb,:]/norm
+                x = np.arange(len(y), dtype='float')
                 lines.append(Line2D(x, y))
                 self._update_auto_limit(x, y)
 


### PR DESCRIPTION
This will solve the problem from this issue: https://github.com/legend-exp/pygama/issues/317

Note that I still have to add VectorOfVector support. This means that values that are best represented by VectorOfVectors will for now be NaN-padded ArraysOfArrays.