### PR TITLE
Bare-bones class for setting global Numba options

### DIFF
--- a/docs/source/manuals/build_dsp.rst
+++ b/docs/source/manuals/build_dsp.rst
@@ -45,7 +45,7 @@ Writing custom processors
     from numba import guvectorize
 
     from pygama.dsp.errors import DSPFatal
-
+    from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
 
     # 2) Provide instructions to Numba
     #
@@ -53,14 +53,17 @@ Writing custom processors
     # https://numba.pydata.org/numba-doc/latest/user/vectorize.html#the-guvectorize-decorator
     #
     # Notes:
-    # - Use "nopython=True, cache=True"
+    # - Set default Numba arguments by expanding dsp.utils.numba_defaults_kwargs (see below)
+    # - If you need to customize the value of one default argument do it, and
+    #   use numba_defaults from dsp.utils to set up the remaining arguments:
+    #       @guvectorize(..., cache=numba_defaults.cache, boundscheck=True)
     # - Use two declarations, one for 32-bit variables and one for 64-bit variables
     # - Do not use "int" as it does not support an NaN value
     # - Use [:] for all output parameters
     #
     @guvectorize(["void(float32[:], float32, float32, float32[:])",
                   "void(float64[:], float64, float64, float64[:])"],
-                  "(n),(),()->()", nopython=True, cache=True)
+                  "(n),(),()->()", **nb_kwargs)
 
     # 3) Define the processor interface
     #

--- a/src/pygama/dsp/processors/bl_subtract.py
+++ b/src/pygama/dsp/processors/bl_subtract.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 import numpy as np
 from numba import guvectorize
 
+from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
+
 
 @guvectorize(
     ["void(float32[:], float32, float32[:])", "void(float64[:], float64, float64[:])"],
     "(n),()->(n)",
-    nopython=True,
-    cache=True,
+    **nb_kwargs
 )
 def bl_subtract(w_in: np.ndarray, a_baseline: float, w_out: np.ndarray) -> None:
     """Subtract the constant baseline from the entire waveform.

--- a/src/pygama/dsp/processors/bl_subtract.py
+++ b/src/pygama/dsp/processors/bl_subtract.py
@@ -9,7 +9,7 @@ from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
 @guvectorize(
     ["void(float32[:], float32, float32[:])", "void(float64[:], float64, float64[:])"],
     "(n),()->(n)",
-    **nb_kwargs
+    **nb_kwargs,
 )
 def bl_subtract(w_in: np.ndarray, a_baseline: float, w_out: np.ndarray) -> None:
     """Subtract the constant baseline from the entire waveform.

--- a/src/pygama/dsp/processors/convolutions.py
+++ b/src/pygama/dsp/processors/convolutions.py
@@ -6,6 +6,7 @@ import numpy as np
 from numba import guvectorize
 
 from pygama.dsp.errors import DSPFatal
+from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
 
 
 def cusp_filter(length: int, sigma: float, flat: int, decay: int) -> Callable:
@@ -69,6 +70,7 @@ def cusp_filter(length: int, sigma: float, flat: int, decay: int) -> Callable:
     @guvectorize(
         ["void(float32[:], float32[:])", "void(float64[:], float64[:])"],
         "(n),(m)",
+        **nb_kwargs,
         forceobj=True,
     )
     def cusp_out(w_in: np.ndarray, w_out: np.ndarray) -> None:
@@ -172,6 +174,7 @@ def zac_filter(length: int, sigma: float, flat: int, decay: int) -> Callable:
     @guvectorize(
         ["void(float32[:], float32[:])", "void(float64[:], float64[:])"],
         "(n),(m)",
+        **nb_kwargs,
         forceobj=True,
     )
     def zac_out(w_in: np.ndarray, w_out: np.ndarray) -> None:
@@ -242,6 +245,7 @@ def t0_filter(rise: int, fall: int) -> Callable:
     @guvectorize(
         ["void(float32[:], float32[:])", "void(float64[:], float64[:])"],
         "(n),(m)",
+        **nb_kwargs,
         forceobj=True,
     )
     def t0_filter_out(w_in: np.ndarray, w_out: np.ndarray) -> None:

--- a/src/pygama/dsp/processors/fftw.py
+++ b/src/pygama/dsp/processors/fftw.py
@@ -6,6 +6,8 @@ import numpy as np
 from numba import guvectorize
 from pyfftw import FFTW
 
