### PR TITLE
Disabled numba cache and add bound checks

### DIFF
--- a/src/pygama/dsp/processing_chain.py
+++ b/src/pygama/dsp/processing_chain.py
@@ -1194,7 +1194,7 @@ class ProcessorManager:
 class UnitConversionManager(ProcessorManager):
     """A special processor manager for handling converting variables between unit systems."""
 
-    @vectorize(nopython=True, cache=True)
+    @vectorize(nopython=True, cache=False)
     def convert(buf_in, offset_in, offset_out, period_ratio):  # noqa: N805
         return (buf_in - offset_in) * period_ratio + offset_out
 

--- a/src/pygama/dsp/processing_chain.py
+++ b/src/pygama/dsp/processing_chain.py
@@ -1194,7 +1194,7 @@ class ProcessorManager:
 class UnitConversionManager(ProcessorManager):
     """A special processor manager for handling converting variables between unit systems."""
 
-    @vectorize(nopython=True, cache=False,boundscheck=True)
+    @vectorize(nopython=True, cache=False, boundscheck=True)
     def convert(buf_in, offset_in, offset_out, period_ratio):  # noqa: N805
         return (buf_in - offset_in) * period_ratio + offset_out
 

--- a/src/pygama/dsp/processing_chain.py
+++ b/src/pygama/dsp/processing_chain.py
@@ -1194,7 +1194,7 @@ class ProcessorManager:
 class UnitConversionManager(ProcessorManager):
     """A special processor manager for handling converting variables between unit systems."""
 
-    @vectorize(nopython=True, cache=False)
+    @vectorize(nopython=True, cache=False,boundscheck=True)
     def convert(buf_in, offset_in, offset_out, period_ratio):  # noqa: N805
         return (buf_in - offset_in) * period_ratio + offset_out
 

--- a/src/pygama/dsp/processors/bl_subtract.py
+++ b/src/pygama/dsp/processors/bl_subtract.py
@@ -8,7 +8,8 @@ from numba import guvectorize
     ["void(float32[:], float32, float32[:])", "void(float64[:], float64, float64[:])"],
     "(n),()->(n)",
     nopython=True,
-    cache=True,
+    cache=False,
+    boundscheck=True,
 )
 def bl_subtract(w_in: np.ndarray, a_baseline: float, w_out: np.ndarray) -> None:
     """Subtract the constant baseline from the entire waveform.

--- a/src/pygama/dsp/processors/convolutions.py
+++ b/src/pygama/dsp/processors/convolutions.py
@@ -70,6 +70,8 @@ def cusp_filter(length: int, sigma: float, flat: int, decay: int) -> Callable:
         ["void(float32[:], float32[:])", "void(float64[:], float64[:])"],
         "(n),(m)",
         forceobj=True,
+        cache=False,
+        boundscheck=True,
     )
     def cusp_out(w_in: np.ndarray, w_out: np.ndarray) -> None:
         """
@@ -173,6 +175,8 @@ def zac_filter(length: int, sigma: float, flat: int, decay: int) -> Callable:
         ["void(float32[:], float32[:])", "void(float64[:], float64[:])"],
         "(n),(m)",
         forceobj=True,
+        cache=False,
+        boundscheck=True,
     )
     def zac_out(w_in: np.ndarray, w_out: np.ndarray) -> None:
         """
@@ -243,6 +247,8 @@ def t0_filter(rise: int, fall: int) -> Callable:
         ["void(float32[:], float32[:])", "void(float64[:], float64[:])"],
         "(n),(m)",
         forceobj=True,
+        cache=False,
+        boundscheck=True,
     )
     def t0_filter_out(w_in: np.ndarray, w_out: np.ndarray) -> None:
         """

--- a/src/pygama/dsp/processors/fftw.py
+++ b/src/pygama/dsp/processors/fftw.py
@@ -51,7 +51,13 @@ def dft(buf_in: np.ndarray, buf_out: np.ndarray) -> Callable:
     typesig = "void(" + str(buf_in.dtype) + "[:, :], " + str(buf_out.dtype) + "[:, :])"
     sizesig = "(m, n)->(m, n)" if buf_in.shape == buf_out.shape else "(m, n),(m, l)"
 
