### PR TITLE
added compass decoding capabilities to build_raw

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,6 +42,7 @@ install_requires =
     pyfftw
     scipy
     tqdm
+    xmltodict
 python_requires = >=3.9
 include_package_data = True
 package_dir =

--- a/src/pygama/raw/build_raw.py
+++ b/src/pygama/raw/build_raw.py
@@ -28,7 +28,7 @@ def build_raw(
     buffer_size: int = 8192,
     n_max: int = np.inf,
     overwrite: bool = False,
-    config_file: str = None,
+    compass_config_file: str = None,
     **kwargs,
 ) -> None:
     """Convert data into LEGEND HDF5 raw-tier format.
@@ -68,10 +68,10 @@ def build_raw(
     overwrite
         sets whether to overwrite the output file(s) if it (they) already exist.
 
-    config_file
+    compass_config_file
         Specification of config file, used for decoding CoMPASS files
 
-        - if None, CompassDecoder will eat the first packet to determine waveform length
+        - if None, CompassDecoder will sacrifice the first packet to determine waveform length
         - if a str ending in ``.json``, interpreted as a filename containing
           json-shorthand for the output specification (see :mod:`.compass.compass_event_decoder`).
 
@@ -173,7 +173,7 @@ def build_raw(
     elif in_stream_type == "FlashCam":
         streamer = FCStreamer()
     elif in_stream_type == "Compass":
-        streamer = CompassStreamer(config_file)
+        streamer = CompassStreamer(compass_config_file)
     elif in_stream_type == "LlamaDaq":
         raise NotImplementedError("LlamaDaq streaming not yet implemented")
     elif in_stream_type == "MGDO":

--- a/src/pygama/raw/build_raw.py
+++ b/src/pygama/raw/build_raw.py
@@ -13,6 +13,7 @@ from tqdm import tqdm
 from pygama import lgdo
 from pygama.math.utils import sizeof_fmt
 
+from .compass.compass_streamer import CompassStreamer
 from .fc.fc_streamer import FCStreamer
 from .orca.orca_streamer import OrcaStreamer
 from .raw_buffer import RawBufferLibrary, write_to_lh5_and_clear
@@ -27,6 +28,7 @@ def build_raw(
     buffer_size: int = 8192,
     n_max: int = np.inf,
     overwrite: bool = False,
+    config_file: str = None,
     **kwargs,
 ) -> None:
     """Convert data into LEGEND HDF5 raw-tier format.