+from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
+
 
 def dft(buf_in: np.ndarray, buf_out: np.ndarray) -> Callable:
     """Perform discrete Fourier transforms using the FFTW library.
@@ -51,7 +53,7 @@ def dft(buf_in: np.ndarray, buf_out: np.ndarray) -> Callable:
     typesig = "void(" + str(buf_in.dtype) + "[:, :], " + str(buf_out.dtype) + "[:, :])"
     sizesig = "(m, n)->(m, n)" if buf_in.shape == buf_out.shape else "(m, n),(m, l)"
 
-    @guvectorize([typesig], sizesig, forceobj=True)
+    @guvectorize([typesig], sizesig, **nb_kwargs, forceobj=True)
     def dft(wf_in: np.ndarray, dft_out: np.ndarray) -> None:
         dft_fun(wf_in, dft_out)
 
@@ -102,7 +104,7 @@ def inv_dft(buf_in: np.ndarray, buf_out: np.ndarray) -> Callable:
     typesig = "void(" + str(buf_in.dtype) + "[:, :], " + str(buf_out.dtype) + "[:, :])"
     sizesig = "(m, n)->(m, n)" if buf_in.shape == buf_out.shape else "(m, n),(m, l)"
 
-    @guvectorize([typesig], sizesig, forceobj=True)
+    @guvectorize([typesig], sizesig, **nb_kwargs, forceobj=True)
     def inv_dft(wf_in: np.ndarray, dft_out: np.ndarray) -> None:
         idft_fun(wf_in, dft_out)
 
@@ -159,7 +161,7 @@ def psd(buf_in: np.ndarray, buf_out: np.ndarray) -> Callable:
     typesig = "void(" + str(buf_in.dtype) + "[:, :], " + str(buf_out.dtype) + "[:, :])"
     sizesig = "(m, n)->(m, n)" if buf_in.shape == buf_out.shape else "(m, n),(m, l)"
 
-    @guvectorize([typesig], sizesig, forceobj=True)
+    @guvectorize([typesig], sizesig, **nb_kwargs, forceobj=True)
     def psd(wf_in: np.ndarray, psd_out: np.ndarray) -> None:
         dft_fun(wf_in, buf_dft)
         np.abs(buf_dft, psd_out)

--- a/src/pygama/dsp/processors/fixed_time_pickoff.py
+++ b/src/pygama/dsp/processors/fixed_time_pickoff.py
@@ -4,13 +4,13 @@ import numpy as np
 from numba import guvectorize
 
 from pygama.dsp.errors import DSPFatal
+from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
 
 
 @guvectorize(
     ["void(float32[:], float32, float32[:])", "void(float64[:], float64, float64[:])"],
     "(n),()->()",
-    nopython=True,
-    cache=True,
+    **nb_kwargs
 )
 def fixed_time_pickoff(w_in: np.ndarray, t_in: int, a_out: np.ndarray) -> None:
     """Pick off the waveform value at the provided index.

--- a/src/pygama/dsp/processors/fixed_time_pickoff.py
+++ b/src/pygama/dsp/processors/fixed_time_pickoff.py
@@ -10,7 +10,7 @@ from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
 @guvectorize(
     ["void(float32[:], float32, float32[:])", "void(float64[:], float64, float64[:])"],
     "(n),()->()",
-    **nb_kwargs
+    **nb_kwargs,
 )
 def fixed_time_pickoff(w_in: np.ndarray, t_in: int, a_out: np.ndarray) -> None:
     """Pick off the waveform value at the provided index.

--- a/src/pygama/dsp/processors/gaussian_filter1d.py
+++ b/src/pygama/dsp/processors/gaussian_filter1d.py
@@ -38,6 +38,8 @@ from __future__ import annotations
 import numpy
 from numba import guvectorize
 
+from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
+
 
 def gaussian_filter1d(sigma: int, truncate: float = 4.0) -> numpy.ndarray:
     """1-D Gaussian filter.
@@ -89,6 +91,7 @@ def gaussian_filter1d(sigma: int, truncate: float = 4.0) -> numpy.ndarray:
             "void(int64[:], int64[:])",
         ],
         "(n),(m)",
+        **nb_kwargs,
         forceobj=True,
     )
     def gaussian_filter1d_out(wf_in, wf_out):

--- a/src/pygama/dsp/processors/get_multi_local_extrema.py
+++ b/src/pygama/dsp/processors/get_multi_local_extrema.py
@@ -5,6 +5,8 @@ from numba import guvectorize
 
 from pygama.dsp.errors import DSPFatal
 
+from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
+
 
 @guvectorize(
     [
@@ -12,8 +14,7 @@ from pygama.dsp.errors import DSPFatal
         "void(float64[:], float64, float64[:], float64[:],float64[:], float64[:], float64[:])",
     ],
     "(n),(),(m),(m),(),(),()",
-    nopython=True,
-    cache=True,
+    **nb_kwargs
 )
 def get_multi_local_extrema(
     w_in: np.ndarray,

--- a/src/pygama/dsp/processors/get_multi_local_extrema.py
+++ b/src/pygama/dsp/processors/get_multi_local_extrema.py
@@ -4,7 +4,6 @@ import numpy as np
 from numba import guvectorize
 
 from pygama.dsp.errors import DSPFatal
-
 from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
 
 
@@ -14,7 +13,7 @@ from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
         "void(float64[:], float64, float64[:], float64[:],float64[:], float64[:], float64[:])",
     ],
     "(n),(),(m),(m),(),(),()",