-    @guvectorize([typesig], sizesig, forceobj=True cache=False, boundscheck=True)
+    @guvectorize(
+         [typesig], 
+         sizesig, 
+         forceobj=True, 
+         cache=False, 
+         boundscheck=True,
+    )
     def dft(wf_in: np.ndarray, dft_out: np.ndarray) -> None:
         dft_fun(wf_in, dft_out)
 
@@ -102,7 +108,13 @@ def inv_dft(buf_in: np.ndarray, buf_out: np.ndarray) -> Callable:
     typesig = "void(" + str(buf_in.dtype) + "[:, :], " + str(buf_out.dtype) + "[:, :])"
     sizesig = "(m, n)->(m, n)" if buf_in.shape == buf_out.shape else "(m, n),(m, l)"
 
-    @guvectorize([typesig], sizesig, forceobj=True, cache=False, boundscheck=True)
+    @guvectorize(
+         [typesig], 
+         sizesig, 
+         forceobj=True, 
+         cache=False, 
+         boundscheck=True,
+    )
     def inv_dft(wf_in: np.ndarray, dft_out: np.ndarray) -> None:
         idft_fun(wf_in, dft_out)
 
@@ -159,7 +171,13 @@ def psd(buf_in: np.ndarray, buf_out: np.ndarray) -> Callable:
     typesig = "void(" + str(buf_in.dtype) + "[:, :], " + str(buf_out.dtype) + "[:, :])"
     sizesig = "(m, n)->(m, n)" if buf_in.shape == buf_out.shape else "(m, n),(m, l)"
 
-    @guvectorize([typesig], sizesig, forceobj=True, cache=False, boundscheck=True)
+    @guvectorize(
+         [typesig], 
+         sizesig, 
+         forceobj=True, 
+         cache=False, 
+         boundscheck=True,
+    )
     def psd(wf_in: np.ndarray, psd_out: np.ndarray) -> None:
         dft_fun(wf_in, buf_dft)
         np.abs(buf_dft, psd_out)

--- a/src/pygama/dsp/processors/fftw.py
+++ b/src/pygama/dsp/processors/fftw.py
@@ -51,7 +51,7 @@ def dft(buf_in: np.ndarray, buf_out: np.ndarray) -> Callable:
     typesig = "void(" + str(buf_in.dtype) + "[:, :], " + str(buf_out.dtype) + "[:, :])"
     sizesig = "(m, n)->(m, n)" if buf_in.shape == buf_out.shape else "(m, n),(m, l)"
 
-    @guvectorize([typesig], sizesig, forceobj=True)
+    @guvectorize([typesig], sizesig, forceobj=True cache=False, boundscheck=True)
     def dft(wf_in: np.ndarray, dft_out: np.ndarray) -> None:
         dft_fun(wf_in, dft_out)
 
@@ -102,7 +102,7 @@ def inv_dft(buf_in: np.ndarray, buf_out: np.ndarray) -> Callable:
     typesig = "void(" + str(buf_in.dtype) + "[:, :], " + str(buf_out.dtype) + "[:, :])"
     sizesig = "(m, n)->(m, n)" if buf_in.shape == buf_out.shape else "(m, n),(m, l)"
 
-    @guvectorize([typesig], sizesig, forceobj=True)
+    @guvectorize([typesig], sizesig, forceobj=True, cache=False, boundscheck=True)
     def inv_dft(wf_in: np.ndarray, dft_out: np.ndarray) -> None:
         idft_fun(wf_in, dft_out)
 
@@ -159,7 +159,7 @@ def psd(buf_in: np.ndarray, buf_out: np.ndarray) -> Callable:
     typesig = "void(" + str(buf_in.dtype) + "[:, :], " + str(buf_out.dtype) + "[:, :])"
     sizesig = "(m, n)->(m, n)" if buf_in.shape == buf_out.shape else "(m, n),(m, l)"
 
