### PR TITLE
More advanced `build_hit` interface

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,6 +7,7 @@ url = https://github.com/legend-exp/pygama
 author = The LEGEND collaboration
 maintainer = The LEGEND collaboration
 license = Apache-2.0
+license_file = LICENSE
 license_files = LICENSE
 classifiers =
     Development Status :: 4 - Beta

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ url = https://github.com/legend-exp/pygama
 author = The LEGEND collaboration
 maintainer = The LEGEND collaboration
 license = Apache-2.0
-license_file = LICENSE
+license_files = LICENSE
 classifiers =
     Development Status :: 4 - Beta
     Intended Audience :: Developers

--- a/src/pygama/hit/build_hit.py
+++ b/src/pygama/hit/build_hit.py
@@ -17,9 +17,10 @@ log = logging.getLogger(__name__)
 
 def build_hit(
     infile: str,
-    hit_config: str | dict,
     outfile: str = None,
+    hit_config: str | dict = None,
     lh5_tables: list[str] = None,
+    lh5_tables_config: str | dict[str] = None,
     n_max: int = np.inf,
     wo_mode: str = "write_safe",
     buffer_len: int = 3200,
@@ -34,14 +35,19 @@ def build_hit(
     ----------
     infile
         input LH5 file name containing tables to be processed.
-    hit_config
-        dictionary or name of JSON file defining column transformations.
     outfile
         name of the output LH5 file. If ``None``, create a file in the same
         directory and append `_hit` to its name.
+    hit_config
+        dictionary or name of JSON file defining column transformations.
     lh5_tables
         tables to consider in the input file. if ``None``, tables with name
         `dsp` will be searched for in the file, even nested by one level.
+    lh5_tables_config
+        dictionary or JSON file defining the mapping between LH5 tables in
+        `infile` and hit configuration. Table names can be directly mapped to
+        configuration blocks or to JSON files containing them. This option is
+        mutually exclusive with `hit_config` and `lh5_tables`.
     n_max
         maximum number of rows to process
     wo_mode
@@ -49,25 +55,46 @@ def build_hit(
     """
     store = LH5Store()
 
-    if lh5_tables is None:
-        lh5_tables = []
-        if "dsp" in ls(infile):
-            lh5_tables.append("dsp")
-        for el in ls(infile):
-            if f"{el}/dsp" in ls(infile, f"{el}/"):
-                lh5_tables.append(f"{el}/dsp")
+    if lh5_tables_config is None and hit_config is None:
+        raise ValueError("either lh5_tables_config or hit_config must be specified")
 
-    log.debug(f"found candidate tables: {lh5_tables}")
+    if lh5_tables_config is not None and (hit_config is not None or lh5_tables is not None):
+        raise ValueError("lh5_tables_config and hit_config/lh5_tables options are mutually exclusive")
+
+    if lh5_tables_config is not None:
+        tbl_cfg = lh5_tables_config
+        # sanitize config
+        if isinstance(tbl_cfg, str):
+            with open(tbl_cfg) as f:
+                tbl_cfg = json.load(f)
+
+        for (k, v) in tbl_cfg.items():
+            if isinstance(v, str):
+                with open(v) as f:
+                    # order in hit configs is important (dependencies)
+                    tbl_cfg[k] = json.load(f, object_pairs_hook=OrderedDict)
+    else:
+        if isinstance(hit_config, str):
+            # sanitize config
+            with open(hit_config) as f:
+                # order in hit configs is important (dependencies)
+                hit_config = json.load(f, object_pairs_hook=OrderedDict)
+
+        if lh5_tables is None:
+            lh5_tables_config = {}
+            if "dsp" in ls(infile):
+                log.debug("found candidate table /dsp")
+                lh5_tables_config["dsp"] = hit_config
+            for el in ls(infile):
+                if f"{el}/dsp" in ls(infile, f"{el}/"):
+                    log.debug(f"found candidate table /{el}/dsp")
+                    lh5_tables_config[f"{el}/dsp"] = hit_config
 
     if outfile is None:
         outfile = os.path.splitext(os.path.basename(infile))[0]
         outfile = outfile.removesuffix("_dsp") + "_hit.lh5"
 
-    if isinstance(hit_config, str):
-        with open(hit_config) as f:
-            hit_config = json.load(f, object_pairs_hook=OrderedDict)
-
-    for tbl in lh5_tables:
+    for (tbl, cfg) in lh5_tables_config.items():
         lh5_it = LH5Iterator(infile, tbl, buffer_len=buffer_len)
         tot_n_rows = store.read_n_rows(tbl, infile)
         write_offset = 0
@@ -77,7 +104,7 @@ def build_hit(
         for tbl_obj, start_row, n_rows in lh5_it:
             n_rows = min(tot_n_rows - start_row, n_rows)
 
-            outtbl_obj = tbl_obj.eval(hit_config)
+            outtbl_obj = tbl_obj.eval(cfg)
 
             store.write_object(
                 obj=outtbl_obj,

--- a/src/pygama/hit/build_hit.py
+++ b/src/pygama/hit/build_hit.py
@@ -58,8 +58,12 @@ def build_hit(
     if lh5_tables_config is None and hit_config is None:
         raise ValueError("either lh5_tables_config or hit_config must be specified")
 
-    if lh5_tables_config is not None and (hit_config is not None or lh5_tables is not None):
-        raise ValueError("lh5_tables_config and hit_config/lh5_tables options are mutually exclusive")
+    if lh5_tables_config is not None and (
+        hit_config is not None or lh5_tables is not None
+    ):
+        raise ValueError(
+            "lh5_tables_config and hit_config/lh5_tables options are mutually exclusive"
+        )
 
     if lh5_tables_config is not None:
         tbl_cfg = lh5_tables_config

--- a/src/pygama/hit/build_hit.py
+++ b/src/pygama/hit/build_hit.py
@@ -124,6 +124,7 @@ def build_hit(
 
         log.info(f"Processing table '{tbl}' in file {infile}")
 
+        first_done = False
         for tbl_obj, start_row, n_rows in lh5_it:
             n_rows = min(tot_n_rows - start_row, n_rows)
 
@@ -149,6 +150,8 @@ def build_hit(
                 name=tbl.replace("/dsp", "/hit"),
                 lh5_file=outfile,
                 n_rows=n_rows,
-                wo_mode=wo_mode,
+                wo_mode=wo_mode if first_done is False else "append",
                 write_start=write_offset + start_row,
             )
+
+            first_done = True

--- a/src/pygama/lgdo/struct.py
+++ b/src/pygama/lgdo/struct.py
@@ -69,7 +69,7 @@ class Struct(dict):
         self.update_datatype()
 
     def remove_field(self, name: str, delete: bool = False) -> None:
-        """Remove a field to the table.
+        """Remove a field from the table.
 
         Parameters
         ----------

--- a/src/pygama/lgdo/struct.py
+++ b/src/pygama/lgdo/struct.py
@@ -64,7 +64,24 @@ class Struct(dict):
         self.attrs["datatype"] = self.form_datatype()
 
     def add_field(self, name: str, obj: LGDO | Struct) -> None:
+        """Add a field to the table."""
         self[name] = obj
+        self.update_datatype()
+
+    def remove_field(self, name: str, delete=False) -> None:
+        """Remove a field to the table.
+
+        Parameters
+        ----------
+        name
+            name of the field to be removed
+        delete
+            if ``True``, delete the field object by calling :any:`del`.
+        """
+        if delete:
+            del self[name]
+        else:
+            self.pop(name)
         self.update_datatype()
 
     def __len__(self) -> int:

--- a/src/pygama/lgdo/struct.py
+++ b/src/pygama/lgdo/struct.py
@@ -68,7 +68,7 @@ class Struct(dict):
         self[name] = obj
         self.update_datatype()
 
-    def remove_field(self, name: str, delete=False) -> None:
+    def remove_field(self, name: str, delete: bool = False) -> None:
         """Remove a field to the table.
 
         Parameters

--- a/src/pygama/lgdo/table.py
+++ b/src/pygama/lgdo/table.py
@@ -149,6 +149,10 @@ class Table(Struct):
         """Alias for :meth:`.add_field` using table terminology 'column'."""
         self.add_field(name, obj, use_obj_size=use_obj_size, do_warn=do_warn)
 
+    def remove_column(self, name: str, delete=False):
+        """Alias for :meth:`.remove_field` using table terminology 'column'."""
+        super().remove_field(name, delete)
+
     def join(
         self, other_table: Table, cols: list[str] = None, do_warn: bool = True
     ) -> None:

--- a/src/pygama/lgdo/table.py
+++ b/src/pygama/lgdo/table.py
@@ -149,7 +149,7 @@ class Table(Struct):
         """Alias for :meth:`.add_field` using table terminology 'column'."""
         self.add_field(name, obj, use_obj_size=use_obj_size, do_warn=do_warn)
 
-    def remove_column(self, name: str, delete=False):
+    def remove_column(self, name: str, delete: bool = False) -> None:
         """Alias for :meth:`.remove_field` using table terminology 'column'."""
         super().remove_field(name, delete)
 

--- a/tests/hit/configs/basic-hit-config.json
+++ b/tests/hit/configs/basic-hit-config.json
@@ -1,12 +1,18 @@
 {
-  "calE": {
-    "expression": "sqrt(@a + @b * trapEmax**2)",
-    "parameters": {
-      "a": "1.23",
-      "b": "42.69"
+  "outputs": ["calE", "AoE", "A_max"],
+  "operations": {
+    "twice_trap_e_max": {
+      "expression": "2 * trapEmax"
+    },
+    "calE": {
+      "expression": "sqrt(@a + @b * twice_trap_e_max**2)",
+      "parameters": {
+        "a": "1.23",
+        "b": "42.69"
+      }
+    },
+    "AoE": {
+      "expression": "A_max/calE"
     }
-  },
-  "AoE": {
-    "expression": "A_max/calE"
   }
 }

--- a/tests/hit/test_build_hit.py
+++ b/tests/hit/test_build_hit.py
@@ -1,16 +1,80 @@
+import pytest
+
 import os
 from pathlib import Path
 
 from pygama.hit import build_hit
+from pygama.lgdo import ls
 
 config_dir = Path(__file__).parent / "configs"
 
 
-def test_build_hit_basic(dsp_test_file):
+def test_basics(dsp_test_file):
+    outfile = "/tmp/LDQTA_r117_20200110T105115Z_cal_geds_hit.lh5"
+
     build_hit(
         dsp_test_file,
-        f"{config_dir}/basic-hit-config.json",
-        outfile="/tmp/LDQTA_r117_20200110T105115Z_cal_geds_hit.lh5",
+        outfile=outfile,
+        hit_config=f"{config_dir}/basic-hit-config.json",
+        wo_mode="overwrite",
     )
 
-    assert os.path.exists("/tmp/LDQTA_r117_20200110T105115Z_cal_geds_hit.lh5")
+    assert os.path.exists(outfile)
+    assert ls(outfile, "/geds/") == ["geds/hit"]
+
+
+def test_illegal_arguments(dsp_test_file):
+    with pytest.raises(ValueError):
+        build_hit(dsp_test_file)
+
+    with pytest.raises(ValueError):
+        build_hit(
+            dsp_test_file,
+            hit_config=f"{config_dir}/basic-hit-config.json",
+            lh5_tables_config={},
+        )
+
+    with pytest.raises(ValueError):
+        build_hit(
+            dsp_test_file,
+            lh5_tables=[],
+            lh5_tables_config={},
+        )
+
+
+def test_build_hit_table_configs(dsp_test_file):
+    outfile = "/tmp/LDQTA_r117_20200110T105115Z_cal_geds_hit.lh5"
+
+    lh5_tables_config = {
+        "/geds/dsp": f"{config_dir}/basic-hit-config.json"
+    }
+
+    build_hit(
+        dsp_test_file,
+        outfile=outfile,
+        lh5_tables_config=lh5_tables_config,
+        wo_mode="overwrite",
+    )
+
+    assert os.path.exists(outfile)
+    assert ls(outfile, "/geds/") == ["geds/hit"]
+
+    lh5_tables_config = {
+        "/geds/dsp": {
+            "calE": {
+                "expression": "sqrt(@a + @b * trapEmax**2)",
+                "parameters": {"a": "1.23", "b": "42.69"}
+            },
+            "AoE": {"expression": "A_max/calE"}
+        }
+    }
+
+    build_hit(
+        dsp_test_file,
+        outfile=outfile,
+        lh5_tables_config=lh5_tables_config,
+        wo_mode="overwrite",
+    )
+
+    assert os.path.exists(outfile)
+    assert ls(outfile, "/geds/") == ["geds/hit"]

--- a/tests/hit/test_build_hit.py
+++ b/tests/hit/test_build_hit.py
@@ -1,7 +1,7 @@
-import pytest
-
 import os
 from pathlib import Path
+
+import pytest
 
 from pygama.hit import build_hit
 from pygama.lgdo import ls
@@ -45,9 +45,7 @@ def test_illegal_arguments(dsp_test_file):
 def test_build_hit_table_configs(dsp_test_file):
     outfile = "/tmp/LDQTA_r117_20200110T105115Z_cal_geds_hit.lh5"
 
-    lh5_tables_config = {
-        "/geds/dsp": f"{config_dir}/basic-hit-config.json"
-    }
+    lh5_tables_config = {"/geds/dsp": f"{config_dir}/basic-hit-config.json"}
 
     build_hit(
         dsp_test_file,
@@ -63,9 +61,9 @@ def test_build_hit_table_configs(dsp_test_file):
         "/geds/dsp": {
             "calE": {
                 "expression": "sqrt(@a + @b * trapEmax**2)",
-                "parameters": {"a": "1.23", "b": "42.69"}
+                "parameters": {"a": "1.23", "b": "42.69"},
             },
-            "AoE": {"expression": "A_max/calE"}
+            "AoE": {"expression": "A_max/calE"},
         }
     }
 

--- a/tests/lgdo/test_struct.py
+++ b/tests/lgdo/test_struct.py
@@ -34,3 +34,15 @@ def test_add_field():
 
     struct.add_field("array1", lgdo.Array(shape=(700, 21), dtype="f", fill_val=2))
     assert struct.attrs["datatype"] == "struct{scalar1,array1}"
+
+
+def test_remove_field():
+    struct = lgdo.Struct()
+    struct.add_field("scalar1", lgdo.Scalar(value=10))
+    struct.add_field("array1", lgdo.Array(shape=(10), fill_val=0))
+
+    struct.remove_field("scalar1")
+    assert list(struct.keys()) == ["array1"]
+
+    struct.remove_field("array1", delete=True)
+    assert list(struct.keys()) == []

--- a/tests/lgdo/test_table.py
+++ b/tests/lgdo/test_table.py
@@ -90,3 +90,19 @@ def test_get_dataframe():
     df = tbl.get_dataframe()
     assert isinstance(df, pd.DataFrame)
     assert df.keys().all() == "a"
+
+
+def test_remove_column():
+    col_dict = {
+        "a": lgdo.Array(nda=np.array([1, 2, 3, 4])),
+        "b": lgdo.Array(nda=np.array([5, 6, 7, 8])),
+        "c": lgdo.Array(nda=np.array([9, 10, 11, 12])),
+    }
+
+    tbl = Table(col_dict=col_dict)
+
+    tbl.remove_column("a")
+    assert list(tbl.keys()) == ["b", "c"]
+
+    tbl.remove_column("c")
+    assert list(tbl.keys()) == ["b"]


### PR DESCRIPTION
As required by data production. This is how the hit config JSON file would look like:
```json

{
  "outputs": ["calE", "AoE", "A_max"],
  "operations": {
    "twice_trap_e_max": {
      "expression": "2 * trapEmax"
    },
    "calE": {
      "expression": "sqrt(@a + @b * twice_trap_e_max**2)",
      "parameters": {
        "a": "1.23",
        "b": "42.69"
      }
    },
    "AoE": {
      "expression": "A_max/calE"
    }
  }
}
```