-    **nb_kwargs
+    **nb_kwargs,
 )
 def get_multi_local_extrema(
     w_in: np.ndarray,

--- a/src/pygama/dsp/processors/linear_slope_fit.py
+++ b/src/pygama/dsp/processors/linear_slope_fit.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import numpy as np
 from numba import guvectorize
 
+from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
+
 
 @guvectorize(
     [
@@ -10,8 +12,7 @@ from numba import guvectorize
         "void(float64[:], float64[:], float64[:], float64[:], float64[:])",
     ],
     "(n)->(),(),(),()",
-    nopython=True,
-    cache=True,
+    **nb_kwargs
 )
 def linear_slope_fit(
     w_in: np.ndarray, mean: float, stdev: float, slope: float, intercept: float

--- a/src/pygama/dsp/processors/linear_slope_fit.py
+++ b/src/pygama/dsp/processors/linear_slope_fit.py
@@ -12,7 +12,7 @@ from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
         "void(float64[:], float64[:], float64[:], float64[:], float64[:])",
     ],
     "(n)->(),(),(),()",
-    **nb_kwargs
+    **nb_kwargs,
 )
 def linear_slope_fit(
     w_in: np.ndarray, mean: float, stdev: float, slope: float, intercept: float

--- a/src/pygama/dsp/processors/log_check.py
+++ b/src/pygama/dsp/processors/log_check.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 import numpy as np
 from numba import guvectorize
 
+from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
+
 
 @guvectorize(
     ["void(float32[:], float32[:])", "void(float64[:], float64[:])"],
     "(n)->(n)",
-    nopython=True,
-    cache=True,
+    **nb_kwargs
 )
 def log_check(w_in: np.ndarray, w_log: np.ndarray) -> None:
     """

--- a/src/pygama/dsp/processors/log_check.py
+++ b/src/pygama/dsp/processors/log_check.py
@@ -9,7 +9,7 @@ from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
 @guvectorize(
     ["void(float32[:], float32[:])", "void(float64[:], float64[:])"],
     "(n)->(n)",
-    **nb_kwargs
+    **nb_kwargs,
 )
 def log_check(w_in: np.ndarray, w_log: np.ndarray) -> None:
     """

--- a/src/pygama/dsp/processors/min_max.py
+++ b/src/pygama/dsp/processors/min_max.py
@@ -12,7 +12,7 @@ from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
         "void(float64[:], float64[:], float64[:], float64[:], float64[:])",
     ],
     "(n)->(),(),(),()",