-    @guvectorize([typesig], sizesig, forceobj=True)
+    @guvectorize([typesig], sizesig, forceobj=True, cache=False, boundscheck=True)
     def psd(wf_in: np.ndarray, psd_out: np.ndarray) -> None:
         dft_fun(wf_in, buf_dft)
         np.abs(buf_dft, psd_out)

--- a/src/pygama/dsp/processors/fftw.py
+++ b/src/pygama/dsp/processors/fftw.py
@@ -52,11 +52,11 @@ def dft(buf_in: np.ndarray, buf_out: np.ndarray) -> Callable:
     sizesig = "(m, n)->(m, n)" if buf_in.shape == buf_out.shape else "(m, n),(m, l)"
 
     @guvectorize(
-         [typesig], 
-         sizesig, 
-         forceobj=True, 
-         cache=False, 
-         boundscheck=True,
+        [typesig],
+        sizesig,
+        forceobj=True,
+        cache=False,
+        boundscheck=True,
     )
     def dft(wf_in: np.ndarray, dft_out: np.ndarray) -> None:
         dft_fun(wf_in, dft_out)
@@ -109,11 +109,11 @@ def inv_dft(buf_in: np.ndarray, buf_out: np.ndarray) -> Callable:
     sizesig = "(m, n)->(m, n)" if buf_in.shape == buf_out.shape else "(m, n),(m, l)"
 
     @guvectorize(
-         [typesig], 
-         sizesig, 
-         forceobj=True, 
-         cache=False, 
-         boundscheck=True,
+        [typesig],
+        sizesig,
+        forceobj=True,
+        cache=False,
+        boundscheck=True,
     )
     def inv_dft(wf_in: np.ndarray, dft_out: np.ndarray) -> None:
         idft_fun(wf_in, dft_out)
@@ -172,11 +172,11 @@ def psd(buf_in: np.ndarray, buf_out: np.ndarray) -> Callable:
     sizesig = "(m, n)->(m, n)" if buf_in.shape == buf_out.shape else "(m, n),(m, l)"
 
     @guvectorize(
-         [typesig], 
-         sizesig, 
-         forceobj=True, 
-         cache=False, 
-         boundscheck=True,
+        [typesig],
+        sizesig,
+        forceobj=True,
+        cache=False,
+        boundscheck=True,
     )
     def psd(wf_in: np.ndarray, psd_out: np.ndarray) -> None:
         dft_fun(wf_in, buf_dft)

--- a/src/pygama/dsp/processors/fixed_time_pickoff.py
+++ b/src/pygama/dsp/processors/fixed_time_pickoff.py
@@ -10,7 +10,8 @@ from pygama.dsp.errors import DSPFatal
     ["void(float32[:], float32, float32[:])", "void(float64[:], float64, float64[:])"],
     "(n),()->()",
     nopython=True,
-    cache=True,
+    cache=False,
+    boundscheck=True,
 )
 def fixed_time_pickoff(w_in: np.ndarray, t_in: int, a_out: np.ndarray) -> None:
     """Pick off the waveform value at the provided index.

--- a/src/pygama/dsp/processors/gaussian_filter1d.py
+++ b/src/pygama/dsp/processors/gaussian_filter1d.py
@@ -90,6 +90,8 @@ def gaussian_filter1d(sigma: int, truncate: float = 4.0) -> numpy.ndarray:
         ],
         "(n),(m)",
         forceobj=True,
+        cache=False,
+        boundscheck=True,
     )
     def gaussian_filter1d_out(wf_in, wf_out):
 

--- a/src/pygama/dsp/processors/get_multi_local_extrema.py
+++ b/src/pygama/dsp/processors/get_multi_local_extrema.py
@@ -13,7 +13,8 @@ from pygama.dsp.errors import DSPFatal
     ],
     "(n),(),(m),(m),(),(),()",
     nopython=True,
-    cache=True,
+    cache=False,
+    boundscheck=True,
 )
 def get_multi_local_extrema(
     w_in: np.ndarray,

--- a/src/pygama/dsp/processors/linear_slope_fit.py
+++ b/src/pygama/dsp/processors/linear_slope_fit.py
@@ -11,7 +11,8 @@ from numba import guvectorize
     ],
     "(n)->(),(),(),()",
     nopython=True,
-    cache=True,
+    cache=False,
+    boundscheck=True,
 )
 def linear_slope_fit(
     w_in: np.ndarray, mean: float, stdev: float, slope: float, intercept: float

--- a/src/pygama/dsp/processors/log_check.py
+++ b/src/pygama/dsp/processors/log_check.py
@@ -8,7 +8,8 @@ from numba import guvectorize
     ["void(float32[:], float32[:])", "void(float64[:], float64[:])"],
     "(n)->(n)",
     nopython=True,
-    cache=True,
+    cache=False,
+    boundscheck=True,
 )
 def log_check(w_in: np.ndarray, w_log: np.ndarray) -> None:
     """

