### PR TITLE
Added interpolation option to `fixed_time_pickoff()` processor

### DIFF
--- a/src/pygama/dsp/processing_chain.py
+++ b/src/pygama/dsp/processing_chain.py
@@ -1150,6 +1150,16 @@ class ProcessorManager:
                         arshape.insert(len(arshape) + idim + 1, 1)
                 param = param.reshape(tuple(arshape))
 
+            elif isinstance(param, str):
+                # Convert string into integer buffer if appropriate
+                if np.issubdtype(dtype, np.integer):
+                    try:
+                        param = np.frombuffer(param.encode('ascii'), dtype).reshape(shape)
+                    except(ValueError):
+                        raise ProcessingChainError(
+                            f"could not convert string '{param}' into"
+                            f"byte-array of type {dtype} and shape {shape}")
+
             elif param is not None:
                 # Convert scalar to right type, including units
                 if isinstance(param, (Quantity, Unit)):

--- a/src/pygama/dsp/processing_chain.py
+++ b/src/pygama/dsp/processing_chain.py
@@ -1693,76 +1693,87 @@ def build_processing_chain(
             log.warning(
                 f"I don't know what to do with {input_par}. Building output without it!"
             )
-        proc_chain.link_input_buffer(input_par, buf_in)
+        try:
+            proc_chain.link_input_buffer(input_par, buf_in)
+        except Exception as e:
+            raise ProcessingChainError(
+                f"Exception raised while linking input buffer {input_par}."
+            ) from e
 
     # now add the processors
     for proc_par in proc_par_list:
         recipe = processors[proc_par]
-        module = importlib.import_module(recipe["module"])
-        func = getattr(module, recipe["function"])
-        args = recipe["args"]
-
-        # Initialize the new variables, if needed
-        if "unit" in recipe:
-            new_vars = [k for k in re.split(",| ", proc_par) if k != ""]
-            for i, name in enumerate(new_vars):
-                unit = recipe.get("unit", auto)
-                if isinstance(unit, list):
-                    unit = unit[i]
-
-                proc_chain.add_variable(name, unit=unit)
-
-        # get this list of kwargs
-        kwargs = recipe.get("kwargs", {})  # might also need db lookup here
-
-        # if init_args are defined, parse any strings and then call func
-        # as a factory/constructor function
         try:
-            init_args_in = recipe["init_args"]
-            init_args = []
-            init_kwargs = {}
-            for _, arg in enumerate(init_args_in):
-                for db_var in db_parser.findall(arg):
-                    try:
-                        db_node = db_dict
-                        for key in db_var[3:].split("."):
-                            db_node = db_node[key]
-                        log.debug(f"database lookup: found {db_node} for {db_var}")
-                    except (KeyError, TypeError):
+            module = importlib.import_module(recipe["module"])
+            func = getattr(module, recipe["function"])
+            args = recipe["args"]
+            
+            # Initialize the new variables, if needed
+            if "unit" in recipe:
+                new_vars = [k for k in re.split(",| ", proc_par) if k != ""]
+                for i, name in enumerate(new_vars):
+                    unit = recipe.get("unit", auto)
+                    if isinstance(unit, list):
+                        unit = unit[i]
+
+                    proc_chain.add_variable(name, unit=unit)
+
+            # get this list of kwargs
+            kwargs = recipe.get("kwargs", {})  # might also need db lookup here
+
+            # if init_args are defined, parse any strings and then call func
+            # as a factory/constructor function
+            try:
+                init_args_in = recipe["init_args"]
+                init_args = []
+                init_kwargs = {}
+                for _, arg in enumerate(init_args_in):
+                    for db_var in db_parser.findall(arg):
                         try:
-                            db_node = recipe["defaults"][db_var]
-                            log.debug(
-                                "database lookup: using default value of {db_node} for {db_var}"
-                            )
+                            db_node = db_dict
+                            for key in db_var[3:].split("."):
+                                db_node = db_node[key]
+                            log.debug(f"database lookup: found {db_node} for {db_var}")
                         except (KeyError, TypeError):
-                            raise ProcessingChainError(
-                                f"did not find {db_var} in database, and "
-                                f"could not find default value."
-                            )
+                            try:
+                                db_node = recipe["defaults"][db_var]
+                                log.debug(
+                                    "database lookup: using default value of {db_node} for {db_var}"
+                                )
+                            except (KeyError, TypeError):
+                                raise ProcessingChainError(
+                                    f"did not find {db_var} in database, and "
+                                    f"could not find default value."
+                                )
 
-                    if arg == db_var:
-                        arg = db_node
+                        if arg == db_var:
+                            arg = db_node
+                        else:
+                            arg = arg.replace(db_var, str(db_node))
+
+                    # see if string can be parsed by proc_chain
+                    if isinstance(arg, str):
+                        arg = proc_chain.get_variable(arg)
+                    if isinstance(arg, dict):
+                        init_kwargs.update(arg)
                     else:
-                        arg = arg.replace(db_var, str(db_node))
+                        init_args.append(arg)
 
-                # see if string can be parsed by proc_chain
-                if isinstance(arg, str):
-                    arg = proc_chain.get_variable(arg)
-                if isinstance(arg, dict):
-                    init_kwargs.update(arg)
-                else:
-                    init_args.append(arg)
+                expr = ", ".join(
+                    [f"{a}" for a in init_args]
+                    + [f"{k}={v}" for k, v in init_kwargs.items()]
+                )
+                log.debug(f"building function from init_args: {func.__name__}({expr})")
+                func = func(*init_args)
+            except KeyError:
+                pass
 
-            expr = ", ".join(
-                [f"{a}" for a in init_args]
-                + [f"{k}={v}" for k, v in init_kwargs.items()]
-            )
-            log.debug(f"building function from init_args: {func.__name__}({expr})")
-            func = func(*init_args)
-        except KeyError:
-            pass
-
-        proc_chain.add_processor(func, *args, **kwargs)
+            proc_chain.add_processor(func, *args, **kwargs)
+        except Exception as e:
+            raise ProcessingChainError(
+                "Exception raised while attempting to add processor:\n" + \
+                json.dumps(recipe, indent=2)
+                ) from e
 
     # build the output buffers
     lh5_out = lgdo.Table(size=proc_chain._buffer_len)
@@ -1779,8 +1790,13 @@ def build_processing_chain(
 
     # finally, add the output buffers to lh5_out and the proc chain
     for out_par in out_par_list:
-        buf_out = proc_chain.link_output_buffer(out_par)
-        lh5_out.add_field(out_par, buf_out)
+        try:
+            buf_out = proc_chain.link_output_buffer(out_par)
+            lh5_out.add_field(out_par, buf_out)
+        except Exception as e:
+            raise ProcessingChainError(
+                f"Exception raised while linking output buffer {out_par}."
+            ) from e
 
     field_mask = input_par_list + copy_par_list
     return (proc_chain, field_mask, lh5_out)

--- a/src/pygama/dsp/processors/__init__.py
+++ b/src/pygama/dsp/processors/__init__.py
@@ -63,7 +63,7 @@ from .bl_subtract import bl_subtract
 from .convolutions import cusp_filter, t0_filter, zac_filter
 from .dwt import discrete_wavelet_transform
 from .fftw import dft, inv_dft, psd
-from .fixed_time_pickoff import fixed_sample_pickoff, fixed_time_pickoff
+from .fixed_time_pickoff import fixed_time_pickoff
 from .gaussian_filter1d import gaussian_filter1d
 from .get_multi_local_extrema import get_multi_local_extrema
 from .histogram import histogram, histogram_stats
@@ -102,7 +102,6 @@ __all__ = [
     "dft",
     "inv_dft",
     "psd",
-    "fixed_sample_pickoff",
     "fixed_time_pickoff",
     "gaussian_filter1d",
     "get_multi_local_extrema",

--- a/src/pygama/dsp/processors/__init__.py
+++ b/src/pygama/dsp/processors/__init__.py
@@ -62,7 +62,7 @@ several advantages:
 from .bl_subtract import bl_subtract
 from .convolutions import cusp_filter, t0_filter, zac_filter
 from .fftw import dft, inv_dft, psd
-from .fixed_time_pickoff import fixed_time_pickoff
+from .fixed_time_pickoff import fixed_sample_pickoff, fixed_time_pickoff
 from .gaussian_filter1d import gaussian_filter1d
 from .get_multi_local_extrema import get_multi_local_extrema
 from .linear_slope_fit import linear_slope_fit
@@ -97,6 +97,7 @@ __all__ = [
     "dft",
     "inv_dft",
     "psd",
+    "fixed_sample_pickoff",
     "fixed_time_pickoff",
     "gaussian_filter1d",
     "get_multi_local_extrema",

--- a/src/pygama/dsp/processors/__init__.py
+++ b/src/pygama/dsp/processors/__init__.py
@@ -85,7 +85,7 @@ from .saturation import saturation
 from .soft_pileup_corr import soft_pileup_corr, soft_pileup_corr_bl
 from .time_point_thresh import time_point_thresh
 from .trap_filters import asym_trap_filter, trap_filter, trap_norm, trap_pickoff
-from .upsampler import upsampler
+from .upsampler import upsampler, interpolating_upsampler
 from .wiener_filter import wiener_filter
 from .windower import windower
 
@@ -128,6 +128,7 @@ __all__ = [
     "trap_norm",
     "trap_pickoff",
     "upsampler",
+    "interpolating_upsampler",
     "wiener_filter",
     "windower",
 ]

--- a/src/pygama/dsp/processors/__init__.py
+++ b/src/pygama/dsp/processors/__init__.py
@@ -85,7 +85,7 @@ from .saturation import saturation
 from .soft_pileup_corr import soft_pileup_corr, soft_pileup_corr_bl
 from .time_point_thresh import time_point_thresh
 from .trap_filters import asym_trap_filter, trap_filter, trap_norm, trap_pickoff
-from .upsampler import upsampler, interpolating_upsampler
+from .upsampler import interpolating_upsampler, upsampler
 from .wiener_filter import wiener_filter
 from .windower import windower
 

--- a/src/pygama/dsp/processors/fixed_time_pickoff.py
+++ b/src/pygama/dsp/processors/fixed_time_pickoff.py
@@ -11,7 +11,7 @@ from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
     [
         "void(float32[:], float32, float32[:])",
         "void(float64[:], float64, float64[:])",
-        "void(float32[:], int32, float32[:])",
+        "void(float32[:], int64, float32[:])",
         "void(float64[:], int64, float64[:])",
     ],
     "(n),()->()",

--- a/src/pygama/dsp/processors/fixed_time_pickoff.py
+++ b/src/pygama/dsp/processors/fixed_time_pickoff.py
@@ -4,7 +4,6 @@ import numpy as np
 from numba import guvectorize
 
 from pygama.dsp.errors import DSPFatal
-from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
 
 
 @guvectorize(

--- a/src/pygama/dsp/processors/fixed_time_pickoff.py
+++ b/src/pygama/dsp/processors/fixed_time_pickoff.py
@@ -9,60 +9,6 @@ from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
 
 @guvectorize(
     [
-        "void(float32[:], float32, float32[:])",
-        "void(float64[:], float64, float64[:])",
-        "void(float32[:], int64, float32[:])",
-        "void(float64[:], int64, float64[:])",
-    ],
-    "(n),()->()",
-    **nb_kwargs,
-)
-def fixed_sample_pickoff(w_in: np.ndarray, t_in: int, a_out: np.ndarray) -> None:
-    """
-    Pick off the waveform value at the provided index. If t_in is non-
-    integral, raise an exception. If non-integral t_in is required, use
-    fixed_time_pickoff to interpolate between samples.
-
-    If the provided index `t_in` is out of range, return :any:`numpy.nan`.
-
-    Parameters
-    ----------
-    w_in
-        the input waveform
-    t_in
-        the waveform index to pick off
-    a_out
-        the output pick-off value
-
-    JSON Configuration Example
-    --------------------------
-
-    .. code-block :: json
-
-        "trapEftp": {
-            "function": "fixed_time_pickoff",
-            "module": "pygama.dsp.processors",
-            "args": ["wf_trap", "tp_0+10*us", "trapEftp"],
-            "unit": "ADC"
-        }
-    """
-
-    a_out[0] = np.nan
-
-    if np.isnan(w_in).any() or np.isnan(t_in):
-        return
-
-    if np.floor(t_in) != t_in:
-        raise DSPFatal("The pick-off index must be an integer")
-
-    if int(t_in) < 0 or int(t_in) >= len(w_in):
-        return
-
-    a_out[0] = w_in[int(t_in)]
-
-
-@guvectorize(
-    [
         "void(float32[:], float32, char, float32[:])",
         "void(float64[:], float64, char, float64[:])",
     ],

--- a/src/pygama/dsp/processors/fixed_time_pickoff.py
+++ b/src/pygama/dsp/processors/fixed_time_pickoff.py
@@ -18,7 +18,8 @@ from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
     **nb_kwargs,
 )
 def fixed_sample_pickoff(w_in: np.ndarray, t_in: int, a_out: np.ndarray) -> None:
-    """Pick off the waveform value at the provided index. If t_in is non-
+    """
+    Pick off the waveform value at the provided index. If t_in is non-
     integral, raise an exception. If non-integral t_in is required, use
     fixed_time_pickoff to interpolate between samples.
 
@@ -45,6 +46,7 @@ def fixed_sample_pickoff(w_in: np.ndarray, t_in: int, a_out: np.ndarray) -> None
             "unit": "ADC"
         }
     """
+
     a_out[0] = np.nan
 
     if np.isnan(w_in).any() or np.isnan(t_in):

--- a/src/pygama/dsp/processors/fixed_time_pickoff.py
+++ b/src/pygama/dsp/processors/fixed_time_pickoff.py
@@ -70,7 +70,7 @@ def fixed_sample_pickoff(w_in: np.ndarray, t_in: int, a_out: np.ndarray) -> None
     nopython=True,
     cache=True,
 )
-def fixed_time_pickoff(w_in: np.ndarray, t_in: float, mode_in: char, a_out: float):
+def fixed_time_pickoff(w_in: np.ndarray, t_in: float, mode_in: np.int8, a_out: float):
     """
     Pick off the waveform value at the provided time.  If the
     provided index is out of range, return NaN. For non-integral
@@ -86,17 +86,19 @@ def fixed_time_pickoff(w_in: np.ndarray, t_in: float, mode_in: char, a_out: floa
     t_in
         The waveform index to pick off
     mode_in
-        Character selecting which interpolation method to use. Options:
-        'i': integer t_in; equivalent to fixed_sample_pickoff
-        'n': nearest-neighbor interpolation; defined at all values,
-             but not continuous
-        'l': linear interpolation; continuous at all values, but not
-             differentiable
-        'h': hermite cubic spline interpolation; continuous and
-             differentiable at all values but not twice-differentiable
-        's': natural cubic spline interpolation; continuous and twice-
-             differentiable at all values. This method is much slower
-             than the others because it utilizes the entire input waveform!
+        Character selecting which interpolation method to use. Note this
+        must be passed as a int8, e.g. ``ord('i')``. Options:
+
+        * 'i': integer t_in; equivalent to fixed_sample_pickoff
+        * 'n': nearest-neighbor interpolation; defined at all values,
+          but not continuous
+        * 'l': linear interpolation; continuous at all values, but not
+          differentiable
+        * 'h': hermite cubic spline interpolation; continuous and
+          differentiable at all values but not twice-differentiable
+        * 's': natural cubic spline interpolation; continuous and twice-
+          differentiable at all values. This method is much slower
+          than the others because it utilizes the entire input waveform!
     a_out
         The output pick-off value
 

--- a/src/pygama/dsp/processors/fixed_time_pickoff.py
+++ b/src/pygama/dsp/processors/fixed_time_pickoff.py
@@ -16,40 +16,39 @@ from pygama.dsp.errors import DSPFatal
     cache=True,
 )
 def fixed_time_pickoff(w_in: np.ndarray, t_in: float, mode_in: np.int8, a_out: float):
-    """
-    Pick off the waveform value at the provided time.  If the
-    provided index is out of range, return NaN. For non-integral
-    times, interpolate between samples using the method
-    selected using "mode_in".
+    """Pick off the waveform value at the provided time.
 
-    If the provided index `t_in` is out of range, return :any:`numpy.nan`.
+    For non-integral times, interpolate between samples using the method
+    selected using `mode_in`. If the provided index `t_in` is out of range,
+    return :any:`numpy.nan`.
 
     Parameters
     ----------
     w_in
-        The input waveform
+        the input waveform.
     t_in
-        The waveform index to pick off
+        the waveform index to pick off.
     mode_in
-        Character selecting which interpolation method to use. Note this
-        must be passed as a int8, e.g. ``ord('i')``. Options:
+        character selecting which interpolation method to use. Note this
+        must be passed as a ``int8``, e.g. ``ord('i')``. Options:
 
-        * 'i': integer t_in; equivalent to fixed_sample_pickoff
-        * 'n': nearest-neighbor interpolation; defined at all values,
+        * ``i`` -- integer `t_in`; equivalent to
+          :func:`~.dsp.processors.fixed_sample_pickoff`
+        * ``n`` -- nearest-neighbor interpolation; defined at all values,
           but not continuous
-        * 'f': floor, or value at previous neighbor; defined at all
+        * ``f`` -- floor, or value at previous neighbor; defined at all
           values but not continuous
-        * 'c': ceiling, or value at next neighbor; defined at all values,
+        * ``c`` -- ceiling, or value at next neighbor; defined at all values,
           but not continuous
-        * 'l': linear interpolation; continuous at all values, but not
+        * ``l`` -- linear interpolation; continuous at all values, but not
           differentiable
-        * 'h': hermite cubic spline interpolation; continuous and
+        * ``h`` -- Hermite cubic spline interpolation; continuous and
           differentiable at all values but not twice-differentiable
-        * 's': natural cubic spline interpolation; continuous and twice-
-          differentiable at all values. This method is much slower
+        * ``s`` -- natural cubic spline interpolation; continuous and
+          twice-differentiable at all values. This method is much slower
           than the others because it utilizes the entire input waveform!
     a_out
-        The output pick-off value
+        the output pick-off value.
 
     Examples
     --------

--- a/src/pygama/dsp/processors/fixed_time_pickoff.py
+++ b/src/pygama/dsp/processors/fixed_time_pickoff.py
@@ -92,6 +92,10 @@ def fixed_time_pickoff(w_in: np.ndarray, t_in: float, mode_in: np.int8, a_out: f
         * 'i': integer t_in; equivalent to fixed_sample_pickoff
         * 'n': nearest-neighbor interpolation; defined at all values,
           but not continuous
+        * 'f': floor, or value at previous neighbor; defined at all
+          values but not continuous
+        * 'c': ceiling, or value at next neighbor; defined at all values,
+          but not continuous
         * 'l': linear interpolation; continuous at all values, but not
           differentiable
         * 'h': hermite cubic spline interpolation; continuous and
@@ -133,6 +137,10 @@ def fixed_time_pickoff(w_in: np.ndarray, t_in: float, mode_in: np.int8, a_out: f
         raise DSPFatal("fixed_time_pickoff requires integer t_in when using mode 'i'")
     elif chr(mode_in) == "n":  # Nearest-neighbor
         a_out[0] = w_in[i_in] if t0 < 0.5 else w_in[i_in + 1]
+    elif chr(mode_in) == "f":  # Floor
+        a_out[0] = w_in[i_in]
+    elif chr(mode_in) == "c":  # Ceiling
+        a_out[0] = w_in[i_in+1]
     elif chr(mode_in) == "l":  # linear
         a_out[0] = t1 * w_in[i_in] + t0 * w_in[i_in + 1]
     elif chr(mode_in) == "h":  # Cubic hermite

--- a/src/pygama/dsp/processors/fixed_time_pickoff.py
+++ b/src/pygama/dsp/processors/fixed_time_pickoff.py
@@ -8,12 +8,14 @@ from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
 
 
 @guvectorize(
-    ["void(float32[:], float32, float32[:])", "void(float64[:], float64, float64[:])"],
+    ["void(float32[:], float32, float32[:])", "void(float64[:], float64, float64[:])", "void(float32[:], int32, float32[:])", "void(float64[:], int64, float64[:])"],
     "(n),()->()",
     **nb_kwargs,
 )
-def fixed_time_pickoff(w_in: np.ndarray, t_in: int, a_out: np.ndarray) -> None:
-    """Pick off the waveform value at the provided index.
+def fixed_sample_pickoff(w_in: np.ndarray, t_in: int, a_out: np.ndarray) -> None:
+    """Pick off the waveform value at the provided index. If t_in is non-
+    integral, raise an exception. If non-integral t_in is required, use
+    fixed_time_pickoff to interpolate between samples.
 
     If the provided index `t_in` is out of range, return :any:`numpy.nan`.
 
@@ -50,3 +52,89 @@ def fixed_time_pickoff(w_in: np.ndarray, t_in: int, a_out: np.ndarray) -> None:
         return
 
     a_out[0] = w_in[int(t_in)]
+
+@guvectorize(["void(float32[:], float32, char, float32[:])",
+              "void(float64[:], float64, char, float64[:])"],
+             "(n),(),()->()", nopython=True, cache=True)
+def fixed_time_pickoff(w_in: np.ndarray, t_in: float, mode_in: char, a_out: float):
+    """
+    Pick off the waveform value at the provided time.  If the
+    provided index is out of range, return NaN. For non-integral
+    times, interpolate between samples using the method
+    selected using "mode_in".
+
+    If the provided index `t_in` is out of range, return :any:`numpy.nan`.
+
+    Parameters
+    ----------
+    w_in
+        The input waveform
+    t_in
+        The waveform index to pick off
+    mode_in
+        Character selecting which interpolation method to use. Options:
+        'i': integer t_in; equivalent to fixed_sample_pickoff
+        'n': nearest-neighbor interpolation; defined at all values,
+             but not continuous
+        'l': linear interpolation; continuous at all values, but not
+             differentiable
+        'h': hermite cubic spline interpolation; continuous and
+             differentiable at all values but not twice-differentiable
+        's': natural cubic spline interpolation; continuous and twice-
+             differentiable at all values. This method is much slower
+             than the others because it utilizes the entire input waveform!
+    a_out
+        The output pick-off value
+
+    Examples
+    --------
+    .. code-block :: json
+
+        "trapEftp": {
+            "function": "fixed_time_pickoff",
+            "module": "pygama.dsp.processors",
+            "args": ["wf_trap", "tp_0+10*us", "'h'", "trapEftp"],
+            "unit": "ADC",
+        }
+    """
+    a_out[0] = np.nan
+
+    if np.isnan(w_in).any() or np.isnan(t_in):
+        return
+
+    if t_in < 0 or t_in > len(w_in)-1:
+        return
+    
+    i_in = int(t_in)
+    if i_in==t_in:
+        a_out[0] = w_in[i_in]
+        return
+    
+    t0 = t_in - i_in
+    t1 = 1-t0
+    
+    if chr(mode_in)=='i': # Index
+        raise DSPFatal("fixed_time_pickoff requires integer t_in when using mode 'i'")
+    elif chr(mode_in)=='n': # Nearest-neighbor
+        a_out[0] = w_in[i_in] if t0<0.5 else w_in[i_in+1]
+    elif chr(mode_in)=='l': #linear
+        a_out[0] = t1*w_in[i_in] + t0*w_in[i_in+1]
+    elif chr(mode_in)=='h': # Cubic hermite
+        m0 = w_in[1]-w_in[0] if i_in==0 else (w_in[i_in+1] - w_in[i_in-1])/2
+        m1 = w_in[-1]-w_in[-2] if i_in==len(w_in)-2 else (w_in[i_in+2] - w_in[i_in])/2
+        a_out[0] = (-2*t1**3 + 3*t1**2)*w_in[i_in] + (-2*t0**3 + 3*t0**2)*w_in[i_in+1] - (t1**3 - t1**2)*m0 + (t0**3 - t0**2)*m1
+    elif chr(mode_in)=='s': # Cubic spline
+        u = np.zeros(len(w_in))
+        w2 = np.zeros(len(w_in)) # second derivative values
+        
+        for i in range(1, len(w_in)-1):
+            p = 0.5*w2[i-1] + 2
+            w2[i] = -0.5/p
+            u[i] = w_in[i+1]-2*w_in[i]+w_in[i-1]
+            u[i] = (3*u[i] - 0.5*u[i-1])/p
+        for i in range(len(w_in)-2, i_in-1, -1):
+            w2[i] = w2[i]*w2[i+1] + u[i]
+    
+        a_out[0] = t1*w_in[i_in] + t0*w_in[i_in+1] + ((t1**3-t1)*w2[i_in] + (t0**3-t0)*w2[i_in+1])/6.
+    else:
+        raise DSPFatal("Unrecognized interpolation mode")

--- a/src/pygama/dsp/processors/multi_a_filter.py
+++ b/src/pygama/dsp/processors/multi_a_filter.py
@@ -44,4 +44,4 @@ def multi_a_filter(w_in, vt_maxs_in, va_max_out):
             "The length of your return array must be smaller than the length of your waveform"
         )
 
-    fixed_time_pickoff(w_in, vt_maxs_in, ord('i'), va_max_out)
+    fixed_time_pickoff(w_in, vt_maxs_in, ord("i"), va_max_out)

--- a/src/pygama/dsp/processors/multi_a_filter.py
+++ b/src/pygama/dsp/processors/multi_a_filter.py
@@ -44,4 +44,4 @@ def multi_a_filter(w_in, vt_maxs_in, va_max_out):
             "The length of your return array must be smaller than the length of your waveform"
         )
 
-    fixed_time_pickoff(w_in, vt_maxs_in, va_max_out)
+    fixed_time_pickoff(w_in, vt_maxs_in, ord('i'), va_max_out)

--- a/src/pygama/dsp/processors/multi_a_filter.py
+++ b/src/pygama/dsp/processors/multi_a_filter.py
@@ -17,17 +17,17 @@ from .fixed_time_pickoff import fixed_time_pickoff
     forceobj=True
 )
 def multi_a_filter(w_in, vt_maxs_in, va_max_out):
-    """
-    Finds the maximums in a waveform and returns the amplitude of the wave at those points
+    """Finds the maximums in a waveform and returns the amplitude of the wave
+    at those points.
 
     Parameters
     ----------
-    w_in : array-like
-        The array of data within which amplitudes of extrema will be found
-    vt_maxs_in : array-like
-        The array of max positions for each wf
-    va_max_out : array-like
-        An array (in-place filled) of the amplitudes of the maximums of the waveform
+    w_in
+        the array of data within which amplitudes of extrema will be found.
+    vt_maxs_in
+        the array of max positions for each waveform.
+    va_max_out
+        an array (in-place filled) of the amplitudes of the maximums of the waveform.
     """
 
     # Initialize output parameters

--- a/src/pygama/dsp/processors/time_point_thresh.py
+++ b/src/pygama/dsp/processors/time_point_thresh.py
@@ -86,7 +86,12 @@ def time_point_thresh(
     **nb_kwargs,
 )
 def interpolated_time_point_thresh(
-        w_in: np.ndarray, a_threshold: float, t_start: int, walk_forward: int, mode_in: np.int8, t_out: float
+    w_in: np.ndarray,
+    a_threshold: float,
+    t_start: int,
+    walk_forward: int,
+    mode_in: np.int8,
+    t_out: float,
 ) -> None:
     """Find the time where the waveform value crosses the threshold, walking
     either forward or backward from the starting index. Use interpolation to
@@ -152,19 +157,22 @@ def interpolated_time_point_thresh(
     else:
         for i in range(int(t_start), 1, -1):
             if w_in[i - 1] < a_threshold <= w_in[i]:
-                i_cross = i-1
+                i_cross = i - 1
 
-    if i_cross==-1: return
+    if i_cross == -1:
+        return
 
-    if mode_in==ord('i'): # return index before crossing
+    if mode_in == ord("i"):  # return index before crossing
         t_out[0] = i_cross
-    elif mode_in==ord('f'): # return index before crossing
+    elif mode_in == ord("f"):  # return index before crossing
         t_out[0] = i_cross + 1
-    elif mode_in==ord('c'): # return index before crossing
+    elif mode_in == ord("c"):  # return index before crossing
         t_out[0] = i_cross
-    elif mode_in==ord('n'): # nearest-neighbor; return half-way between samps
+    elif mode_in == ord("n"):  # nearest-neighbor; return half-way between samps
         t_out[0] = i_cross + 0.5
-    elif mode_in==ord('l'): # linear
-        t_out[0] = i_cross + (a_threshold - w_in[i_cross])/(w_in[i_cross+1] - w_in[i_cross])
+    elif mode_in == ord("l"):  # linear
+        t_out[0] = i_cross + (a_threshold - w_in[i_cross]) / (
+            w_in[i_cross + 1] - w_in[i_cross]
+        )
     else:
         raise DSPFatal("Unrecognized interpolation mode")

--- a/src/pygama/dsp/processors/time_point_thresh.py
+++ b/src/pygama/dsp/processors/time_point_thresh.py
@@ -93,9 +93,11 @@ def interpolated_time_point_thresh(
     mode_in: np.int8,
     t_out: float,
 ) -> None:
-    """Find the time where the waveform value crosses the threshold, walking
-    either forward or backward from the starting index. Use interpolation to
-    estimate a time between samples. Interpolation mode selected with mode_in
+    """Find the time where the waveform value crosses the threshold
+
+    Search performed walking either forward or backward from the starting
+    index. Use interpolation to estimate a time between samples. Interpolation
+    mode selected with `mode_in`.
 
     Parameters
     ----------
@@ -109,18 +111,19 @@ def interpolated_time_point_thresh(
         the backward (``0``) or forward (``1``) search direction.
     mode_in
         Character selecting which interpolation method to use. Note this
-        must be passed as a int8, e.g. ``ord('i')``. Options:
+        must be passed as a ``int8``, e.g. ``ord('i')``. Options:
 
-        * 'i': integer t_in; equivalent to fixed_sample_pickoff
-        * 'f': floor; interpolated values are at previous neighbor, so
+        * ``i`` -- integer `t_in`; equivalent to
+          :func:`~.dsp.processors.fixed_sample_pickoff`
+        * ``f`` -- floor; interpolated values are at previous neighbor, so
           threshold crossing is at next neighbor
-        * 'c': ceiling, interpolated values are at next neighbor, so
+        * ``c`` -- ceiling, interpolated values are at next neighbor, so
           threshold crossing is at previous neighbor
-        * 'n': nearest-neighbor interpolation; threshold crossing is
+        * ``n`` -- nearest-neighbor interpolation; threshold crossing is
           half-way between samples
-        * 'l': linear interpolation
-        * 'h': hermite cubic spline interpolation (TODO)
-        * 's': natural cubic spline interpolation (TODO)
+        * ``l`` -- linear interpolation
+        * ``h`` -- Hermite cubic spline interpolation (*not implemented*)
+        * ``s`` -- natural cubic spline interpolation (*not implemented*)
     t_out
         the index where the waveform value crosses the threshold.
 

--- a/src/pygama/dsp/processors/time_point_thresh.py
+++ b/src/pygama/dsp/processors/time_point_thresh.py
@@ -75,3 +75,96 @@ def time_point_thresh(
             if w_in[i - 1] < a_threshold <= w_in[i]:
                 t_out[0] = i
                 return
+
+
+@guvectorize(
+    [
+        "void(float32[:], float32, float32, int64, char, float32[:])",
+        "void(float64[:], float64, float64, int64, char, float64[:])",
+    ],
+    "(n),(),(),(),()->()",
+    **nb_kwargs,
+)
+def interpolated_time_point_thresh(
+        w_in: np.ndarray, a_threshold: float, t_start: int, walk_forward: int, mode_in: np.int8, t_out: float
+) -> None:
+    """Find the time where the waveform value crosses the threshold, walking
+    either forward or backward from the starting index. Use interpolation to
+    estimate a time between samples. Interpolation mode selected with mode_in
+
+    Parameters
+    ----------
+    w_in
+        the input waveform.
+    a_threshold
+        the threshold value.
+    t_start
+        the starting index.
+    walk_forward
+        the backward (``0``) or forward (``1``) search direction.
+    mode_in
+        Character selecting which interpolation method to use. Note this
+        must be passed as a int8, e.g. ``ord('i')``. Options:
+
+        * 'i': integer t_in; equivalent to fixed_sample_pickoff
+        * 'f': floor; interpolated values are at previous neighbor, so
+          threshold crossing is at next neighbor
+        * 'c': ceiling, interpolated values are at next neighbor, so
+          threshold crossing is at previous neighbor
+        * 'n': nearest-neighbor interpolation; threshold crossing is
+          half-way between samples
+        * 'l': linear interpolation
+        * 'h': hermite cubic spline interpolation (TODO)
+        * 's': natural cubic spline interpolation (TODO)
+    t_out
+        the index where the waveform value crosses the threshold.
+
+    JSON Configuration Example
+    --------------------------
+
+    .. code-block :: json
+
+        "tp_0": {
+            "function": "time_point_thresh",
+            "module": "pygama.dsp.processors",
+            "args": ["wf_atrap", "bl_std", "tp_start", 0, "'l'", "tp_0"],
+            "unit": "ns"
+        }
+    """
+    t_out[0] = np.nan
+
+    if (
+        np.isnan(w_in).any()
+        or np.isnan(a_threshold)
+        or np.isnan(t_start)
+        or np.isnan(walk_forward)
+    ):
+        return
+
+    if t_start < 0 or t_start >= len(w_in):
+        return
+
+    i_cross = -1
+    if walk_forward > 0:
+        for i in range(int(t_start), len(w_in) - 1, 1):
+            if w_in[i] <= a_threshold < w_in[i + 1]:
+                i_cross = i
+    else:
+        for i in range(int(t_start), 1, -1):
+            if w_in[i - 1] < a_threshold <= w_in[i]:
+                i_cross = i-1
+
+    if i_cross==-1: return
+
+    if mode_in==ord('i'): # return index before crossing
+        t_out[0] = i_cross
+    elif mode_in==ord('f'): # return index before crossing
+        t_out[0] = i_cross + 1
+    elif mode_in==ord('c'): # return index before crossing
+        t_out[0] = i_cross
+    elif mode_in==ord('n'): # nearest-neighbor; return half-way between samps
+        t_out[0] = i_cross + 0.5
+    elif mode_in==ord('l'): # linear
+        t_out[0] = i_cross + (a_threshold - w_in[i_cross])/(w_in[i_cross+1] - w_in[i_cross])
+    else:
+        raise DSPFatal("Unrecognized interpolation mode")

--- a/src/pygama/dsp/processors/upsampler.py
+++ b/src/pygama/dsp/processors/upsampler.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from math import ceil, floor
 import numpy as np
 from numba import guvectorize
 
@@ -40,3 +41,156 @@ def upsampler(w_in: np.ndarray, upsample: float, w_out: np.ndarray) -> None:
             if (t_out >= 0) & (t_out < len(w_out)):
                 w_out[t_out] = w_in[t_in]
             t_out += 1
+
+
+@guvectorize(
+    ["void(float32[:], char, float32[:])", "void(float64[:], char, float64[:])"],
+    "(n),(),(m)", nopython=True,
+    **nb_kwargs,
+)
+def interpolating_upsampler(w_in: np.ndarray, mode_in: np.int8, w_out: np.ndarray) -> None:
+    """Upsamples the waveform; resampling ratio is set by size of w_out
+    and w_in. Using the interpolation technique specified by mode_in to
+    fill newly added samples
+
+    Parameters
+    ----------
+    w_in
+        waveform to upsample.
+    mode_in
+        Character selecting which interpolation method to use. Note this
+        must be passed as a int8, e.g. ``ord('i')``. Options:
+
+        * 'i': only set values at original samples; fill in between
+          with zeros. Requires integer resampling ratio
+        * 'n': nearest-neighbor interpolation; defined at all values,
+          but not continuous
+        * 'f': floor, or value at previous neighbor; defined at all
+          values but not continuous
+        * 'c': ceiling, or value at next neighbor; defined at all values,
+          but not continuous
+        * 'l': linear interpolation; continuous at all values, but not
+          differentiable
+        * 'h': hermite cubic spline interpolation; continuous and
+          differentiable at all values but not twice-differentiable
+        * 's': natural cubic spline interpolation; continuous and twice-
+          differentiable at all values. This method is much slower
+          than the others because it utilizes the entire input waveform!
+    w_out
+        output array for upsampled waveform.
+
+    JSON Configuration Example
+    --------------------------
+
+    .. code-block :: json
+
+        "wf_up": {
+            "function": "interpolating_upsampler",
+            "module": "pygama.dsp.processors",
+            "args": ["wf", "'s'", "wf_up(len(wf)*10, period=wf.period/10)"],
+            "unit": "ADC"
+        }
+    """
+
+    w_out[:] = np.nan
+
+    if np.isnan(w_in).any():
+        return
+
+    upsample = len(w_out)/len(w_in)
+    
+    if mode_in == ord("i"):  # Index
+        if upsample != int(upsample):
+            raise DSPFatal("interpolating_upsampler requires len(w_out) to be an integer multiple of len(w_in) for mode 'i'")
+        for i_in, a in enumerate(w_in):
+            i_out = int(upsample*i_in)
+            w_out[i_out] = a
+            w_out[i_out+1:i_out+upsample] = 0
+
+    elif mode_in == ord("n"):  # Nearest-neighbor
+        i_last = 0
+        for i_in, a in enumerate(w_in):
+            i_next = ceil(upsample*(i_in+0.5))
+            w_out[i_last:i_next] = a
+            i_last = i_next
+        w_out[i_last:] = w_in[-1]
+
+    elif mode_in == ord("f"):  # Floor
+        i_last = 0
+        for i_in, a in enumerate(w_in):
+            i_next = ceil(upsample*(i_in+1))
+            w_out[i_last:i_next] = a
+            i_last = i_next
+
+    elif mode_in == ord("c"):  # Ceiling
+        i_last = 0
+        for i_in, a in enumerate(w_in):
+            i_next = floor(upsample*(i_in))+1
+            w_out[i_last:i_next] = a
+            i_last = i_next
+        w_out[i_last:] = w_in[-1]
+
+    elif mode_in == ord("l"):  # linear
+        i_last = 0
+        for i_in, a in enumerate(w_in):
+            i_next = ceil(upsample*(i_in+1))
+            a_next = w_in[i_in+1] if i_in<len(w_in)-1 else w_in[-1]
+            for i_out in range(i_last, i_next):
+                t = i_out/upsample - i_in
+                w_out[i_out] = a + t * (a_next - a)
+            i_last = i_next
+
+    elif mode_in == ord("h"):  # Cubic hermite
+        i_last = 0
+        for i_in in range(len(w_in)-1):
+            i_next = ceil(upsample*(i_in+1))
+            m0 = w_in[1] - w_in[0] if i_in == 0 else (w_in[i_in + 1] - w_in[i_in - 1]) / 2
+            m1 = w_in[-1] - w_in[-2] if i_in == len(w_in) - 2 else (w_in[i_in + 2] - w_in[i_in]) / 2
+            for i_out in range(i_last, i_next):
+                t0 = i_out/upsample - i_in
+                t1 = 1 - t0
+                w_out[i_out] = (
+                    (-2 * t1**3 + 3 * t1**2) * w_in[i_in]
+                    + (-2 * t0**3 + 3 * t0**2) * w_in[i_in + 1]
+                    - (t1**3 - t1**2) * m0
+                    + (t0**3 - t0**2) * m1
+                )
+            i_last = i_next
+
+        for i_out in range(i_last, len(w_out)):
+            t0 = i_out/upsample - i_in
+            t1 = 1 - t0
+            w_out[i_out] = (
+                (-2 * t1**3 + 3 * t1**2) * w_in[i_in]
+                + (-2 * t0**3 + 3 * t0**2) * w_in[i_in + 1]
+                - (t1**3 - t1**2) * m0
+                + (t0**3 - t0**2) * m1
+            )
+
+    elif mode_in == ord("s"):  # Cubic spline
+        u = np.zeros(len(w_in))
+        w2 = np.zeros(len(w_in))  # second derivative values
+
+        for i_in in range(1, len(w_in) - 1):
+            p = 0.5 * w2[i_in - 1] + 2
+            w2[i_in] = -0.5 / p
+            u[i_in] = w_in[i_in + 1] - 2 * w_in[i_in] + w_in[i_in - 1]
+            u[i_in] = (3 * u[i_in] - 0.5 * u[i_in - 1]) / p
+
+        i_last = len(w_out)
+        for i_in in range(len(w_in) - 2, -1, -1):
+            w2[i_in] = w2[i_in] * w2[i_in + 1] + u[i_in]
+            i_next = ceil(upsample*(i_in))
+
+            for i_out in range(i_last, i_next-1, -1):
+                t0 = i_out/upsample - i_in
+                t1 = 1 - t0
+                w_out[i_out] = (
+                    t1 * w_in[i_in]
+                    + t0 * w_in[i_in + 1]
+                    + ((t1**3 - t1) * w2[i_in] + (t0**3 - t0) * w2[i_in + 1]) / 6.0
+                )
+            i_last = i_next
+
+    else:
+        raise DSPFatal("Unrecognized interpolation mode")

--- a/src/pygama/dsp/processors/upsampler.py
+++ b/src/pygama/dsp/processors/upsampler.py
@@ -15,8 +15,11 @@ from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
     **nb_kwargs,
 )
 def upsampler(w_in: np.ndarray, upsample: float, w_out: np.ndarray) -> None:
-    """Upsamples the waveform by the number specified, a series of moving
-    windows should be applied afterwards for smoothing.
+    """Upsamples the waveform by the number specified.
+
+    Note
+    ----
+    A series of moving windows should be applied afterwards for smoothing.
 
     Parameters
     ----------
@@ -53,31 +56,32 @@ def upsampler(w_in: np.ndarray, upsample: float, w_out: np.ndarray) -> None:
 def interpolating_upsampler(
     w_in: np.ndarray, mode_in: np.int8, w_out: np.ndarray
 ) -> None:
-    """Upsamples the waveform; resampling ratio is set by size of w_out
-    and w_in. Using the interpolation technique specified by mode_in to
-    fill newly added samples
+    """Upsamples the waveform.
+
+    Resampling ratio is set by size of `w_out` and `w_in`. Using the
+    interpolation technique specified by `mode_in` to fill newly added samples.
 
     Parameters
     ----------
     w_in
         waveform to upsample.
     mode_in
-        Character selecting which interpolation method to use. Note this
-        must be passed as a int8, e.g. ``ord('i')``. Options:
+        character selecting which interpolation method to use. Note this
+        must be passed as a ``int8``, e.g. ``ord('i')``. Options:
 
-        * 'i': only set values at original samples; fill in between
+        * ``i`` -- only set values at original samples; fill in between
           with zeros. Requires integer resampling ratio
-        * 'n': nearest-neighbor interpolation; defined at all values,
+        * ``n`` -- nearest-neighbor interpolation; defined at all values,
           but not continuous
-        * 'f': floor, or value at previous neighbor; defined at all
+        * ``f`` -- floor, or value at previous neighbor; defined at all
           values but not continuous
-        * 'c': ceiling, or value at next neighbor; defined at all values,
+        * ``c`` -- ceiling, or value at next neighbor; defined at all values,
           but not continuous
-        * 'l': linear interpolation; continuous at all values, but not
+        * ``l`` -- linear interpolation; continuous at all values, but not
           differentiable
-        * 'h': hermite cubic spline interpolation; continuous and
+        * ``h`` -- Hermite cubic spline interpolation; continuous and
           differentiable at all values but not twice-differentiable
-        * 's': natural cubic spline interpolation; continuous and twice-
+        * ``s`` -- natural cubic spline interpolation; continuous and twice-
           differentiable at all values. This method is much slower
           than the others because it utilizes the entire input waveform!
     w_out

--- a/tests/dsp/configs/icpc-dsp-config.json
+++ b/tests/dsp/configs/icpc-dsp-config.json
@@ -173,9 +173,9 @@
       "unit": "ADC"
     },
     "cuspEftp": {
-      "function": "fixed_sample_pickoff",
+      "function": "fixed_time_pickoff",
       "module": "pygama.dsp.processors",
-      "args": ["wf_cusp", "db.cusp.sample", "cuspEftp"],
+	"args": ["wf_cusp", "db.cusp.sample", "'i'", "cuspEftp"],
       "unit": "ADC",
       "defaults": { "db.cusp.sample": "50" }
     },
@@ -204,9 +204,9 @@
       "unit": "ADC"
     },
     "zacEftp": {
-      "function": "fixed_sample_pickoff",
+      "function": "fixed_time_pickoff",
       "module": "pygama.dsp.processors",
-      "args": ["wf_zac", "db.zac.sample", "zacEftp"],
+      "args": ["wf_zac", "db.zac.sample", "'i'", "zacEftp"],
       "defaults": { "db.zac.sample": "50" },
       "unit": "ADC"
     },

--- a/tests/dsp/configs/icpc-dsp-config.json
+++ b/tests/dsp/configs/icpc-dsp-config.json
@@ -138,6 +138,7 @@
       "args": [
         "wf_etrap",
         "tp_0_est+db.etrap.rise+db.etrap.flat*db.etrap.sample",
+        "'l'",
         "trapEftp"
       ],
       "unit": "ADC",
@@ -172,7 +173,7 @@
       "unit": "ADC"
     },
     "cuspEftp": {
-      "function": "fixed_time_pickoff",
+      "function": "fixed_sample_pickoff",
       "module": "pygama.dsp.processors",
       "args": ["wf_cusp", "db.cusp.sample", "cuspEftp"],
       "unit": "ADC",
@@ -203,7 +204,7 @@
       "unit": "ADC"
     },
     "zacEftp": {
-      "function": "fixed_time_pickoff",
+      "function": "fixed_sample_pickoff",
       "module": "pygama.dsp.processors",
       "args": ["wf_zac", "db.zac.sample", "zacEftp"],
       "defaults": { "db.zac.sample": "50" },
@@ -272,7 +273,7 @@
     "trapQftp": {
       "function": "fixed_time_pickoff",
       "module": "pygama.dsp.processors",
-      "args": ["wf_trap2", "tp_0_est + 8.096*us", "trapQftp"],
+      "args": ["wf_trap2", "tp_0_est + 8.096*us", "'l'", "trapQftp"],
       "unit": "ADC"
     },
     "QDrift": {

--- a/tests/dsp/configs/icpc-dsp-config.json
+++ b/tests/dsp/configs/icpc-dsp-config.json
@@ -175,7 +175,7 @@
     "cuspEftp": {
       "function": "fixed_time_pickoff",
       "module": "pygama.dsp.processors",
-	"args": ["wf_cusp", "db.cusp.sample", "'i'", "cuspEftp"],
+      "args": ["wf_cusp", "db.cusp.sample", "'i'", "cuspEftp"],
       "unit": "ADC",
       "defaults": { "db.cusp.sample": "50" }
     },


### PR DESCRIPTION
Note: this pull request is not yet ready to accept, as changes to processing_chain are required to handle string inputs

- Renamed old `fixed_time_pickoff` to `fixed_sample_pickoff`
- `fixed_time_pickoff` now has a character argument to accept an interpolation mode. Options are:
  - 'i': require integer index (same as `fixed_sample_pickoff`)
  - 'n': nearest-neighbor; round to nearest integer index
  - 'l': linear interpolation
  - 'h': cubic hermite spline interpolation (continuous and once-differentiable; requires 4 nearest samples)
  - 's': cubic natural spline interpolation (continuous and twice-differentiable; requires full waveform)

See issue https://github.com/legend-exp/pygama/issues/325 for more discussion