-    **nb_kwargs
+    **nb_kwargs,
 )
 def min_max(
     w_in: np.ndarray, t_min: int, t_max: int, a_min: float, a_max: float

--- a/src/pygama/dsp/processors/min_max.py
+++ b/src/pygama/dsp/processors/min_max.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import numpy as np
 from numba import guvectorize
 
+from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
+
 
 @guvectorize(
     [
@@ -10,8 +12,7 @@ from numba import guvectorize
         "void(float64[:], float64[:], float64[:], float64[:], float64[:])",
     ],
     "(n)->(),(),(),()",
-    nopython=True,
-    cache=True,
+    **nb_kwargs
 )
 def min_max(
     w_in: np.ndarray, t_min: int, t_max: int, a_min: float, a_max: float

--- a/src/pygama/dsp/processors/moving_windows.py
+++ b/src/pygama/dsp/processors/moving_windows.py
@@ -4,14 +4,13 @@ import numpy as np
 from numba import guvectorize
 
 from pygama.dsp.errors import DSPFatal
-
 from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
 
 
 @guvectorize(
     ["void(float32[:], float32, float32[:])", "void(float64[:], float64, float64[:])"],
     "(n),()->(n)",
-    **nb_kwargs
+    **nb_kwargs,
 )
 def moving_window_left(w_in: np.ndarray, length: float, w_out: np.ndarray) -> None:
     """Applies a moving average window to the waveform.
@@ -62,7 +61,7 @@ def moving_window_left(w_in: np.ndarray, length: float, w_out: np.ndarray) -> No
 @guvectorize(
     ["void(float32[:], float32, float32[:])", "void(float64[:], float64, float64[:])"],
     "(n),()->(n)",
-    **nb_kwargs
+    **nb_kwargs,
 )
 def moving_window_right(w_in: np.ndarray, length: float, w_out: np.ndarray) -> None:
     """Applies a moving average window to the waveform from the right.
@@ -117,7 +116,7 @@ def moving_window_right(w_in: np.ndarray, length: float, w_out: np.ndarray) -> N
         "void(float64[:], float64, float64, int32, float64[:])",
     ],
     "(n),(),(),()->(n)",
-    **nb_kwargs
+    **nb_kwargs,
 )
 def moving_window_multi(
     w_in: np.ndarray, length: float, num_mw: int, mw_type: int, w_out: np.ndarray
@@ -199,7 +198,7 @@ def moving_window_multi(
 @guvectorize(
     ["void(float32[:], float32, float32[:])", "void(float64[:], float64, float64[:])"],
     "(n),(),(m)",
-    **nb_kwargs
+    **nb_kwargs,
 )
 def avg_current(w_in: np.ndarray, length: float, w_out: np.ndarray) -> None:
     """Calculate the derivative of a waveform, averaged across `length` samples.

--- a/src/pygama/dsp/processors/moving_windows.py
+++ b/src/pygama/dsp/processors/moving_windows.py
@@ -5,12 +5,13 @@ from numba import guvectorize
 
 from pygama.dsp.errors import DSPFatal
 
+from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
+
 
 @guvectorize(
     ["void(float32[:], float32, float32[:])", "void(float64[:], float64, float64[:])"],
     "(n),()->(n)",
-    nopython=True,
-    cache=True,
+    **nb_kwargs
 )
 def moving_window_left(w_in: np.ndarray, length: float, w_out: np.ndarray) -> None:
     """Applies a moving average window to the waveform.
@@ -61,8 +62,7 @@ def moving_window_left(w_in: np.ndarray, length: float, w_out: np.ndarray) -> No
 @guvectorize(
     ["void(float32[:], float32, float32[:])", "void(float64[:], float64, float64[:])"],
     "(n),()->(n)",
-    nopython=True,
-    cache=True,
+    **nb_kwargs
 )
 def moving_window_right(w_in: np.ndarray, length: float, w_out: np.ndarray) -> None:
     """Applies a moving average window to the waveform from the right.
@@ -117,8 +117,7 @@ def moving_window_right(w_in: np.ndarray, length: float, w_out: np.ndarray) -> N
         "void(float64[:], float64, float64, int32, float64[:])",
     ],
     "(n),(),(),()->(n)",
-    nopython=True,
-    cache=True,
+    **nb_kwargs
 )
 def moving_window_multi(
     w_in: np.ndarray, length: float, num_mw: int, mw_type: int, w_out: np.ndarray
@@ -200,8 +199,7 @@ def moving_window_multi(
 @guvectorize(
     ["void(float32[:], float32, float32[:])", "void(float64[:], float64, float64[:])"],
     "(n),(),(m)",
-    nopython=True,
-    cache=True,
+    **nb_kwargs
 )
 def avg_current(w_in: np.ndarray, length: float, w_out: np.ndarray) -> None:
     """Calculate the derivative of a waveform, averaged across `length` samples.

--- a/src/pygama/dsp/processors/multi_a_filter.py
+++ b/src/pygama/dsp/processors/multi_a_filter.py
@@ -2,9 +2,9 @@ import numpy as np
 from numba import guvectorize
 
 from pygama.dsp.errors import DSPFatal
+from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
 
 from .fixed_time_pickoff import fixed_time_pickoff
-from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
 
 
 @guvectorize(

--- a/src/pygama/dsp/processors/multi_a_filter.py
+++ b/src/pygama/dsp/processors/multi_a_filter.py
@@ -4,6 +4,7 @@ from numba import guvectorize
 from pygama.dsp.errors import DSPFatal
 
 from .fixed_time_pickoff import fixed_time_pickoff
+from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
 
 
 @guvectorize(
@@ -12,8 +13,8 @@ from .fixed_time_pickoff import fixed_time_pickoff
         "void(float64[:], float64[:], float64[:])",
     ],
     "(n),(m),(m)",
-    forceobj=True,
-    cache=True,
+    **nb_kwargs,
+    forceobj=True
 )
 def multi_a_filter(w_in, vt_maxs_in, va_max_out):
     """

--- a/src/pygama/dsp/processors/multi_t_filter.py
+++ b/src/pygama/dsp/processors/multi_t_filter.py
@@ -6,6 +6,7 @@ from numba import guvectorize
 from pygama.dsp.errors import DSPFatal
 
 from .time_point_thresh import time_point_thresh
+from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
 
 
 @guvectorize(
@@ -14,8 +15,8 @@ from .time_point_thresh import time_point_thresh
         "void(float64[:],float64[:],float64[:])",
     ],
     "(n),(n) -> (n)",
-    nopython=True,
-    cache=True,
+    **nb_kwargs,
+    forceobj=True
 )
 def remove_duplicates(
     t_in: np.ndarray, vt_min_in: np.ndarray, t_out: np.ndarray
@@ -80,8 +81,8 @@ def remove_duplicates(
         "void(float64[:], float64[:], float64[:], float64[:], float64[:])",
     ],
     "(n),(),(m),(m),(m)",
-    forceobj=True,
-    cache=True,
+    **nb_kwargs,
+    forceobj=True
 )
 def multi_t_filter(
     w_in: np.ndarray,

--- a/src/pygama/dsp/processors/multi_t_filter.py
+++ b/src/pygama/dsp/processors/multi_t_filter.py
@@ -4,9 +4,9 @@ import numpy as np
 from numba import guvectorize
 
 from pygama.dsp.errors import DSPFatal
+from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
 
 from .time_point_thresh import time_point_thresh
-from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
 
 
 @guvectorize(
@@ -16,7 +16,7 @@ from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
     ],
     "(n),(n) -> (n)",
     **nb_kwargs,
-    forceobj=True
+    forceobj=True,
 )
 def remove_duplicates(
     t_in: np.ndarray, vt_min_in: np.ndarray, t_out: np.ndarray
@@ -82,7 +82,7 @@ def remove_duplicates(
     ],
     "(n),(),(m),(m),(m)",
     **nb_kwargs,
-    forceobj=True
+    forceobj=True,
 )
 def multi_t_filter(
     w_in: np.ndarray,

--- a/src/pygama/dsp/processors/optimize.py
+++ b/src/pygama/dsp/processors/optimize.py
@@ -9,6 +9,7 @@ from numba import guvectorize
 from pygama.dsp.errors import DSPFatal
 
 from .pole_zero import double_pole_zero, pole_zero
+from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
 
 
 class Model:
@@ -40,6 +41,7 @@ class Model:
         "void(float64[:], float64, float64, float64, float64, float64[:])",
     ],
     "(n),(),(),(),()->()",
+    **nb_kwargs,
     forceobj=True,
 )
 def optimize_1pz(
@@ -124,6 +126,7 @@ def optimize_1pz(
         "void(float64[:], float64, float64, float64, float64, float64, float64, float64[:], float64[:], float64[:])",
     ],
     "(n),(),(),(),(),(),()->(),(),()",
+    **nb_kwargs,
     forceobj=True,
 )
 def optimize_2pz(

--- a/src/pygama/dsp/processors/optimize.py
+++ b/src/pygama/dsp/processors/optimize.py
@@ -7,9 +7,9 @@ from iminuit import Minuit
 from numba import guvectorize
 
 from pygama.dsp.errors import DSPFatal
+from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
 
 from .pole_zero import double_pole_zero, pole_zero
-from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
 
 
 class Model:

--- a/src/pygama/dsp/processors/param_lookup.py
+++ b/src/pygama/dsp/processors/param_lookup.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import numpy as np
 from numba import from_dtype, guvectorize, types
 
+from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
+
 
 def param_lookup(
     param_dict: dict[int, float], default_val: float, dtype: str | np.dtype
@@ -18,7 +20,7 @@ def param_lookup(
     param_dict = {types.uint32(k): out_type(v) for k, v in param_dict.items()}
     default_val = out_type(default_val)
 
-    @guvectorize(["void(uint32, " + out_type.name + "[:])"], "()->()", forceobj=True)
+    @guvectorize(["void(uint32, " + out_type.name + "[:])"], "()->()", **nb_kwargs, forceobj=True)
     def lookup(channel: int, val: np.ndarray) -> None:
         """Look up a value for the provided channel from a dictionary provided
         at compile time.

--- a/src/pygama/dsp/processors/param_lookup.py
+++ b/src/pygama/dsp/processors/param_lookup.py
@@ -20,7 +20,9 @@ def param_lookup(
     param_dict = {types.uint32(k): out_type(v) for k, v in param_dict.items()}
     default_val = out_type(default_val)
 
-    @guvectorize(["void(uint32, " + out_type.name + "[:])"], "()->()", **nb_kwargs, forceobj=True)
+    @guvectorize(
+        ["void(uint32, " + out_type.name + "[:])"], "()->()", **nb_kwargs, forceobj=True
+    )
     def lookup(channel: int, val: np.ndarray) -> None:
         """Look up a value for the provided channel from a dictionary provided
         at compile time.

--- a/src/pygama/dsp/processors/pole_zero.py
+++ b/src/pygama/dsp/processors/pole_zero.py
@@ -5,12 +5,13 @@ from numba import guvectorize
 
 from pygama.dsp.errors import DSPFatal
 
+from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
+
 
 @guvectorize(
     ["void(float32[:], float32, float32[:])", "void(float64[:], float64, float64[:])"],
     "(n),()->(n)",
-    nopython=True,
-    cache=True,
+    **nb_kwargs
 )
 def pole_zero(w_in: np.ndarray, t_tau: float, w_out: np.ndarray) -> None:
     """Apply a pole-zero cancellation using the provided time
@@ -54,8 +55,7 @@ def pole_zero(w_in: np.ndarray, t_tau: float, w_out: np.ndarray) -> None:
         "void(float64[:], float64, float64, float64, float64[:])",
     ],
     "(n),(),(),()->(n)",
-    nopython=True,
-    cache=True,
+    **nb_kwargs
 )
 def double_pole_zero(
     w_in: np.ndarray, t_tau1: float, t_tau2: float, frac: float, w_out: np.ndarray

--- a/src/pygama/dsp/processors/pole_zero.py
+++ b/src/pygama/dsp/processors/pole_zero.py
@@ -4,14 +4,13 @@ import numpy as np
 from numba import guvectorize
 
 from pygama.dsp.errors import DSPFatal
-
 from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
 
 
 @guvectorize(
     ["void(float32[:], float32, float32[:])", "void(float64[:], float64, float64[:])"],
     "(n),()->(n)",
-    **nb_kwargs
+    **nb_kwargs,
 )
 def pole_zero(w_in: np.ndarray, t_tau: float, w_out: np.ndarray) -> None:
     """Apply a pole-zero cancellation using the provided time
@@ -55,7 +54,7 @@ def pole_zero(w_in: np.ndarray, t_tau: float, w_out: np.ndarray) -> None:
         "void(float64[:], float64, float64, float64, float64[:])",
     ],
     "(n),(),(),()->(n)",
-    **nb_kwargs
+    **nb_kwargs,
 )
 def double_pole_zero(
     w_in: np.ndarray, t_tau1: float, t_tau2: float, frac: float, w_out: np.ndarray

--- a/src/pygama/dsp/processors/presum.py
+++ b/src/pygama/dsp/processors/presum.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 import numpy as np
 from numba import guvectorize
 
+from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
+
 
 @guvectorize(
     ["void(float32[:], float32[:])", "void(float64[:], float64[:])"],
     "(n),(m)",
-    nopython=True,
-    cache=True,
+    **nb_kwargs
 )
 def presum(w_in: np.ndarray, w_out: np.ndarray) -> None:
     """Presum the waveform.

--- a/src/pygama/dsp/processors/presum.py
+++ b/src/pygama/dsp/processors/presum.py
@@ -9,7 +9,7 @@ from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
 @guvectorize(
     ["void(float32[:], float32[:])", "void(float64[:], float64[:])"],
     "(n),(m)",
-    **nb_kwargs
+    **nb_kwargs,
 )
 def presum(w_in: np.ndarray, w_out: np.ndarray) -> None:
     """Presum the waveform.

--- a/src/pygama/dsp/processors/pulse_injector.py
+++ b/src/pygama/dsp/processors/pulse_injector.py
@@ -5,6 +5,8 @@ from math import exp, log
 import numpy as np
 from numba import guvectorize
 
+from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
+
 
 @guvectorize(
     [
@@ -12,8 +14,7 @@ from numba import guvectorize
         "void(float64[:], float64, float64,float64,float64,float64[:])",
     ],
     "(n),(),(),(), ()->(n)",
-    nopython=True,
-    cache=True,
+    **nb_kwargs
 )
 def inject_sig_pulse(
     wf_in: np.ndarray, t0: int, rt: float, a: float, decay: float, wf_out: np.ndarray
@@ -66,8 +67,7 @@ def inject_sig_pulse(
         "void(float64[:], float64, float64,float64,float64,float64[:])",
     ],
     "(n),(),(),(), ()->(n)",
-    nopython=True,
-    cache=True,
+    **nb_kwargs
 )
 def inject_exp_pulse(
     wf_in: np.ndarray, t0: int, rt: float, a: float, decay: float, wf_out: np.ndarray

--- a/src/pygama/dsp/processors/pulse_injector.py
+++ b/src/pygama/dsp/processors/pulse_injector.py
@@ -14,7 +14,7 @@ from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
         "void(float64[:], float64, float64,float64,float64,float64[:])",
     ],
     "(n),(),(),(), ()->(n)",
-    **nb_kwargs
+    **nb_kwargs,
 )
 def inject_sig_pulse(
     wf_in: np.ndarray, t0: int, rt: float, a: float, decay: float, wf_out: np.ndarray
@@ -67,7 +67,7 @@ def inject_sig_pulse(
         "void(float64[:], float64, float64,float64,float64,float64[:])",
     ],
     "(n),(),(),(), ()->(n)",
-    **nb_kwargs
+    **nb_kwargs,
 )
 def inject_exp_pulse(
     wf_in: np.ndarray, t0: int, rt: float, a: float, decay: float, wf_out: np.ndarray

--- a/src/pygama/dsp/processors/saturation.py
+++ b/src/pygama/dsp/processors/saturation.py
@@ -5,6 +5,8 @@ from numba import guvectorize
 
 from pygama.dsp.errors import DSPFatal
 
+from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
+
 
 @guvectorize(
     [
@@ -12,8 +14,7 @@ from pygama.dsp.errors import DSPFatal
         "void(float64[:], float64, float64[:], float64[:])",
     ],
     "(n),()->(),()",
-    nopython=True,
-    cache=True,
+    **nb_kwargs
 )
 def saturation(
     w_in: np.ndarray, bit_depth_in: int, n_lo_out: int, n_hi_out: int

--- a/src/pygama/dsp/processors/saturation.py
+++ b/src/pygama/dsp/processors/saturation.py
@@ -4,7 +4,6 @@ import numpy as np
 from numba import guvectorize
 
 from pygama.dsp.errors import DSPFatal
-
 from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
 
 
@@ -14,7 +13,7 @@ from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
         "void(float64[:], float64, float64[:], float64[:])",
     ],
     "(n),()->(),()",
-    **nb_kwargs
+    **nb_kwargs,
 )
 def saturation(
     w_in: np.ndarray, bit_depth_in: int, n_lo_out: int, n_hi_out: int

--- a/src/pygama/dsp/processors/soft_pileup_corr.py
+++ b/src/pygama/dsp/processors/soft_pileup_corr.py
@@ -4,7 +4,6 @@ import numpy as np
 from numba import guvectorize
 
 from pygama.dsp.errors import DSPFatal
-
 from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
 
 
@@ -14,7 +13,7 @@ from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
         "void(float64[:], float64, float64, float64[:])",
     ],
     "(n),(),()->(n)",
-    **nb_kwargs
+    **nb_kwargs,
 )
 def soft_pileup_corr(
     w_in: np.ndarray, n_in: int, tau_in: float, w_out: np.ndarray
@@ -83,7 +82,7 @@ def soft_pileup_corr(
         "void(float64[:], float64, float64, float64, float64[:])",
     ],
     "(n),(),(),()->(n)",
-    **nb_kwargs
+    **nb_kwargs,
 )
 def soft_pileup_corr_bl(
     w_in: np.ndarray, n_in: int, tau_in: float, b_in: float, w_out: np.ndarray

--- a/src/pygama/dsp/processors/soft_pileup_corr.py
+++ b/src/pygama/dsp/processors/soft_pileup_corr.py
@@ -5,6 +5,8 @@ from numba import guvectorize
 
 from pygama.dsp.errors import DSPFatal
 
+from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
+
 
 @guvectorize(
     [
@@ -12,8 +14,7 @@ from pygama.dsp.errors import DSPFatal
         "void(float64[:], float64, float64, float64[:])",
     ],
     "(n),(),()->(n)",
-    nopython=True,
-    cache=True,
+    **nb_kwargs
 )
 def soft_pileup_corr(
     w_in: np.ndarray, n_in: int, tau_in: float, w_out: np.ndarray
@@ -82,8 +83,7 @@ def soft_pileup_corr(
         "void(float64[:], float64, float64, float64, float64[:])",
     ],
     "(n),(),(),()->(n)",
-    nopython=True,
-    cache=True,
+    **nb_kwargs
 )
 def soft_pileup_corr_bl(
     w_in: np.ndarray, n_in: int, tau_in: float, b_in: float, w_out: np.ndarray

--- a/src/pygama/dsp/processors/time_point_thresh.py
+++ b/src/pygama/dsp/processors/time_point_thresh.py
@@ -4,7 +4,6 @@ import numpy as np
 from numba import guvectorize
 
 from pygama.dsp.errors import DSPFatal
-
 from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
 
 
@@ -14,7 +13,7 @@ from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
         "void(float64[:], float64, float64, float64, float64[:])",
     ],
     "(n),(),(),()->()",
-    **nb_kwargs
+    **nb_kwargs,
 )
 def time_point_thresh(
     w_in: np.ndarray, a_threshold: float, t_start: int, walk_forward: int, t_out: float

--- a/src/pygama/dsp/processors/time_point_thresh.py
+++ b/src/pygama/dsp/processors/time_point_thresh.py
@@ -5,6 +5,8 @@ from numba import guvectorize
 
 from pygama.dsp.errors import DSPFatal
 
+from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
+
 
 @guvectorize(
     [
@@ -12,8 +14,7 @@ from pygama.dsp.errors import DSPFatal
         "void(float64[:], float64, float64, float64, float64[:])",
     ],
     "(n),(),(),()->()",
-    nopython=True,
-    cache=True,
+    **nb_kwargs
 )
 def time_point_thresh(
     w_in: np.ndarray, a_threshold: float, t_start: int, walk_forward: int, t_out: float

--- a/src/pygama/dsp/processors/trap_filters.py
+++ b/src/pygama/dsp/processors/trap_filters.py
@@ -4,7 +4,6 @@ import numpy as np
 from numba import guvectorize
 
 from pygama.dsp.errors import DSPFatal
-
 from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
 
 
@@ -14,7 +13,7 @@ from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
         "void(float64[:], int32, int32, float64[:])",
     ],
     "(n),(),()->(n)",
-    **nb_kwargs
+    **nb_kwargs,
 )
 def trap_filter(w_in: np.ndarray, rise: int, flat: int, w_out: np.ndarray) -> None:
     """Apply a symmetric trapezoidal filter to the waveform.
@@ -79,7 +78,7 @@ def trap_filter(w_in: np.ndarray, rise: int, flat: int, w_out: np.ndarray) -> No
         "void(float64[:], int32, int32, float64[:])",
     ],
     "(n),(),()->(n)",
-    **nb_kwargs
+    **nb_kwargs,
 )
 def trap_norm(w_in: np.ndarray, rise: int, flat: int, w_out: np.ndarray) -> None:
     """Apply a symmetric trapezoidal filter to the waveform, normalized by the
@@ -150,7 +149,7 @@ def trap_norm(w_in: np.ndarray, rise: int, flat: int, w_out: np.ndarray) -> None
         "void(float64[:], int32, int32, int32, float64[:])",
     ],
     "(n),(),(),()->(n)",
-    **nb_kwargs
+    **nb_kwargs,
 )
 def asym_trap_filter(
     w_in: np.ndarray, rise: int, flat: int, fall: int, w_out: np.ndarray
@@ -225,7 +224,7 @@ def asym_trap_filter(
         "void(float64[:], int32, int32, float64, float64[:])",
     ],
     "(n),(),(),()->()",
-    **nb_kwargs
+    **nb_kwargs,
 )
 def trap_pickoff(
     w_in: np.ndarray, rise: int, flat: int, t_pickoff: float, a_out: float

--- a/src/pygama/dsp/processors/trap_filters.py
+++ b/src/pygama/dsp/processors/trap_filters.py
@@ -5,6 +5,8 @@ from numba import guvectorize
 
 from pygama.dsp.errors import DSPFatal
 
+from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
+
 
 @guvectorize(
     [
@@ -12,8 +14,7 @@ from pygama.dsp.errors import DSPFatal
         "void(float64[:], int32, int32, float64[:])",
     ],
     "(n),(),()->(n)",
-    nopython=True,
-    cache=True,
+    **nb_kwargs
 )
 def trap_filter(w_in: np.ndarray, rise: int, flat: int, w_out: np.ndarray) -> None:
     """Apply a symmetric trapezoidal filter to the waveform.