--- a/src/pygama/dsp/processors/min_max.py
+++ b/src/pygama/dsp/processors/min_max.py
@@ -11,7 +11,8 @@ from numba import guvectorize
     ],
     "(n)->(),(),(),()",
     nopython=True,
-    cache=True,
+    cache=False,
+    boundscheck=True,
 )
 def min_max(
     w_in: np.ndarray, t_min: int, t_max: int, a_min: float, a_max: float

--- a/src/pygama/dsp/processors/moving_windows.py
+++ b/src/pygama/dsp/processors/moving_windows.py
@@ -10,7 +10,7 @@ from pygama.dsp.errors import DSPFatal
     ["void(float32[:], float32, float32[:])", "void(float64[:], float64, float64[:])"],
     "(n),()->(n)",
     nopython=True,
-    cache=True,
+    cache=False,
 )
 def moving_window_left(w_in: np.ndarray, length: float, w_out: np.ndarray) -> None:
     """Applies a moving average window to the waveform.
@@ -62,7 +62,7 @@ def moving_window_left(w_in: np.ndarray, length: float, w_out: np.ndarray) -> No
     ["void(float32[:], float32, float32[:])", "void(float64[:], float64, float64[:])"],
     "(n),()->(n)",
     nopython=True,
-    cache=True,
+    cache=False,
 )
 def moving_window_right(w_in: np.ndarray, length: float, w_out: np.ndarray) -> None:
     """Applies a moving average window to the waveform from the right.
@@ -118,7 +118,7 @@ def moving_window_right(w_in: np.ndarray, length: float, w_out: np.ndarray) -> N
     ],
     "(n),(),(),()->(n)",
     nopython=True,
-    cache=True,
+    cache=False,
 )
 def moving_window_multi(
     w_in: np.ndarray, length: float, num_mw: int, mw_type: int, w_out: np.ndarray
@@ -201,7 +201,7 @@ def moving_window_multi(
     ["void(float32[:], float32, float32[:])", "void(float64[:], float64, float64[:])"],
     "(n),(),(m)",
     nopython=True,
-    cache=True,
+    cache=False,
 )
 def avg_current(w_in: np.ndarray, length: float, w_out: np.ndarray) -> None:
     """Calculate the derivative of a waveform, averaged across `length` samples.

--- a/src/pygama/dsp/processors/multi_a_filter.py
+++ b/src/pygama/dsp/processors/multi_a_filter.py
@@ -13,7 +13,7 @@ from .fixed_time_pickoff import fixed_time_pickoff
     ],
     "(n),(m),(m)",
     forceobj=True,
-    cache=True,
+    cache=False,
 )
 def multi_a_filter(w_in, vt_maxs_in, va_max_out):
     """

--- a/src/pygama/dsp/processors/multi_t_filter.py
+++ b/src/pygama/dsp/processors/multi_t_filter.py
@@ -15,7 +15,7 @@ from .time_point_thresh import time_point_thresh
     ],
     "(n),(n) -> (n)",
     nopython=True,