@@ -66,6 +68,13 @@ def build_raw(
     overwrite
         sets whether to overwrite the output file(s) if it (they) already exist.
 
+    config_file
+        Specification of config file, used for decoding CoMPASS files
+
+        - if None, CompassDecoder will eat the first packet to determine waveform length
+        - if a str ending in ``.json``, interpreted as a filename containing
+          json-shorthand for the output specification (see :mod:`.compass.compass_event_decoder`).
+
     **kwargs
         sent to :class:`.RawBufferLibrary` generation as `kw_dict`.
     """
@@ -93,6 +102,8 @@ def build_raw(
                 in_stream_type = "FlashCam"
             elif OrcaStreamer.is_orca_stream(in_stream):
                 in_stream_type = "ORCA"
+            elif ext == "bin" or ext == "BIN":
+                in_stream_type = "Compass"
             else:
                 raise RuntimeError(
                     f"unknown file extension {ext}. Specify in_stream_type"
@@ -161,10 +172,10 @@ def build_raw(
         streamer = OrcaStreamer()
     elif in_stream_type == "FlashCam":
         streamer = FCStreamer()
+    elif in_stream_type == "Compass":
+        streamer = CompassStreamer(config_file)
     elif in_stream_type == "LlamaDaq":
         raise NotImplementedError("LlamaDaq streaming not yet implemented")
-    elif in_stream_type == "Compass":
-        raise NotImplementedError("Compass streaming not yet implemented")
     elif in_stream_type == "MGDO":
         raise NotImplementedError("MGDO streaming not yet implemented")
     else:

--- a/src/pygama/raw/compass/__init__.py
+++ b/src/pygama/raw/compass/__init__.py
@@ -1,0 +1,5 @@
+"""
+This subpackage overloads decoding utilities defined in :mod:`pygama.raw` to
+read files produced by the `ORCA <http://orca.physics.unc.edu/orca>`
+acquisition system.
+"""

--- a/src/pygama/raw/compass/__init__.py
+++ b/src/pygama/raw/compass/__init__.py
@@ -1,5 +1,4 @@
 """
 This subpackage overloads decoding utilities defined in :mod:`pygama.raw` to
-read files produced by the `ORCA <http://orca.physics.unc.edu/orca>`
-acquisition system.
+read files produced by the `CoMPASS` software.
 """

--- a/src/pygama/raw/compass/compass_config_parser.py
+++ b/src/pygama/raw/compass/compass_config_parser.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+import logging
+
+import xmltodict
+
+log = logging.getLogger(__name__)
+
+
+max_number_channels = 8
+max_number_of_boards = 2  # overload this value if you are using more boards and don't want to supply a config file!
+DT5730_sample_freq = 0.5  # sample/ns, because wf_len is stored in ns in the xml file
+DT5725_sample_freq = 0.25  # sample/ns
+
+
+def compass_config_to_dict(compass_config_file: str = None, wf_len: int = None) -> dict:
+    """
+    Read run-level data from a CoMPASS configuration file.
+
+    Parameters
+    ----------
+    compass_config_file
+        An xml config file for a CoMPASS data run
+
+    Returns
+    -------
+    config_dict
+        A dictionary of configuration data to pass to the streamer
+
+    JSON Configuration Example
+    --------------------------
+
+    .. code-block :: json
+
+        {
+            "boards" : {
+                "0" : {
+                    "modelName" : "DT5730",
+                    "adcBitCount" : 14,
+                    "sample_rate" : 0.5,
+                    "wf_len" : 1000,
+                    "channels": {
+                        "0" : {
+                            "Vpp": 2,
+                        }
+                    }
+                }
+            }
+        }
+
+    Notes
+    -----
+    First, if the CoMPASS xml config is not none, it is turned into a dictionary.
+    If the CoMPASS config file is none, then a generic dictionary with the
+    maximum number of channels and boards is returned, in order to create the
+    most generic raw buffer to fill.
+    """
+    # If the config file is not none, read in the xml and convert it to dict
+    if compass_config_file is not None:
+
+        with open(compass_config_file) as xml_file:
+            data_dict = xmltodict.parse(xml_file.read())
+
+        # Initialize a dictionary to hold the config data
+        config_dict = {}
+        config_dict["boards"] = {}
+
+        # get the number of boards enabled
+        # "configuration/board" is a dictionary if there is only one board
+        if isinstance(data_dict["configuration"]["board"], dict):
+            config_dict["boards"][0] = {}
+            # Read in board and adc
+            config_dict["boards"][0]["modelName"] = data_dict["configuration"]["board"][
+                "modelName"
+            ]
+            config_dict["boards"][0]["adcBitCount"] = data_dict["configuration"][
+                "board"
+            ]["adcBitCount"]
+
+            # Write the sampling rate, in samples/ns and store for conversion of the wf_len
+            if config_dict["boards"][0]["modelName"] == "DT5730":
+                config_dict["boards"][0]["sample_rate"] = DT5730_sample_freq
+            elif config_dict["boards"][0]["modelName"] == "DT5725":
+                config_dict["boards"][0]["sample_rate"] = DT5725_sample_freq
+            else:
+                raise NotImplementedError(
+                    f'warning! no sample rate defined yet for board {config_dict["boards"][0]["modelName"]}'
+                )
+                config_dict["boards"][0]["sample_rate"] = 1
+
+            # The parameters tag is a list of dictionaries, turn it into one dictionary
+            param_dict = {}
+            for item in data_dict["configuration"]["board"]["parameters"]["entry"]:
+                param_name = item["key"]
+                param_dict[param_name] = item["value"]
+
+            # Read in wf_len
+            if "SRV_PARAM_RECLEN" in param_dict.keys():
+                # all xml values are stored with the key "#text" in the config_file
+                # the wf_len are stored in ns, but we need the sample length to decode the packets, so convert using the sample rate
+                config_dict["boards"][0]["wf_len"] = float(
+                    param_dict["SRV_PARAM_RECLEN"]["value"]["#text"]
+                ) * float(config_dict["boards"][0]["sample_rate"])
+            else:
+                raise RuntimeError("wf_len not in config file!")
+
+            # Now, loop through the channels and update the dictionary
+            config_dict["boards"][0]["channels"] = {}
+
+            for channel_dictionary in data_dict["configuration"]["board"]["channel"]:
+
+                channel_number = channel_dictionary["index"]
+                # first check to make sure that the channel wasn't disabled from the compass interface,
+                # the xml file would then have <index>channel_no</index></values>
+                if channel_dictionary["values"] is None:
+                    continue
+                # if channel_dictionary["values"]["entry"] is a dictionary, then that channel is not enabled
+                if isinstance(channel_dictionary["values"]["entry"], dict):
+                    continue
+                # initialize the sub dictionary
+                else:
+                    config_dict["boards"][0]["channels"][channel_number] = {}
+
+                for x in channel_dictionary["values"]["entry"]:
+
+                    # if a value isn't present, then the key is just set to the default in the param_dict
+                    if (x["key"] in param_dict.keys()) and ("value" not in x.keys()):
+                        config_dict["boards"][0]["channels"][channel_number][
+                            x["key"]
+                        ] = param_dict[x["key"]]["value"]["#text"]
+                    else:
+
+                        config_dict["boards"][0]["channels"][channel_number][
+                            x["key"]
+                        ] = x["value"]["#text"]
+
+        # if there is more than one board, loop over each board and get the values
+        if isinstance(data_dict["configuration"]["board"], list):
+            for i in range(len(data_dict["configuration"]["board"])):
+                config_dict["boards"][i] = {}
+                # Read in board and adc
+                config_dict["boards"][i]["modelName"] = data_dict["configuration"][
+                    "board"
+                ][i]["modelName"]
+                config_dict["boards"][i]["adcBitCount"] = data_dict["configuration"][
+                    "board"
+                ][i]["adcBitCount"]
+
+                # Write the sampling rate, in samples/ns and store for conversion of the wf_len
+                if config_dict["boards"][i]["modelName"] == "DT5730":
+                    config_dict["boards"][i]["sample_rate"] = DT5730_sample_freq
+                elif config_dict["boards"][i]["modelName"] == "DT5725":
+                    config_dict["boards"][i]["sample_rate"] = DT5725_sample_freq
+                else:
+                    raise NotImplementedError(
+                        f'warning! no sample rate defined yet for board {config_dict["boards"][i]["modelName"]}'
+                    )
+                    config_dict["boards"][i]["sample_rate"] = 1
+
+                # The parameters tag is a list of dictionaries, turn it into one dictionary
+                param_dict = {}
+                for item in data_dict["configuration"]["board"][i]["parameters"][
+                    "entry"
+                ]:
+                    param_name = item["key"]
+                    param_dict[param_name] = item["value"]
+
+                # Read in wf_len
+                if "SRV_PARAM_RECLEN" in param_dict.keys():
+                    # all xml values are stored with the key "#text" in the config_file
+                    # the wf_len are stored in ns, but we need the sample length to decode the packets, so convert using the sample rate
+                    config_dict["boards"][i]["wf_len"] = float(
+                        param_dict["SRV_PARAM_RECLEN"]["value"]["#text"]
+                    ) * float(
+                        config_dict["boards"][i]["sample_rate"]
+                    )  # all xml values are stored with the key "#text" in the config_file
+                else:
+                    raise RuntimeError("wf_len not in config file!")
+
+                config_dict["boards"][i]["channels"] = {}
+
+                # Now, loop through the channels and update the dictionary
+                for channel_dictionary in data_dict["configuration"]["board"][i][
+                    "channel"
+                ]:
+
+                    channel_number = channel_dictionary["index"]
+                    # if channel_dictionary["values"]["entry"] is a dictionary, then that channel is not enabled
+                    if isinstance(channel_dictionary["values"]["entry"], dict):
+                        continue
+                    # initialize the sub dictionary
+                    else:
+                        config_dict["boards"][i]["channels"][channel_number] = {}
+
+                    for x in channel_dictionary["values"]["entry"]:
+
+                        # if a value isn't present, then the key is just set to the default in the param_dict
+                        if (x["key"] in param_dict.keys()) and (
+                            "value" not in x.keys()
+                        ):
+                            config_dict["boards"][i]["channels"][channel_number][
+                                x["key"]
+                            ] = param_dict[x["key"]]["value"]["#text"]
+                        else:
+
+                            config_dict["boards"][i]["channels"][channel_number][
+                                x["key"]
+                            ] = x["value"]["#text"]
+
+        return config_dict
+
+    # if the config file is none, return a generic dict with the most channels and boards enabled possible, in order to create a alrge enough raw buffer
+    else:
+        config_dict = {}
+        config_dict["boards"] = {}
+        for i in range(max_number_of_boards):
+            config_dict["boards"][i] = {}
+
+            # Set board and adc to none
+            config_dict["boards"][i]["modelName"] = None
+            config_dict["boards"][i]["adcBitCount"] = None
+            config_dict["boards"][i]["sample_rate"] = None
+
+            # set the wf_len
+            if wf_len is not None:
+                config_dict["boards"][i]["wf_len"] = float(wf_len)
+            else:
+                raise RuntimeError(
+                    "wf_len not passed correctly when config file is absent!"
+                )
+
+            config_dict["boards"][i]["channels"] = {}
+            for j in range(max_number_channels):
+                # initialize the sub-dict
+                config_dict["boards"][i]["channels"][j] = {}
+
+        return config_dict

--- a/src/pygama/raw/compass/compass_config_parser.py
+++ b/src/pygama/raw/compass/compass_config_parser.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import logging
-import plistlib
+
+import xmltodict
 
 log = logging.getLogger(__name__)
 
@@ -58,7 +59,7 @@ def compass_config_to_dict(compass_config_file: str = None, wf_len: int = None) 
     if compass_config_file is not None:
 
         with open(compass_config_file) as xml_file:
-            data_dict = plistlib.loads(xml_file, fmt=plistlib.FMT_XML)
+            data_dict = xmltodict.parse(xml_file.read())
 
         # Initialize a dictionary to hold the config data
         config_dict = {}

--- a/src/pygama/raw/compass/compass_config_parser.py
+++ b/src/pygama/raw/compass/compass_config_parser.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 import logging
-
-import xmltodict
+import plistlib
 
 log = logging.getLogger(__name__)
 
@@ -59,7 +58,7 @@ def compass_config_to_dict(compass_config_file: str = None, wf_len: int = None) 
     if compass_config_file is not None:
 
         with open(compass_config_file) as xml_file:
-            data_dict = xmltodict.parse(xml_file.read())
+            data_dict = plistlib.loads(xml_file, fmt=plistlib.FMT_XML)
 
         # Initialize a dictionary to hold the config data
         config_dict = {}

--- a/src/pygama/raw/compass/compass_event_decoder.py
+++ b/src/pygama/raw/compass/compass_event_decoder.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import copy
+import logging
+from typing import Any
+
+import numpy as np
+
+from pygama import lgdo
+from pygama.raw.data_decoder import DataDecoder
+
+log = logging.getLogger(__name__)
+
+compass_decoded_values = {
+    # packet index in file
+    "packet_id": {
+        "dtype": "uint32",
+    },
+    # ID of board
+    "board": {
+        "dtype": "uint32",
+    },
+    # ID of channel recording data
+    "channel": {
+        "dtype": "uint32",
+    },
+    # Timestamp of event
+    "timestamp": {
+        "dtype": "float64",
+        "units": "ps",
+    },
+    # Energy of event
+    "energy": {
+        "dtype": "uint32",
+    },
+    # Energy short of event
+    "energy_short": {
+        "dtype": "uint32",
+    },
+    # Flags that the digitizer raised
+    "flags": {
+        "dtype": "uint32",
+    },
+    # number of samples in a waveform
+    "num_samples": {
+        "dtype": "int64",
+    },
+    # waveform data
+    "waveform": {
+        "dtype": "uint16",
+        "datatype": "waveform",
+        "wf_len": 65532,  # max value. override this before initializing buffers to save RAM
+        "dt": 16,  # override if a different clock rate is used
+        "dt_units": "ns",
+        "t0_units": "ns",
+    },
+}
+
+
+class CompassEventDecoder(DataDecoder):
+    """
+    Decode CAEN digitizer event data.
+    """
+
+    def __init__(self, *args, **kwargs) -> None:
+        self.decoded_values = copy.deepcopy(compass_decoded_values)
+        super().__init__(*args, **kwargs)
+        self.skipped_channels = {}
+
+    def get_key_list(self) -> list[int | str]:
+        """
+        Get a unique key for each channel present in the CoMPASS file.
+
+        Notes
+        -----
+        The config file needs the number of channels enabled, because it
+        is read into the header and then used here to create the keys.
+        If no config file is present, the maximum 8 channels of a
+        CAEN digitizer is used, but all events raw_buffers might
+        not be filled in that case.
+        """
+        return range(self.header["num_enabled_channels"].value)
+
+    def set_file_config(self, header: lgdo.Struct) -> None:
+        """Access ``header`` members once when each file is opened.
+        Parameters
+        ----------
+        header
+            extracted via :meth:`~.compass_header_decoder.CompassHeaderDecoder.decode_header`.
+        """
+        self.header = header
+        self.decoded_values["waveform"]["wf_len"] = self.header["wf_len"].value
+
+    def get_decoded_values(self, channel: int = None) -> dict[str, dict[str, Any]]:
+        # CoMPASS uses the same values for all channels
+        return self.decoded_values
+
+    def decode_packet(
+        self,
+        packet: bytes,
+        evt_rbkd: lgdo.Table | dict[int, lgdo.Table],
+        packet_id: int,
+        header: lgdo.Table | dict[int, lgdo.Table],
+    ) -> bool:
+        """Access ``CoMPASSEvent`` members for each event in the DAQ file.
+
+        Parameters
+        ----------
+        packet
+            The packet to be decoded
+        evt_rbkd
+            A single table for reading out all data, or a dictionary of tables
+            keyed by channel number.
+        packet_id
+            The index of the packet in the `CoMPASS` stream. Incremented by
+            :class:`~.raw.compass.compass_streamer.CompassStreamer`.
+        header
+            The header of the CoMPASS file, along with user config info,
+            that is used to determine waveform lengths and thus buffer sizes
+
+        Returns
+        -------
+        n_bytes
+            (estimated) number of bytes in the packet that was just decoded.
+        """
+        # Read in the board number and channel number so we can get the right entry in the table
+        # Regardless of the length of the header, the first 4 bytes are the board and the channel number
+        board = np.frombuffer(packet[0:2], dtype=np.uint16)[0]
+        channel = np.frombuffer(packet[2:4], dtype=np.uint16)[0]
+
+        # get the table for this channel
+        if channel not in evt_rbkd:
+            if channel not in self.skipped_channels:
+                self.skipped_channels[channel] = 0
+                log.debug(f"Skipping channel: {channel}")
+                log.debug(f"evt_rbkd: {evt_rbkd.keys()}")
+            self.skipped_channels[channel] += 1
+            return False
+        tbl = evt_rbkd[channel].lgdo
+        ii = evt_rbkd[channel].loc
+
+        # store packet id
+        tbl["packet_id"].nda[ii] = packet_id
+
+        # store the info we already have read in
+        tbl["board"].nda[ii] = board
+        tbl["channel"].nda[ii] = channel
+
+        # the time stamp also does not care about if we have an energy short present
+        tbl["timestamp"].nda[ii] = np.frombuffer(packet[4:12], dtype=np.uint64)[0]
+
+        # get the rest of the values depending on if there is an energy_short present
+        if header["energy_short"].value == 1:
+            tbl["energy"].nda[ii] = np.frombuffer(packet[12:14], dtype=np.uint16)[0]
+            tbl["energy_short"].nda[ii] = np.frombuffer(packet[14:16], dtype=np.uint16)[
+                0
+            ]
+            tbl["flags"].nda[ii] = np.frombuffer(packet[16:20], np.uint32)[0]
+            tbl["num_samples"].nda[ii] = np.frombuffer(packet[21:25], dtype=np.uint32)[
+                0
+            ]
+
+            if (
+                tbl["num_samples"].nda[ii] != self.decoded_values["waveform"]["wf_len"]
+            ):  # make sure that the waveform we read in is the same length as in the config
+                raise RuntimeError(
+                    f"Waveform size {tbl['num_samples'].nda[ii]} doesn't match expected size {self.decoded_values['waveform']['wf_len']}. "
+                    "Skipping packet"
+                )
+
+            tbl["waveform"]["values"].nda[ii] = np.frombuffer(
+                packet[25:], dtype=np.uint16
+            )
+
+        else:
+            tbl["energy"].nda[ii] = np.frombuffer(packet[12:14], dtype=np.uint16)[0]
+            tbl["energy_short"].nda[ii] = None
+            tbl["flags"].nda[ii] = np.frombuffer(packet[14:18], np.uint32)[0]
+            tbl["num_samples"].nda[ii] = np.frombuffer(packet[19:23], dtype=np.uint32)[
+                0
+            ]
+
+            if (
+                tbl["num_samples"].nda[ii] != self.decoded_values["waveform"]["wf_len"]
+            ):  # make sure that the waveform we read in is the same length as in the config
+                raise RuntimeError(
+                    f"Waveform size {tbl['num_samples'].nda[ii]} doesn't match expected size {self.decoded_values['waveform']['wf_len']}. "
+                    "Skipping packet"
+                )
+
+            tbl["waveform"]["values"].nda[ii] = np.frombuffer(
+                packet[23:], dtype=np.uint16
+            )
+
+        evt_rbkd[channel].loc += 1
+        return evt_rbkd[channel].is_full()

--- a/src/pygama/raw/compass/compass_header_decoder.py
+++ b/src/pygama/raw/compass/compass_header_decoder.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
-import json
 import logging
 
-import numpy as np
-
 from pygama import lgdo
+from pygama.raw.compass.compass_config_parser import compass_config_to_dict
 from pygama.raw.data_decoder import DataDecoder
 from pygama.raw.raw_buffer import RawBuffer
 
@@ -13,30 +11,17 @@ log = logging.getLogger(__name__)
 
 
 class CompassHeaderDecoder(DataDecoder):
-    """Decode CoMPASS header data. Also, read in CoMPASS config data if provided.
-
-    JSON Configuration Example
-    --------------------------
-
-    Below is an example of the CoMPASS config file; the wf_len and num_enabled_channels are necessary.
-
-    .. code-block:: json
-
-        {
-        "model_name": "DT5730",
-        "adc_bitcount": 14,
-        "sample_rate": 500e6,
-        "v_range": 2.0,
-        "num_enabled_channels": 1,
-        "wf_len": 1000,  # in samples
-        }
+    """
+    Decode CoMPASS header data. Also, read in CoMPASS config data if provided using the compass_config_parser
     """
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.config = lgdo.Struct()
 
-    def decode_header(self, in_stream: bytes, config_file: str = None) -> lgdo.Struct:
+    def decode_header(
+        self, in_stream: bytes, config_file: str = None, wf_len: int = None
+    ) -> dict:
         """Decode the CoMPASS file header, and add CoMPASS config data to the header, if present.
 
         Parameters
@@ -45,13 +30,18 @@ class CompassHeaderDecoder(DataDecoder):
             The stream of data to have its header decoded
         config_file
             The config file for the CoMPASS data, if present
+        wf_len
+            The length of the first waveform in the file, only pre-calculated when the config_file is none
 
         Returns
         -------
         config
-            An lgdo.Struct containing the header information, as well as the important config information
+            A dict containing the header information, as well as the important config information
             of wf_len and num_enabled_channels
         """
+        config_dict = compass_config_to_dict(config_file, wf_len)
+        self.config = config_dict
+
         config_names = [
             "energy_channels",  # energy is given in channels (0: false, 1: true)
             "energy_calibrated",  # energy is given in keV/MeV, according to the calibration (0: false, 1: true)
@@ -70,48 +60,12 @@ class CompassHeaderDecoder(DataDecoder):
             if name in self.config:
                 log.warning(f"{name} already in self.config. skipping...")
                 continue
-            value = np.int32(header_as_list[i])  # all config fields are int32
-            self.config.add_field(name, lgdo.Scalar(value))
-
-        # if a json config_file is present, read in the config values to the header
-        if isinstance(config_file, str) and config_file.endswith(".json"):
-            with open(config_file) as json_file:
-                config_file = json.load(json_file)
-            # Add the rest of the config file
-            for key in config_file:
-                self.config.add_field(key, lgdo.Scalar(config_file[key]))
-            return self.config
-
-        # if the config_file is None, sacrifice the first packet and write the wf_len to the header,
-        # and initialize the number of enabled channels to the max of a CAEN digitizer
-        if config_file is None:
-
-            if self.config["energy_short"].value == 1:
-                header_length = 25  # if the energy short is present, then there are an extra 2 bytes in the metadata
-            else:
-                header_length = 23  # the normal packet metadata is 23 bytes long
-
-            # read in the packet metadata
-            header_in_bytes = in_stream.read(header_length)
-
-            # get the waveform length so we can read in the rest of the packet
-            if header_length == 25:
-                [num_samples] = np.frombuffer(header_in_bytes[21:25], dtype=np.uint32)
-            if header_length == 23:
-                [num_samples] = np.frombuffer(header_in_bytes[19:23], dtype=np.uint32)
-
-            # sacrifice the first waveform so that load_packet() will work correctly, there are 2 bytes per sample
-            in_stream.read(2 * num_samples)
-
-            # add the wf_len to the config
-            self.config.add_field("wf_len", lgdo.Scalar(num_samples))
-            # set the number of enabled channels to the 8 max channels on a CAEN digitizer
-            self.config.add_field("num_enabled_channels", lgdo.Scalar(8))
-
-            return self.config
+            value = int(header_as_list[i])
+            self.config[str(name)] = value
+        return self.config
 
     def make_lgdo(self, key: int = None, size: int = None) -> lgdo.Struct:
-        return self.config
+        return lgdo.Scalar(value="")
 
     def buffer_is_full(self, rb: RawBuffer) -> bool:
         return rb.loc > 0

--- a/src/pygama/raw/compass/compass_header_decoder.py
+++ b/src/pygama/raw/compass/compass_header_decoder.py
@@ -101,7 +101,7 @@ class CompassHeaderDecoder(DataDecoder):
                 [num_samples] = np.frombuffer(header_in_bytes[19:23], dtype=np.uint32)
 
             # sacrifice the first waveform so that load_packet() will work correctly, there are 2 bytes per sample
-            wf = in_stream.read(2 * num_samples)
+            in_stream.read(2 * num_samples)
 
             # add the wf_len to the config
             self.config.add_field("wf_len", lgdo.Scalar(num_samples))

--- a/src/pygama/raw/compass/compass_header_decoder.py
+++ b/src/pygama/raw/compass/compass_header_decoder.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import json
+import logging
+
+import numpy as np
+
+from pygama import lgdo
+from pygama.raw.data_decoder import DataDecoder
+from pygama.raw.raw_buffer import RawBuffer
+
+log = logging.getLogger(__name__)
+
+
+class CompassHeaderDecoder(DataDecoder):
+    """Decode CoMPASS header data. Also, read in CoMPASS config data if provided.
+
+    JSON Configuration Example
+    --------------------------
+
+    Below is an example of the CoMPASS config file; the wf_len and num_enabled_channels are necessary.
+
+    .. code-block:: json
+
+        {
+        "model_name": "DT5730",
+        "adc_bitcount": 14,
+        "sample_rate": 500e6,
+        "v_range": 2.0,
+        "num_enabled_channels": 1,
+        "wf_len": 1000,  # in samples
+        }
+    """
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.config = lgdo.Struct()
+
+    def decode_header(self, in_stream: bytes, config_file: str = None) -> lgdo.Struct:
+        """Decode the CoMPASS file header, and add CoMPASS config data to the header, if present.
+
+        Parameters
+        ----------
+        in_stream
+            The stream of data to have its header decoded
+        config_file
+            The config file for the CoMPASS data, if present
+
+        Returns
+        -------
+        config
+            An lgdo.Struct containing the header information, as well as the important config information
+            of wf_len and num_enabled_channels
+        """
+        config_names = [
+            "energy_channels",  # energy is given in channels (0: false, 1: true)
+            "energy_calibrated",  # energy is given in keV/MeV, according to the calibration (0: false, 1: true)
+            "energy_short",  # energy short is present (0: false, 1: true)
+            "waveform_samples",  # waveform samples are present (0: false, 1: true)
+        ]
+        header_in_bytes = in_stream.read(
+            2
+        )  # we always have to read in the first 2 bytes of the header for CoMPASS v2 files
+        header_in_binary = bin(int.from_bytes(header_in_bytes, byteorder="little"))
+        header_as_list = str(header_in_binary)[
+            ::-1
+        ]  # reverse it as we care about bit 0, bit 1, etc.
+
+        for i, name in enumerate(config_names):
+            if name in self.config:
+                log.warning(f"{name} already in self.config. skipping...")
+                continue
+            value = np.int32(header_as_list[i])  # all config fields are int32
+            self.config.add_field(name, lgdo.Scalar(value))
+
+        # if a json config_file is present, read in the config values to the header
+        if isinstance(config_file, str) and config_file.endswith(".json"):
+            with open(config_file) as json_file:
+                config_file = json.load(json_file)
+            # Add the rest of the config file
+            for key in config_file:
+                self.config.add_field(key, lgdo.Scalar(config_file[key]))
+            return self.config
+
+        # if the config_file is None, sacrifice the first packet and write the wf_len to the header,
+        # and initialize the number of enabled channels to the max of a CAEN digitizer
+        if config_file is None:
+
+            if self.config["energy_short"].value == 1:
+                header_length = 25  # if the energy short is present, then there are an extra 2 bytes in the metadata
+            else:
+                header_length = 23  # the normal packet metadata is 23 bytes long
+
+            # read in the packet metadata
+            header_in_bytes = in_stream.read(header_length)
+
+            # get the waveform length so we can read in the rest of the packet
+            if header_length == 25:
+                [num_samples] = np.frombuffer(header_in_bytes[21:25], dtype=np.uint32)
+            if header_length == 23:
+                [num_samples] = np.frombuffer(header_in_bytes[19:23], dtype=np.uint32)
+
+            # sacrifice the first waveform so that load_packet() will work correctly, there are 2 bytes per sample
+            wf = in_stream.read(2 * num_samples)
+
+            # add the wf_len to the config
+            self.config.add_field("wf_len", lgdo.Scalar(num_samples))
+            # set the number of enabled channels to the 8 max channels on a CAEN digitizer
+            self.config.add_field("num_enabled_channels", lgdo.Scalar(8))
+
+            return self.config
+
+    def make_lgdo(self, key: int = None, size: int = None) -> lgdo.Struct:
+        return self.config
+
+    def buffer_is_full(self, rb: RawBuffer) -> bool:
+        return rb.loc > 0

--- a/src/pygama/raw/compass/compass_streamer.py
+++ b/src/pygama/raw/compass/compass_streamer.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+
+from pygama.raw.compass.compass_event_decoder import CompassEventDecoder
+from pygama.raw.compass.compass_header_decoder import CompassHeaderDecoder
+from pygama.raw.data_decoder import DataDecoder
+from pygama.raw.data_streamer import DataStreamer
+from pygama.raw.raw_buffer import RawBuffer, RawBufferLibrary
+
+log = logging.getLogger(__name__)
+
+
+class CompassStreamer(DataStreamer):
+    """Data streamer for CoMPASS data streams."""
+
+    def __init__(self, config_file) -> None:
+        super().__init__()
+        self.in_stream = None
+        self.header = None
+        self.buffer = np.empty(
+            1024, dtype="bytes"
+        )  # create a buffer that is around 4 kB
+        self.header_decoder = CompassHeaderDecoder()
+        self.event_decoder = CompassEventDecoder()
+        self.config_file = (
+            config_file  # optional config file to be passed when calling build_raw
+        )
+        self.event_rbkd = None
+
+    def get_decoder_list(self) -> list[DataDecoder]:
+        dec_list = []
+        dec_list.append(self.header_decoder)
+        dec_list.append(self.event_decoder)
+        return dec_list
+
+    def open_stream(
+        self,
+        stream_name: str,
+        rb_lib: RawBufferLibrary = None,
+        buffer_size: int = 8192,
+        chunk_mode: str = "any_full",
+        out_stream: str = "",
+    ) -> tuple[list[RawBuffer], int]:
+        """Initialize the CoMPASS data stream. If a config file is present, load just the 2 byte header.
+        If a config file is absent, read the first packet to determine waveform length, and initialize the
+        keys to the max number of channels of a CAEN digitizer.
+
+        Parameters
+        ----------
+        stream_name
+            The CoMPASS filename. Only file streams are currently supported.
+            Socket stream reading can be added later.
+        rb_lib
+            library of buffers for this stream.
+        buffer_size
+            length of tables to be read out in :meth:`read_chunk`.
+        chunk_mode : 'any_full', 'only_full', or 'single_packet'
+            sets the mode use for :meth:`read_chunk`.
+        out_stream
+            optional name of output stream for default `rb_lib` generation.
+
+        Returns
+        -------
+        header_data
+            a list of length 1 containing the raw buffer holding the CoMPASS header.
+
+        Notes
+        -----
+        CoMPASS files have a header that is only 2 bytes long and only appears at the top of the file.
+        So, we must read this header once, and then proceed to read packets in.
+        """
+        # set the in_stream
+        self.set_in_stream(stream_name)
+        self.n_bytes_read = 0
+
+        # read in and decode the file header info if the config file is present
+        if self.config_file is not None:
+            self.header = self.header_decoder.decode_header(
+                self.in_stream, self.config_file
+            )  # returns an lgdo.Struct
+            self.n_bytes_read += (
+                2  # there are 2 bytes in the header, for a 16 bit number to read out
+            )
+
+            # set up data loop variables
+            self.packet_id = 0
+
+        # read in the header and get the wf_len by sacrificing the first packet if the config_file is not present
+        # also set the keys to the maximum number of channels available to a CAEN digitizer
+        else:
+            self.header = self.header_decoder.decode_header(
+                self.in_stream, self.config_file
+            )  # returns an lgdo.Struct
+
+            # set up data loop variables
+            self.packet_id = 1
+
+            # the number of bytes read is different if the energy_short is present in the header
+            if self.header["energy_short"].value == 1:
+                self.n_bytes_read += (
+                    2 + 25 + 2 * self.header["wf_len"].value
+                )  # there are 2 bytes in the header, 25 in packet metadata, and 2*num_samples in bytes
+            else:
+                self.n_bytes_read += 2 + 23 + 2 * self.header["wf_len"].value
+
+        # The wf_len from the config_file or from the first packet is then used to initialize raw_buffers to the correct size
+        self.event_decoder.set_file_config(self.header)
+
+        # initialize the buffers in rb_lib. Store them for fast lookup
+        super().open_stream(
+            stream_name,
+            rb_lib,
+            buffer_size=buffer_size,
+            chunk_mode=chunk_mode,
+            out_stream=out_stream,
+        )
+        if rb_lib is None:
+            rb_lib = self.rb_lib
+
+        # set up the event data raw buffers
+        self.event_rbkd = (
+            rb_lib["CompassEventDecoder"].get_keyed_dict()
+            if "CompassEventDecoder" in rb_lib
+            else None
+        )
+
+        if "CompassHeaderDecoder" in rb_lib:
+            header_rb_list = rb_lib["CompassHeaderDecoder"]
+            if len(header_rb_list) != 1:
+                log.warning(
+                    f"header_rb_list had length {len(header_rb_list)}, ignoring all but the first"
+                )
+            rb = header_rb_list[0]
+        else:
+            rb = RawBuffer(lgdo=self.header)
+        rb.loc = 1  # we have filled this buffer
+        return [rb]
+
+    def set_in_stream(self, stream_name: str) -> None:
+        """Sets the in_stream by opening a binary file"""
+        if self.in_stream is not None:
+            self.in_stream.close()
+            self.in_stream = None
+        else:
+            self.in_stream = open(
+                stream_name.encode("utf-8"), "rb"
+            )  # CoMPASS files are binary
+        self.n_bytes_read = 0
+
+    def close_stream(self) -> None:
+        """Close this data stream."""
+        if self.in_stream is None:
+            raise RuntimeError("tried to close an unopened stream")
+        self.in_stream.close()
+        self.in_stream = None
+
+    # TODO: add a config file that allows users to specify if "ADC Channels" or "Calibrated" or "Both" options were enabled, as well as Vpp
+    def load_packet(self) -> np.uint32 | None:
+        """Loads the next packet into the internal buffer.
+
+        Returns packet as a :class:`numpy.uint32` view of the buffer (a slice),
+        returns ``None`` at EOF.
+
+        Notes
+        -----
+        First, load_packet finds the packet's metadata length in bytes by looking at the header,
+        and then reads the metadata into the buffer. From the metadata, the length of the waveform can be determined and then the buffer is
+        resized to fit the metadata and the waveform. Finally, the buffer is filled with the packet and then returned.
+
+        """
+        if self.in_stream is None:
+            raise RuntimeError("self.in_stream is None")
+
+        if (self.packet_id == 0) and (self.n_bytes_read != 2):
+            raise RuntimeError(
+                f"The 2 byte filer header was not converted, instead read in {self.n_bytes_read} for the file header"
+            )
+
+        # packets have metadata of variable lengths, depending on if the header shows that energy_short is present in the metadata
+        if self.header["energy_short"].value == 1:
+            header_length = 25  # if the energy short is present, then there are an extra 2 bytes in the metadata
+        else:
+            header_length = 23  # the normal packet metadata is 23 bytes long
+
+        # read the packet's metadata into the buffer
+        pkt_hdr = self.buffer[:header_length]
+        n_bytes_read = self.in_stream.readinto(pkt_hdr)
+        self.n_bytes_read += n_bytes_read
+
+        # return None once we run out of file
+        if n_bytes_read == 0:
+            return None
+        if (n_bytes_read != 25) and (n_bytes_read != 23):
+            raise RuntimeError(f"only got {n_bytes_read} bytes for packet header")
+
+        # get the waveform length so we can read in the rest of the packet
+        if n_bytes_read == 25:
+            [num_samples] = np.frombuffer(pkt_hdr[21:25], dtype=np.uint32)
+            pkt_length = header_length + 2 * num_samples
+        if n_bytes_read == 23:
+            [num_samples] = np.frombuffer(pkt_hdr[19:23], dtype=np.uint32)
+            pkt_length = header_length + 2 * num_samples
+
+        # load into buffer, resizing as necessary
+        if len(self.buffer) < pkt_length:
+            self.buffer.resize(pkt_length, refcheck=False)
+        n_bytes_read = self.in_stream.readinto(self.buffer[header_length:pkt_length])
+        self.n_bytes_read += n_bytes_read
+        if n_bytes_read != pkt_length - header_length:
+            raise RuntimeError(
+                f"only got {n_bytes_read} bytes for packet read when {pkt_length-header_length} were expected."
+            )
+
+        # return just the packet
+        return self.buffer[:pkt_length]
+
+    def read_packet(self) -> bool:
+        """Read and decode a packet of data.
+        Data written to the `event_rbkd` attribute.
+        """
+        packet = self.load_packet()
+        # Return True until we have no more file left to read
+        if packet is None:
+            return False
+        self.packet_id += 1
+        self.any_full |= self.event_decoder.decode_packet(
+            packet, self.event_rbkd, self.packet_id, self.header
+        )
+
+        return True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,5 +5,5 @@ from legend_testdata import LegendTestData
 @pytest.fixture(scope="session")
 def lgnd_test_data():
     ldata = LegendTestData()
-    ldata.checkout("968c9ba")
+    ldata.checkout("22f1a54")
     return ldata

--- a/tests/raw/compass/conftest.py
+++ b/tests/raw/compass/conftest.py
@@ -1,0 +1,46 @@
+import pytest
+
+from pygama.raw.compass.compass_header_decoder import CompassHeaderDecoder
+from pygama.raw.compass.compass_streamer import CompassStreamer
+
+
+@pytest.fixture(scope="module")
+def packet(lgnd_test_data):
+    streamer = CompassStreamer()
+    streamer.open_stream(
+        lgnd_test_data.get_path("compass/compass_test_data.BIN"), buffer_size=6
+    )
+    init_rbytes = streamer.n_bytes_read
+    pkt = streamer.load_packet()
+    assert pkt is not None  # load was successful
+    assert (
+        streamer.n_bytes_read
+        == init_rbytes + 25 + 2 * streamer.header["boards"][0]["wf_len"]
+    )
+    streamer.close_stream()
+    return pkt
+
+
+@pytest.fixture(scope="module")
+def compass_config(lgnd_test_data):
+    decoder = CompassHeaderDecoder()
+    test_file = lgnd_test_data.get_path("compass/compass_test_data.BIN")
+    in_stream = open(test_file, "rb")
+    compass_config_file = lgnd_test_data.get_path(
+        "compass/compass_test_data_settings.xml"
+    )
+    decoder.decode_header(in_stream, compass_config_file)
+    in_stream.close()
+    return decoder.config
+
+
+@pytest.fixture(scope="module")
+def compass_config_no_settings(lgnd_test_data):
+    decoder = CompassHeaderDecoder()
+    test_file = lgnd_test_data.get_path("compass/compass_test_data.BIN")
+    in_stream = open(test_file, "rb")
+    compass_config_file = None
+    wf_len = 1000
+    decoder.decode_header(in_stream, compass_config_file, wf_len)
+    in_stream.close()
+    return decoder.config

--- a/tests/raw/compass/test_compass_event_decoder.py
+++ b/tests/raw/compass/test_compass_event_decoder.py
@@ -1,0 +1,80 @@
+import pytest
+
+from pygama import lgdo
+from pygama.raw.compass.compass_event_decoder import CompassEventDecoder
+from pygama.raw.raw_buffer import RawBuffer
+
+
+@pytest.fixture(scope="module")
+def event_rbkd(lgnd_test_data, compass_config, packet):
+    decoder = CompassEventDecoder()
+    decoder.set_header(compass_config)
+
+    # build raw buffer for each channel in the FC trace list
+    rbkd = {}
+    rbkd[0] = RawBuffer(lgdo=decoder.make_lgdo(size=1))
+
+    # decode packet into the lgdo's and check if the buffer is full
+    assert (
+        decoder.decode_packet(packet, evt_rbkd=rbkd, packet_id=1, header=compass_config)
+        is True
+    )
+    return rbkd
+
+
+def test_decoding(event_rbkd):
+    assert event_rbkd != {}
+
+
+def test_data_types(event_rbkd):
+
+    for _, v in event_rbkd.items():
+        # assert v.out_name == 'FCEvent' FIXME: is this a bug?
+        tbl = v.lgdo
+        assert isinstance(tbl, lgdo.Struct)
+        assert isinstance(tbl["packet_id"], lgdo.Array)
+        assert isinstance(tbl["board"], lgdo.Array)
+        assert isinstance(tbl["channel"], lgdo.Array)
+        assert isinstance(tbl["timestamp"], lgdo.Array)
+        assert isinstance(tbl["energy"], lgdo.Array)
+        assert isinstance(tbl["energy_short"], lgdo.Array)
+        assert isinstance(tbl["flags"], lgdo.Array)
+        assert isinstance(tbl["num_samples"], lgdo.Array)
+        assert isinstance(tbl["waveform"], lgdo.Struct)
+        assert isinstance(tbl["waveform"]["t0"], lgdo.Array)
+        assert isinstance(tbl["waveform"]["dt"], lgdo.Array)
+        assert isinstance(tbl["waveform"]["values"], lgdo.ArrayOfEqualSizedArrays)
+
+
+def test_values(event_rbkd):
+
+    for _, v in event_rbkd.items():
+        # assert v.out_name == 'FCEvent' FIXME: is this a bug?
+        tbl = v.lgdo
+        assert tbl["packet_id"].nda == [1]
+        assert tbl["board"].nda == 0
+        assert tbl["channel"].nda == 0
+        assert tbl["timestamp"].nda == [9.78762e10]
+        assert tbl["energy"].nda == [798]
+        assert tbl["energy_short"].nda == [135]
+        assert tbl["flags"].nda == [16384]
+        assert tbl["num_samples"].nda == 1000
+        assert (
+            tbl["waveform"]["values"].nda[0][:14]
+            == [
+                2745,
+                2742,
+                2745,
+                2746,
+                2745,
+                2743,
+                2745,
+                2744,
+                2746,
+                2747,
+                2746,
+                2743,
+                2745,
+                2747,
+            ]
+        ).all()

--- a/tests/raw/compass/test_compass_header_decoder.py
+++ b/tests/raw/compass/test_compass_header_decoder.py
@@ -1,0 +1,75 @@
+def test_decoding(compass_config):
+    pass
+
+
+def test_decoding_no_settings(compass_config_no_settings):
+    pass
+
+
+def test_data_types(compass_config):
+    assert isinstance(compass_config, dict)
+
+
+def test_data_types_no_settings(compass_config_no_settings):
+    assert isinstance(compass_config_no_settings, dict)
+
+
+def test_values(compass_config):
+    assert compass_config
+    expected_dict = {
+        "boards": {
+            0: {
+                "adcBitCount": "14",
+                "channels": {
+                    "0": {
+                        "SRV_PARAM_CH_BLINE_DCOFFSET": "20.0",
+                        "SRV_PARAM_CH_ENABLED": "true",
+                        "SRV_PARAM_CH_INDYN": "INDYN_2_0_VPP",
+                        "SRV_PARAM_CH_THRESHOLD": "100.0",
+                        "SRV_PARAM_CH_TRG_HOLDOFF": "1024.0",
+                    },
+                    "1": {
+                        "SRV_PARAM_CH_ENABLED": "true",
+                        "SRV_PARAM_CH_INDYN": "INDYN_0_5_VPP",
+                    },
+                },
+                "modelName": "DT5730",
+                "sample_rate": 0.5,
+                "wf_len": 1000.0,
+            }
+        },
+        "energy_calibrated": 0,
+        "energy_channels": 1,
+        "energy_short": 1,
+        "waveform_samples": 1,
+    }
+    for k, v in expected_dict.items():
+        assert compass_config[k] == v
+
+
+def test_values_no_config(compass_config_no_settings):
+    expected_dict = {
+        "boards": {
+            0: {
+                "adcBitCount": None,
+                "channels": {0: {}, 1: {}, 2: {}, 3: {}, 4: {}, 5: {}, 6: {}, 7: {}},
+                "modelName": None,
+                "sample_rate": None,
+                "wf_len": 1000.0,
+            },
+            1: {
+                "adcBitCount": None,
+                "channels": {0: {}, 1: {}, 2: {}, 3: {}, 4: {}, 5: {}, 6: {}, 7: {}},
+                "modelName": None,
+                "sample_rate": None,
+                "wf_len": 1000.0,
+            },
+        },
+        "energy_calibrated": 0,
+        "energy_channels": 1,
+        "energy_short": 1,
+        "waveform_samples": 1,
+    }
+
+    for k, v in expected_dict.items():
+        assert compass_config_no_settings[k] == v

--- a/tests/raw/compass/test_compass_streamer.py
+++ b/tests/raw/compass/test_compass_streamer.py
@@ -1,0 +1,82 @@
+from pygama.raw.compass.compass_streamer import CompassStreamer
+from pygama.raw.raw_buffer import RawBuffer, RawBufferList
+
+
+def test_default_rb_lib(lgnd_test_data):
+    streamer = CompassStreamer(
+        lgnd_test_data.get_path("compass/compass_test_data_settings.xml"),
+    )
+    streamer.open_stream(
+        lgnd_test_data.get_path("compass/compass_test_data.BIN"), buffer_size=6
+    )
+    rb_lib = streamer.build_default_rb_lib()
+    assert "CompassHeaderDecoder" in rb_lib.keys()
+    assert "CompassEventDecoder" in rb_lib.keys()
+    assert rb_lib["CompassHeaderDecoder"][0].out_name == "CompassHeader"
+    assert rb_lib["CompassEventDecoder"][0].out_name == "CompassEvent"
+    assert rb_lib["CompassEventDecoder"][0].key_list == [0, 1]
+    streamer.close_stream()
+
+
+def test_open_stream(lgnd_test_data):
+    streamer = CompassStreamer()
+    res = streamer.open_stream(
+        lgnd_test_data.get_path("compass/compass_test_data.BIN"), buffer_size=6
+    )
+    assert isinstance(res[0], RawBuffer)
+    assert streamer.header is not None  # header object is instantiated
+    assert streamer.packet_id == 0  # packet id is initialized
+    assert streamer.n_bytes_read == 2  # CoMPASS header is read
+    assert streamer.event_rbkd is not None  # dict containing event info is initialized
+    streamer.close_stream()
+
+
+def test_read_packet(lgnd_test_data):
+    streamer = CompassStreamer()
+    streamer.open_stream(
+        lgnd_test_data.get_path("compass/compass_test_data.BIN"), buffer_size=6
+    )
+    init_rbytes = streamer.n_bytes_read
+    assert streamer.read_packet() is True  # read was successful
+    assert streamer.packet_id == 1  # packet id is incremented
+    assert (
+        streamer.n_bytes_read
+        == init_rbytes + 25 + 2 * streamer.header["boards"][0]["wf_len"]
+    )
+    streamer.close_stream()
+
+
+def test_read_packet_partial(lgnd_test_data):
+    streamer = CompassStreamer()
+    rb_lib = {"CompassEventDecoder": RawBufferList()}
+    rb_lib["CompassEventDecoder"].append(
+        RawBuffer(key_list=range(0, 1), out_name="events")
+    )
+
+    streamer.open_stream(
+        lgnd_test_data.get_path("compass/compass_test_data.BIN"),
+        rb_lib=rb_lib,
+        buffer_size=6,
+    )
+
+    assert list(streamer.rb_lib.keys()) == ["CompassEventDecoder"]
+    assert streamer.rb_lib["CompassEventDecoder"][0].key_list == range(0, 1)
+    assert streamer.rb_lib["CompassEventDecoder"][0].out_name == "events"
+
+    init_rbytes = streamer.n_bytes_read
+    assert streamer.read_packet() is True  # read was successful
+    assert streamer.packet_id == 1  # packet id is incremented
+    assert (
+        streamer.n_bytes_read
+        == init_rbytes + 25 + 2 * streamer.header["boards"][0]["wf_len"]
+    )
+    streamer.close_stream()
+
+
+def test_read_chunk(lgnd_test_data):
+    streamer = CompassStreamer()
+    streamer.open_stream(
+        lgnd_test_data.get_path("compass/compass_test_data.BIN"), buffer_size=6
+    )
+    streamer.read_chunk()
+    streamer.close_stream()

--- a/tests/raw/test_build_raw.py
+++ b/tests/raw/test_build_raw.py
@@ -135,6 +135,72 @@ def test_build_raw_orca_out_spec(lgnd_test_data):
     )
 
 
+def test_build_raw_compass(lgnd_test_data):
+    build_raw(
+        in_stream=lgnd_test_data.get_path("compass/compass_test_data.BIN"),
+        overwrite=True,
+        compass_config_file=lgnd_test_data.get_path(
+            "compass/compass_test_data_settings.xml"
+        ),
+    )
+
+    assert lgnd_test_data.get_path("compass/compass_test_data.lh5") != ""
+
+    out_file = "/tmp/compass_test_data.lh5"
+
+    build_raw(
+        in_stream=lgnd_test_data.get_path("compass/compass_test_data.BIN"),
+        out_spec=out_file,
+        overwrite=True,
+        compass_config_file=lgnd_test_data.get_path(
+            "compass/compass_test_data_settings.xml"
+        ),
+    )
+
+    assert os.path.exists("/tmp/compass_test_data.lh5")
+
+
+def test_build_raw_compass_out_spec(lgnd_test_data):
+    out_file = "/tmp/compass_test_data.lh5"
+    out_spec = {
+        "CompassEventDecoder": {"spms": {"key_list": [[0, 1]], "out_stream": out_file}}
+    }
+
+    build_raw(
+        in_stream=lgnd_test_data.get_path("compass/compass_test_data.BIN"),
+        out_spec=out_spec,
+        n_max=10,
+        overwrite=True,
+        compass_config_file=lgnd_test_data.get_path(
+            "compass/compass_test_data_settings.xml"
+        ),
+    )
+
+    store = LH5Store()
+    lh5_obj, n_rows = store.read_object("/spms", out_file)
+    assert n_rows == 10
+    assert (lh5_obj["channel"].nda == [0, 1, 0, 1, 0, 1, 0, 1, 0, 1]).all()
+
+
+def test_build_raw_compass_out_spec_no_config(lgnd_test_data):
+    out_file = "/tmp/compass_test_data.lh5"
+    out_spec = {
+        "CompassEventDecoder": {"spms": {"key_list": [[0, 1]], "out_stream": out_file}}
+    }
+
+    build_raw(
+        in_stream=lgnd_test_data.get_path("compass/compass_test_data.BIN"),
+        out_spec=out_spec,
+        n_max=10,
+        overwrite=True,
+    )
+
+    store = LH5Store()
+    lh5_obj, n_rows = store.read_object("/spms", out_file)
+    assert n_rows == 10
+    assert (lh5_obj["channel"].nda == [0, 1, 0, 1, 0, 1, 0, 1, 0, 1]).all()
+
+
 def test_build_raw_overwrite(lgnd_test_data):
     with pytest.raises(FileExistsError):
         build_raw(


### PR DESCRIPTION
Created a CompassStreamer class for build_raw to use to decode CoMPASS files. Because of the layout of CoMPASS files, a further option was added to pass a config file to track enabled channels and waveform length.