@@ -78,8 +79,7 @@ def trap_filter(w_in: np.ndarray, rise: int, flat: int, w_out: np.ndarray) -> No
         "void(float64[:], int32, int32, float64[:])",
     ],
     "(n),(),()->(n)",
-    nopython=True,
-    cache=True,
+    **nb_kwargs
 )
 def trap_norm(w_in: np.ndarray, rise: int, flat: int, w_out: np.ndarray) -> None:
     """Apply a symmetric trapezoidal filter to the waveform, normalized by the
@@ -150,8 +150,7 @@ def trap_norm(w_in: np.ndarray, rise: int, flat: int, w_out: np.ndarray) -> None
         "void(float64[:], int32, int32, int32, float64[:])",
     ],
     "(n),(),(),()->(n)",
-    nopython=True,
-    cache=True,
+    **nb_kwargs
 )
 def asym_trap_filter(
     w_in: np.ndarray, rise: int, flat: int, fall: int, w_out: np.ndarray
@@ -226,8 +225,7 @@ def asym_trap_filter(
         "void(float64[:], int32, int32, float64, float64[:])",
     ],
     "(n),(),(),()->()",
-    nopython=True,
-    cache=True,
+    **nb_kwargs
 )
 def trap_pickoff(
     w_in: np.ndarray, rise: int, flat: int, t_pickoff: float, a_out: float

--- a/src/pygama/dsp/processors/upsampler.py
+++ b/src/pygama/dsp/processors/upsampler.py
@@ -5,12 +5,13 @@ from numba import guvectorize
 
 from pygama.dsp.errors import DSPFatal
 
+from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
+
 
 @guvectorize(
     ["void(float32[:], float32, float32[:])", "void(float64[:], float64, float64[:])"],
     "(n),(),(m)",
-    nopython=True,
-    cache=True,
+    **nb_kwargs
 )
 def upsampler(w_in: np.ndarray, upsample: float, w_out: np.ndarray) -> None:
     """Upsamples the waveform by the number specified, a series of moving