-    cache=True,
+    cache=False,
 )
 def remove_duplicates(
     t_in: np.ndarray, vt_min_in: np.ndarray, t_out: np.ndarray
@@ -81,7 +81,7 @@ def remove_duplicates(
     ],
     "(n),(),(m),(m),(m)",
     forceobj=True,
-    cache=True,
+    cache=False,
 )
 def multi_t_filter(
     w_in: np.ndarray,

--- a/src/pygama/dsp/processors/optimize.py
+++ b/src/pygama/dsp/processors/optimize.py
@@ -41,6 +41,8 @@ class Model:
     ],
     "(n),(),(),(),()->()",
     forceobj=True,
+    cache=False,
+    boundscheck=True,
 )
 def optimize_1pz(
     w_in: np.ndarray,

--- a/src/pygama/dsp/processors/pole_zero.py
+++ b/src/pygama/dsp/processors/pole_zero.py
@@ -10,7 +10,7 @@ from pygama.dsp.errors import DSPFatal
     ["void(float32[:], float32, float32[:])", "void(float64[:], float64, float64[:])"],
     "(n),()->(n)",
     nopython=True,
-    cache=True,
+    cache=False,
 )
 def pole_zero(w_in: np.ndarray, t_tau: float, w_out: np.ndarray) -> None:
     """Apply a pole-zero cancellation using the provided time
@@ -55,7 +55,7 @@ def pole_zero(w_in: np.ndarray, t_tau: float, w_out: np.ndarray) -> None:
     ],
     "(n),(),(),()->(n)",
     nopython=True,
-    cache=True,
+    cache=False,
 )
 def double_pole_zero(
     w_in: np.ndarray, t_tau1: float, t_tau2: float, frac: float, w_out: np.ndarray

--- a/src/pygama/dsp/processors/presum.py
+++ b/src/pygama/dsp/processors/presum.py
@@ -8,7 +8,7 @@ from numba import guvectorize
     ["void(float32[:], float32[:])", "void(float64[:], float64[:])"],
     "(n),(m)",
     nopython=True,
-    cache=True,
+    cache=False,
 )
 def presum(w_in: np.ndarray, w_out: np.ndarray) -> None:
     """Presum the waveform.

--- a/src/pygama/dsp/processors/pulse_injector.py
+++ b/src/pygama/dsp/processors/pulse_injector.py
@@ -13,7 +13,7 @@ from numba import guvectorize
     ],
     "(n),(),(),(), ()->(n)",
     nopython=True,
-    cache=True,
+    cache=False,
 )
 def inject_sig_pulse(
     wf_in: np.ndarray, t0: int, rt: float, a: float, decay: float, wf_out: np.ndarray
@@ -67,7 +67,7 @@ def inject_sig_pulse(
     ],
     "(n),(),(),(), ()->(n)",
     nopython=True,
-    cache=True,
+    cache=False,
 )
 def inject_exp_pulse(
     wf_in: np.ndarray, t0: int, rt: float, a: float, decay: float, wf_out: np.ndarray

--- a/src/pygama/dsp/processors/saturation.py
+++ b/src/pygama/dsp/processors/saturation.py
@@ -13,7 +13,7 @@ from pygama.dsp.errors import DSPFatal
     ],
     "(n),()->(),()",
     nopython=True,
-    cache=True,
+    cache=False,
 )
 def saturation(
     w_in: np.ndarray, bit_depth_in: int, n_lo_out: int, n_hi_out: int

--- a/src/pygama/dsp/processors/soft_pileup_corr.py
+++ b/src/pygama/dsp/processors/soft_pileup_corr.py
@@ -13,7 +13,7 @@ from pygama.dsp.errors import DSPFatal
     ],
     "(n),(),()->(n)",
     nopython=True,
