### PR TITLE
First implementation of `build_hit`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ install_requires =
     iminuit
     matplotlib
     numba!=0.53.*,!=0.54.*
+    numexpr
     numpy>=1.21
     pandas
     parse

--- a/src/pygama/hit/__init__.py
+++ b/src/pygama/hit/__init__.py
@@ -1,3 +1,8 @@
 """
-Subpackage description.
+Routines for applying columnar transformations to tabular data. Specifically,
+to produce the hit-tier from the dsp-tier.
 """
+
+from pygama.hit.build_hit import build_hit
+
+__all__ = ["build_hit"]

--- a/src/pygama/hit/build_hit.py
+++ b/src/pygama/hit/build_hit.py
@@ -1,1 +1,92 @@
-# placeholder
+"""
+This module implements routines to evaluate expressions to columnar data.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from collections import OrderedDict
+
+import numpy as np
+
+from pygama.lgdo import LH5Iterator, LH5Store, ls
+
+log = logging.getLogger(__name__)
+
+
+def build_hit(
+    infile: str,
+    hit_config: str | dict,
+    outfile: str = None,
+    lh5_tables: list[str] = None,
+    n_max: int = np.inf,
+    wo_mode: str = None,
+    buffer_len: int = 3200,
+) -> None:
+    """
+    Transform a :class:`~.lgdo.Table` into a new :class:`~.lgdo.Table` by
+    evaluating strings describing column operations.
+
+    Operates on columns only, not specific rows or elements.
+
+    Parameters
+    ----------
+    infile
+        input LH5 file name containing tables to be processed.
+    hit_config
+        dictionary or name of JSON file defining column transformations.
+    outfile
+        name of the output LH5 file. If ``None``, create a file in the same
+        directory and append `_hit` to its name.
+    lh5_tables
+        tables to consider in the input file. if ``None``, tables with name
+        `dsp` will be searched for in the file, even nested by one level.
+    n_max
+        maximum number of rows to process
+    wo_mode
+        - ``None`` -- create new output file if it does not exist
+        - `'r'` -- delete existing output file with same name before writing
+        - `'a'` -- append to end of existing output file
+        - `'u'` -- update values in existing output file
+    """
+    store = LH5Store()
+
+    if lh5_tables is None:
+        if "dsp" in ls(infile):
+            lh5_tables.append("dsp")
+        for el in ls(infile):
+            if "dsp" in ls(infile, el):
+                lh5_tables.append(f"{el}/dsp")
+
+    if outfile is None:
+        outfile = os.path.splitext(os.path.basename(infile))[0]
+        outfile = outfile.removesuffix("_dsp") + "_hit.lh5"
+
+    if isinstance(hit_config, str):
+        with open(hit_config) as f:
+            hit_config = json.load(f, object_pairs_hook=OrderedDict)
+
+    for tbl in lh5_tables:
+        lh5_it = LH5Iterator(infile, tbl, buffer_len=buffer_len)
+        tot_n_rows = store.read_n_rows(tbl, infile)
+        write_offset = 0
+        store.gimme_file(outfile, "a")
+        if wo_mode == "a" and ls(infile, tbl):
+            write_offset = store.read_n_rows(tbl, outfile)
+
+        log.info(f"Processing table '{tbl}' in file {infile}")
+
+        for tbl_obj, start_row, n_rows in lh5_it:
+            n_rows = min(tot_n_rows - start_row, n_rows)
+
+            outtbl_obj = tbl_obj.eval(hit_config)
+
+            store.write_object(
+                obj=outtbl_obj,
+                name=tbl,
+                lh5_file=outfile,
+                n_rows=n_rows,
+                wo_mode=wo_mode,
+                write_start=write_offset + start_row,
+            )

--- a/src/pygama/lgdo/__init__.py
+++ b/src/pygama/lgdo/__init__.py
@@ -32,7 +32,7 @@ browsed easily in python like any `HDF5 <https://www.hdfgroup.org>`_ file using
 from pygama.lgdo.array import Array
 from pygama.lgdo.arrayofequalsizedarrays import ArrayOfEqualSizedArrays
 from pygama.lgdo.fixedsizearray import FixedSizeArray
-from pygama.lgdo.lh5_store import LH5Store, load_dfs, load_nda, ls
+from pygama.lgdo.lh5_store import LH5Iterator, LH5Store, load_dfs, load_nda, ls
 from pygama.lgdo.scalar import Scalar
 from pygama.lgdo.struct import Struct
 from pygama.lgdo.table import Table
@@ -54,6 +54,7 @@ __all__ = [
     "Table",
     "VectorOfVectors",
     "WaveformTable",
+    "LH5Iterator",
     "LH5Store",
     "load_dfs",
     "load_nda",

--- a/src/pygama/lgdo/table.py
+++ b/src/pygama/lgdo/table.py
@@ -95,8 +95,8 @@ class Table(Struct):
             elif len(obj) != new_size:
                 if do_warn:
                     log.warning(
-                        f"warning: resizing field {field}",
-                        f"with size {len(obj)} != {new_size}",
+                        f"warning: resizing field {field}"
+                        f"with size {len(obj)} != {new_size}"
                     )
                 if isinstance(obj, Table):
                     obj.resize(new_size)
@@ -205,3 +205,63 @@ class Table(Struct):
                 df[col] = self[col].nda
 
         return df
+
+    def eval(self, expr_config: dict) -> Table:
+        """Apply column operations to the table and return a new table holding
+        the resulting columns.
+
+        Currently defers all the job to :meth:`pandas.DataFrame.eval`. This
+        might change in the future.
+
+        Parameters
+        ----------
+        expr_config
+            dictionary that configures expressions according the following
+            specification:
+
+            .. code-block:: js
+
+                {
+                    "O1": {
+                        "expression": "@p1 + @p2 * a**2",
+                        "parameters": {
+                            "p1": "2",
+                            "p2": "3"
+                        }
+                    },
+                    "O2": {
+                        "expression": "O1 - b"
+                    }
+                    // ...
+                }
+
+            where:
+
+            - ``expression`` is an expression string supported by
+              :meth:`pandas.DataFrame.eval` (see also `here
+              <https://pandas.pydata.org/pandas-docs/stable/user_guide/enhancingperf.html#expression-evaluation-via-eval>`_
+              for documentation).
+            - ``parameters`` is a dictionary of function parameters. Passed to
+              :meth:`pandas.DataFrame.eval` as `local_dict` argument.
+
+
+        Warning
+        -------
+        Blocks in `expr_config` must be ordered according to mutual dependency.
+        """
+        # don't want to modify input
+        df = self.get_dataframe().copy()
+        out_tbl = Table(size=self.size)
+
+        for out_var, spec in expr_config.items():
+            df.eval(
+                f"{out_var} = {spec['expression']}",
+                parser="pandas",
+                engine="numexpr",
+                local_dict=spec["parameters"] if "parameters" in spec else None,
+                inplace=True,
+            )
+
+            out_tbl.add_column(out_var, Array(df[out_var].to_numpy()))
+
+        return out_tbl

--- a/tests/hit/test_build_hit.py
+++ b/tests/hit/test_build_hit.py
@@ -1,0 +1,3 @@
+from pathlib import Path
+
+config_dir = Path(__file__).parent / "configs"

--- a/tests/lgdo/test_table_eval.py
+++ b/tests/lgdo/test_table_eval.py
@@ -1,0 +1,41 @@
+import numpy as np
+
+from pygama.lgdo import Array, Table
+
+
+def test_eval_dependency():
+    obj = Table(
+        col_dict={
+            "a": Array(np.array([1, 2, 3, 4], dtype=np.float32)),
+            "b": Array(np.array([5, 6, 7, 8], dtype=np.float32)),
+        }
+    )
+
+    expr_config = {
+        "O1": {"expression": "@p1 + @p2 * a**2", "parameters": {"p1": "2", "p2": "3"}},
+        "O2": {"expression": "O1 - b"},
+    }
+
+    out_tbl = obj.eval(expr_config)
+    assert list(out_tbl.keys()) == ["O1", "O2"]
+    assert (out_tbl["O1"].nda == [5, 14, 29, 50]).all()
+    assert (out_tbl["O2"].nda == [0, 8, 22, 42]).all()
+
+
+def test_eval_math_functions():
+    obj = Table(
+        col_dict={
+            "a": Array(np.array([1, 2, 3, 4], dtype=np.float32)),
+            "b": Array(np.array([5, 6, 7, 8], dtype=np.float32)),
+        }
+    )
+
+    expr_config = {
+        "O1": {
+            "expression": "exp(log(a))",
+        }
+    }
+
+    out_tbl = obj.eval(expr_config)
+    assert list(out_tbl.keys()) == ["O1"]
+    assert (out_tbl["O1"].nda == [1, 2, 3, 4]).all()


### PR DESCRIPTION
Here's a first embarassingly simple implementation and here's some context:

* added `hit.build_hit` (not tested, I'll add tests later)
* evaluating column operations is something we'd surely would like to use in different context (e.g. `build_evt`). I propose the definition of `lgdo.Table.eval`, which does the job.
* if we want this routine to be efficient, I guess we could try to vectorize column operations with Numba. This has a non trivial implementation (most painful part is perhaps string expression parsing).
* before going for the point above, I though about making profit of [`pandas.DataFrame.eval`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.eval.html), which does exactly what we need. [Here](https://pandas.pydata.org/pandas-docs/stable/user_guide/enhancingperf.html#enhancingperf-eval) are some performance notes. I forced `numexpr` as a backend, which should be advantageous with tables with number of rows > 10⁴. I'm not sure this is optimal for us.
* one first downside is that we have to adopt Pandas's expressions syntax 
* another downside of this approach I'm really not comfortable with: lack of propagation of physical units. One idea would be to use [pint-pandas](https://github.com/hgrecco/pint-pandas), which seems to offer the desired functionality. I'm not sure the tool is stable enough though.

This would be the syntax for the `build_hit` JSON config files:
```js
{
    "O1": {  // name of the output column, as in DSP config files
        "expression": "@p1 + @p2 * a**2",  // pandas wants a "@" labeling external variables
        "parameters": {
            "p1": "2",
            "p2": "3"
        }
    },
    "O2": {
        "expression": "O1 - b"
    }
    // ...
}
```

We could test this on data and evaluate the performance, before deciding on how to proceed.