--- a/src/pygama/dsp/processors/upsampler.py
+++ b/src/pygama/dsp/processors/upsampler.py
@@ -4,14 +4,13 @@ import numpy as np
 from numba import guvectorize
 
 from pygama.dsp.errors import DSPFatal
-
 from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
 
 
 @guvectorize(
     ["void(float32[:], float32, float32[:])", "void(float64[:], float64, float64[:])"],
     "(n),(),(m)",
-    **nb_kwargs
+    **nb_kwargs,
 )
 def upsampler(w_in: np.ndarray, upsample: float, w_out: np.ndarray) -> None:
     """Upsamples the waveform by the number specified, a series of moving

--- a/src/pygama/dsp/processors/wiener_filter.py
+++ b/src/pygama/dsp/processors/wiener_filter.py
@@ -5,7 +5,6 @@ from numba import guvectorize
 
 import pygama.lgdo.lh5_store as lh5
 from pygama.dsp.errors import DSPFatal
-
 from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
 
 

--- a/src/pygama/dsp/processors/wiener_filter.py
+++ b/src/pygama/dsp/processors/wiener_filter.py
@@ -6,6 +6,8 @@ from numba import guvectorize
 import pygama.lgdo.lh5_store as lh5
 from pygama.dsp.errors import DSPFatal
 
+from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
+
 
 def wiener_filter(file_name_array: list[str]) -> np.ndarray:
     """Apply a Wiener filter to the waveform.