-    cache=True,
+    cache=False,
 )
 def soft_pileup_corr(
     w_in: np.ndarray, n_in: int, tau_in: float, w_out: np.ndarray
@@ -83,7 +83,7 @@ def soft_pileup_corr(
     ],
     "(n),(),(),()->(n)",
     nopython=True,
-    cache=True,
+    cache=False,
 )
 def soft_pileup_corr_bl(
     w_in: np.ndarray, n_in: int, tau_in: float, b_in: float, w_out: np.ndarray

--- a/src/pygama/dsp/processors/time_point_thresh.py
+++ b/src/pygama/dsp/processors/time_point_thresh.py
@@ -13,7 +13,7 @@ from pygama.dsp.errors import DSPFatal
     ],
     "(n),(),(),()->()",
     nopython=True,
-    cache=True,
+    cache=False,
 )
 def time_point_thresh(
     w_in: np.ndarray, a_threshold: float, t_start: int, walk_forward: int, t_out: float

--- a/src/pygama/dsp/processors/trap_filters.py
+++ b/src/pygama/dsp/processors/trap_filters.py
@@ -13,7 +13,7 @@ from pygama.dsp.errors import DSPFatal
     ],
     "(n),(),()->(n)",
     nopython=True,
-    cache=True,
+    cache=False,
 )
 def trap_filter(w_in: np.ndarray, rise: int, flat: int, w_out: np.ndarray) -> None:
     """Apply a symmetric trapezoidal filter to the waveform.
@@ -79,7 +79,7 @@ def trap_filter(w_in: np.ndarray, rise: int, flat: int, w_out: np.ndarray) -> No
     ],
     "(n),(),()->(n)",
     nopython=True,
-    cache=True,
+    cache=False,
 )
 def trap_norm(w_in: np.ndarray, rise: int, flat: int, w_out: np.ndarray) -> None:
     """Apply a symmetric trapezoidal filter to the waveform, normalized by the
@@ -151,7 +151,7 @@ def trap_norm(w_in: np.ndarray, rise: int, flat: int, w_out: np.ndarray) -> None
     ],
     "(n),(),(),()->(n)",
     nopython=True,
-    cache=True,
+    cache=False,
 )
 def asym_trap_filter(
     w_in: np.ndarray, rise: int, flat: int, fall: int, w_out: np.ndarray
@@ -227,7 +227,7 @@ def asym_trap_filter(
     ],
     "(n),(),(),()->()",
     nopython=True,
-    cache=True,
+    cache=False,
 )
 def trap_pickoff(
     w_in: np.ndarray, rise: int, flat: int, t_pickoff: float, a_out: float

--- a/src/pygama/dsp/processors/upsampler.py
+++ b/src/pygama/dsp/processors/upsampler.py
@@ -10,7 +10,7 @@ from pygama.dsp.errors import DSPFatal
     ["void(float32[:], float32, float32[:])", "void(float64[:], float64, float64[:])"],
     "(n),(),(m)",
     nopython=True,
-    cache=True,
+    cache=False,
 )
 def upsampler(w_in: np.ndarray, upsample: float, w_out: np.ndarray) -> None:
     """Upsamples the waveform by the number specified, a series of moving

--- a/src/pygama/dsp/processors/windower.py
+++ b/src/pygama/dsp/processors/windower.py
@@ -10,7 +10,7 @@ from pygama.dsp.errors import DSPFatal
     ["void(float32[:], float32, float32[:])", "void(float64[:], float64, float64[:])"],
     "(n),(),(m)",
     nopython=True,
-    cache=True,
+    cache=False,
 )
 def windower(w_in: np.ndarray, t0_in: int, w_out: np.ndarray) -> None:
     """Return a shorter sample of the waveform, starting at the


### PR DESCRIPTION
set the cache option to False. False it is the default value but I thought it was a good idea to leave it explicit. 
I also added enable the bounds-check and made uniform the guvectorize decorator throughout the repo.

@iguinn, the cache=true option keeps creating problems for the data production. Cache files are created under the user's home durectory (`~/.cache/numba`) the first time build_dsp is called. These files are not updated and the processing chain creates a seg fault if build_dsp is called with a different processor list. We can discuss more about this during a call.

Why did you enable the cache in the first place? 