@@ -115,6 +117,7 @@ def wiener_filter(file_name_array: list[str]) -> np.ndarray:
     @guvectorize(
         ["void(complex64[:], complex64[:])", "void(complex128[:], complex128[:])"],
         "(n)->(n)",
+        **nb_kwargs,
         forceobj=True,
     )
     def wiener_out(fft_w_in: np.ndarray, fft_w_out: np.ndarray) -> None:

--- a/src/pygama/dsp/processors/windower.py
+++ b/src/pygama/dsp/processors/windower.py
@@ -4,14 +4,13 @@ import numpy as np
 from numba import guvectorize
 
 from pygama.dsp.errors import DSPFatal
-
 from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
 
 
 @guvectorize(
     ["void(float32[:], float32, float32[:])", "void(float64[:], float64, float64[:])"],
     "(n),(),(m)",
-    **nb_kwargs
+    **nb_kwargs,
 )
 def windower(w_in: np.ndarray, t0_in: int, w_out: np.ndarray) -> None:
     """Return a shorter sample of the waveform, starting at the

--- a/src/pygama/dsp/processors/windower.py
+++ b/src/pygama/dsp/processors/windower.py
@@ -5,12 +5,13 @@ from numba import guvectorize
 
 from pygama.dsp.errors import DSPFatal
 
+from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
+
 
 @guvectorize(
     ["void(float32[:], float32, float32[:])", "void(float64[:], float64, float64[:])"],
     "(n),(),(m)",
-    nopython=True,
-    cache=True,
+    **nb_kwargs
 )
 def windower(w_in: np.ndarray, t0_in: int, w_out: np.ndarray) -> None:
     """Return a shorter sample of the waveform, starting at the

--- a/src/pygama/dsp/utils.py
+++ b/src/pygama/dsp/utils.py
@@ -1,5 +1,19 @@
 class NumbaDefaults:
-    """Bare-bones class to store some Numba default options."""
+    """Bare-bones class to store some Numba default options.
+
+    Examples
+    --------
+    Set all default option values at once by expanding the provided dictionary:
+
+    >>> from numba import guvectorize
+    >>> from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
+    >>> @guvectorize([], "", **nb_kwargs, nopython=True) # def proc(...): ...
+
+    Customize one argument but still set defaults for the others:
+
+    >>> from pygama.dsp.utils import numba_defaults as nb_defaults
+    >>> @guvectorize([], "", cache=nb_defaults.cache, boundscheck=True) # def proc(...): ...
+    """
 
     def __init__(self) -> None:
         self.cache: bool = True

--- a/src/pygama/dsp/utils.py
+++ b/src/pygama/dsp/utils.py
@@ -1,0 +1,9 @@
+class NumbaDefaults():
+    """Bare-bones class to store some Numba default options."""
+    def __init__(self) -> None:
+        self.cache: bool = True
+        self.boundscheck: bool = False
+
+
+numba_defaults = NumbaDefaults()
+numba_defaults_kwargs = numba_defaults.__dict__

--- a/src/pygama/dsp/utils.py
+++ b/src/pygama/dsp/utils.py
@@ -1,5 +1,6 @@
-class NumbaDefaults():
+class NumbaDefaults:
     """Bare-bones class to store some Numba default options."""
+
     def __init__(self) -> None:
         self.cache: bool = True
         self.boundscheck: bool = False

--- a/tests/dsp/test_utils.py
+++ b/tests/dsp/test_utils.py
@@ -1,0 +1,6 @@
+from pygama.dsp.utils import numba_defaults
+
+
+def test_numba_defaults_loading():
+    numba_defaults.cache = False
+    numba_defaults.boundscheck = True


### PR DESCRIPTION
Example usage:
```py
from pygama.dsp.utils import numba_defaults
from pygama.dsp import build_dsp

# must do this before explicitly importing pygama.dsp.processors!
numba_defaults.cache = False
numba_defaults.boundscheck = True

build_dsp(...) # processors imports happen here
```
* Compilation of procesors takes ~30 sec on my laptop. I think this is non-negligible and we should set `cache=True` by default.
* I would leave `boundscheck=False` default as in Numba.

To do:
- [ ] @iguinn what do we do with `nopython`? Do we really want to set it to `True`?
- [x] Update documentation
