### PR TITLE
`lgdo.Table.eval()` change to use NumExpr2

### DIFF
--- a/src/pygama/hit/build_hit.py
+++ b/src/pygama/hit/build_hit.py
@@ -128,7 +128,7 @@ def build_hit(
         for tbl_obj, start_row, n_rows in lh5_it:
             n_rows = min(tot_n_rows - start_row, n_rows)
 
-            outtbl_obj = tbl_obj.eval(cfg["operations"])
+            outtbl_obj = tbl_obj.eval(cfg["operations"],usepdeval=False)
 
             # remove or add columns according to "outputs" in the configuration
             # dictionary

--- a/src/pygama/hit/build_hit.py
+++ b/src/pygama/hit/build_hit.py
@@ -128,7 +128,7 @@ def build_hit(
         for tbl_obj, start_row, n_rows in lh5_it:
             n_rows = min(tot_n_rows - start_row, n_rows)
 
-            outtbl_obj = tbl_obj.eval(cfg["operations"],usepdeval=False)
+            outtbl_obj = tbl_obj.eval(cfg["operations"])
 
             # remove or add columns according to "outputs" in the configuration
             # dictionary

--- a/src/pygama/lgdo/table.py
+++ b/src/pygama/lgdo/table.py
@@ -5,18 +5,16 @@ equal length and corresponding utilities.
 from __future__ import annotations
 
 import logging
+import re
 from typing import Any, Union
-
-import pandas as pd
-from pandas.io.formats import format as fmt
 
 import numexpr as ne
 import numpy as np
-import re
+import pandas as pd
+from pandas.io.formats import format as fmt
 
 from pygama.lgdo.array import Array
 from pygama.lgdo.arrayofequalsizedarrays import ArrayOfEqualSizedArrays
-from pygama.lgdo.fixedsizearray import FixedSizeArray
 from pygama.lgdo.scalar import Scalar
 from pygama.lgdo.struct import Struct
 from pygama.lgdo.vectorofvectors import VectorOfVectors
@@ -248,7 +246,7 @@ class Table(Struct):
 
             where:
 
-            - ``expression`` is an expression string supported by 
+            - ``expression`` is an expression string supported by
               :meth:`numexpr.evaluate` (see also `here
               <https://numexpr.readthedocs.io/projects/NumExpr3/en/latest/index.html>`_
               for documentation). Note: because of internal limitations, reduction operations must appear the last in the stack.
@@ -264,43 +262,60 @@ class Table(Struct):
         for out_var, spec in expr_config.items():
             in_vars = {}
             print(spec)
-            #Find all vaild python variables in expression (e.g "a*b+sin(Cool)" --> ['a','b','sin','Cool'])
-            for elem in re.findall(r'\s*[A-Za-z_]\w*\s*',spec['expression']):
+            # Find all vaild python variables in expression (e.g "a*b+sin(Cool)" --> ['a','b','sin','Cool'])
+            for elem in re.findall(r"\s*[A-Za-z_]\w*\s*", spec["expression"]):
                 elem = elem.strip()
-                if elem in self:                #check if the variable comes from dsp
-                    in_vars[elem]=self[elem]
-                elif elem in out_tbl.keys():           #if not try from previously processed data, else ignore since it is e.g sin func
-                    in_vars[elem]=out_tbl[elem]
-                
-                else: continue
-                #get the nda if it is an Array instance
-                if isinstance(in_vars[elem], Array): in_vars[elem]=in_vars[elem].nda
-                #No vector of vectors support yet
-                elif isinstance(in_vars[elem], VectorOfVectors): raise TypeError(f"Data of type VectorOfVectors not supported (yet)")
+                if elem in self:  # check if the variable comes from dsp
+                    in_vars[elem] = self[elem]
+                elif (
+                    elem in out_tbl.keys()
+                ):  # if not try from previously processed data, else ignore since it is e.g sin func
+                    in_vars[elem] = out_tbl[elem]
 
-            loc_dic=dict(in_vars, **spec["parameters"]) if "parameters" in spec else in_vars
-            out_data = ne.evaluate(f"{spec['expression']}",
-                local_dict=dict(in_vars, **spec["parameters"]) if "parameters" in spec else in_vars,
+                else:
+                    continue
+                # get the nda if it is an Array instance
+                if isinstance(in_vars[elem], Array):
+                    in_vars[elem] = in_vars[elem].nda
+                # No vector of vectors support yet
+                elif isinstance(in_vars[elem], VectorOfVectors):
+                    raise TypeError(f"Data of type VectorOfVectors not supported (yet)")
+
+            loc_dic = (
+                dict(in_vars, **spec["parameters"]) if "parameters" in spec else in_vars
+            )
+            out_data = ne.evaluate(
+                f"{spec['expression']}",
+                local_dict=dict(in_vars, **spec["parameters"])
+                if "parameters" in spec
+                else in_vars,
                 global_dict=None,
-                optimization='moderate', #Slow, but calculation is accurate (alternative "aggressive")
-                truediv='auto')            #Division is choosen by __future__.division in the interpreter
+                optimization="moderate",  # Slow, but calculation is accurate (alternative "aggressive")
+                truediv="auto",
+            )  # Division is choosen by __future__.division in the interpreter
 
-            #smart way to find right LGDO data type:
+            # smart way to find right LGDO data type:
 
-            #out_data has one row and this row has a scalar (eg scalar product of two rows)
-            if len(np.shape(out_data)) == 0: out_data = Array(nda=out_data)
-            
-            #out_data has scalar in each row
-            elif len(np.shape(out_data)) == 1: out_data = Array(nda=out_data)
+            # out_data has one row and this row has a scalar (eg scalar product of two rows)
+            if len(np.shape(out_data)) == 0:
+                out_data = Array(nda=out_data)
 
-            #out_data is  like
-            elif len(np.shape(out_data)) == 2: out_data = ArrayOfEqualSizedArrays(nda=out_data)
+            # out_data has scalar in each row
+            elif len(np.shape(out_data)) == 1:
+                out_data = Array(nda=out_data)
 
-            #higher order data (eg matrix product of ArrayOfEqualSizedArrays) not supported yet
-            else: ValueError(f"Calculation resulted in {len(np.shape(out_data))-1}-D row which is not supported yet")
+            # out_data is  like
+            elif len(np.shape(out_data)) == 2:
+                out_data = ArrayOfEqualSizedArrays(nda=out_data)
+
+            # higher order data (eg matrix product of ArrayOfEqualSizedArrays) not supported yet
+            else:
+                ValueError(
+                    f"Calculation resulted in {len(np.shape(out_data))-1}-D row which is not supported yet"
+                )
 
             out_tbl.add_column(out_var, out_data)
-    
+
         return out_tbl
 
     def __str__(self):

--- a/src/pygama/lgdo/table.py
+++ b/src/pygama/lgdo/table.py
@@ -282,11 +282,13 @@ class Table(Struct):
                 in_vars = {}
                 in_dtype = None #in_vars must have the same type and shape anyhow otherwise it will not work.
                 for elem in spec['variables']:
-                    in_vars[elem]=self[elem]
+                    if elem in self:                #check if the variable comes from dsp
+                        in_vars[elem]=self[elem]
+                    else:                           #if not try from previously processed data, else fail
+                        in_vars[elem]=out_tbl[elem]
                     in_dtype = in_vars[elem].__class__.__name__ 
-                    attrs=None
+
                     if isinstance(in_vars[elem], Array): 
-                        attrs = in_vars[elem].attrs
                         in_vars[elem]=in_vars[elem].nda
                         
                 spec['expression']=spec['expression'].translate(str.maketrans('', '', '@'))
@@ -297,10 +299,9 @@ class Table(Struct):
                                        truediv='auto')
 
                 if in_dtype == 'ArrayOfEqualSizedArrays':
-                    out_data = ArrayOfEqualSizedArrays(nda=out_data,attrs=attrs)
+                    out_data = ArrayOfEqualSizedArrays(nda=out_data)
                 elif in_dtype == 'FixedSizeArray':
-                    out_data = FixedSizeArray(nda=out_data,attrs=attrs)
-
+                    out_data = FixedSizeArray(nda=out_data)
 
                 out_tbl.add_column(out_var, out_data)
     

--- a/src/pygama/lgdo/table.py
+++ b/src/pygama/lgdo/table.py
@@ -285,9 +285,6 @@ class Table(Struct):
                 local_dict=dict(in_vars, **spec["parameters"])
                 if "parameters" in spec
                 else in_vars,
-                global_dict=None,
-                optimization="moderate",  # Slow, but calculation is accurate (alternative "aggressive")
-                truediv="auto",
             )  # Division is chosen by __future__.division in the interpreter
 
             # smart way to find right LGDO data type:

--- a/src/pygama/lgdo/table.py
+++ b/src/pygama/lgdo/table.py
@@ -261,8 +261,7 @@ class Table(Struct):
         out_tbl = Table(size=self.size)
         for out_var, spec in expr_config.items():
             in_vars = {}
-            print(spec)
-            # Find all vaild python variables in expression (e.g "a*b+sin(Cool)" --> ['a','b','sin','Cool'])
+            # Find all valid python variables in expression (e.g "a*b+sin(Cool)" --> ['a','b','sin','Cool'])
             for elem in re.findall(r"\s*[A-Za-z_]\w*\s*", spec["expression"]):
                 elem = elem.strip()
                 if elem in self:  # check if the variable comes from dsp
@@ -279,11 +278,8 @@ class Table(Struct):
                     in_vars[elem] = in_vars[elem].nda
                 # No vector of vectors support yet
                 elif isinstance(in_vars[elem], VectorOfVectors):
-                    raise TypeError(f"Data of type VectorOfVectors not supported (yet)")
+                    raise TypeError("Data of type VectorOfVectors not supported (yet)")
 
-            loc_dic = (
-                dict(in_vars, **spec["parameters"]) if "parameters" in spec else in_vars
-            )
             out_data = ne.evaluate(
                 f"{spec['expression']}",
                 local_dict=dict(in_vars, **spec["parameters"])
@@ -292,7 +288,7 @@ class Table(Struct):
                 global_dict=None,
                 optimization="moderate",  # Slow, but calculation is accurate (alternative "aggressive")
                 truediv="auto",
-            )  # Division is choosen by __future__.division in the interpreter
+            )  # Division is chosen by __future__.division in the interpreter
 
             # smart way to find right LGDO data type:
 

--- a/tests/hit/configs/basic-hit-config.json
+++ b/tests/hit/configs/basic-hit-config.json
@@ -5,10 +5,10 @@
       "expression": "2 * trapEmax"
     },
     "calE": {
-      "expression": "sqrt(@a + @b * twice_trap_e_max**2)",
+      "expression": "sqrt(a + b * twice_trap_e_max**2)",
       "parameters": {
-        "a": "1.23",
-        "b": "42.69"
+        "a": 1.23,
+        "b": 42.69
       }
     },
     "AoE": {

--- a/tests/hit/test_build_hit.py
+++ b/tests/hit/test_build_hit.py
@@ -62,8 +62,8 @@ def test_lh5_table_configs(dsp_test_file):
             "outputs": ["calE", "AoE"],
             "operations": {
                 "calE": {
-                    "expression": "sqrt(@a + @b * trapEmax**2)",
-                    "parameters": {"a": "1.23", "b": "42.69"},
+                    "expression": "sqrt(a + b * trapEmax**2)",
+                    "parameters": {"a": 1.23, "b": 42.69},
                 },
                 "AoE": {"expression": "A_max/calE"},
             },

--- a/tests/lgdo/test_table_eval.py
+++ b/tests/lgdo/test_table_eval.py
@@ -1,41 +1,76 @@
 import numpy as np
 
-from pygama.lgdo import Array, Table
+from pygama.lgdo import Array, ArrayOfEqualSizedArrays,Table
 
 
 def test_eval_dependency():
     obj = Table(
         col_dict={
-            "a": Array(np.array([1, 2, 3, 4], dtype=np.float32)),
-            "b": Array(np.array([5, 6, 7, 8], dtype=np.float32)),
+            "a": Array(nda=np.array([1, 2, 3, 4], dtype=np.float32)),
+            "b": Array(nda=np.array([5, 6, 7, 8], dtype=np.float32)),
+            "c": ArrayOfEqualSizedArrays(nda=np.array([[1, 2, 3, 4],
+                                                   [5, 6, 7, 8],
+                                                   [9, 10, 11, 12],
+                                                   [13, 14, 15, 16]], dtype=np.float32)),
+            "d": ArrayOfEqualSizedArrays(nda=np.array([[21, 22, 23, 24],
+                                                   [25, 26, 27, 8],
+                                                   [29, 210, 211, 212],
+                                                   [213, 214, 215, 216]], dtype=np.float32)),
         }
     )
 
     expr_config = {
-        "O1": {"expression": "@p1 + @p2 * a**2", "parameters": {"p1": "2", "p2": "3"}},
+        "O1": {"expression": "p1 + p2 * a**2", "parameters": {"p1": 2, "p2": 3}},
         "O2": {"expression": "O1 - b"},
+        "O3": {"expression": "p1 + p2 * c", "parameters": {"p1": 2, "p2": 3}},
+        "O4": {"expression": "O3 - d", "parameters": {"p1": 2, "p2": 3}},
+        "O5": {"expression": "sum(c,axis=1)"},
+        "O6": {"expression": "a>p1", "parameters": {"p1": 2}},
+        "O7": {"expression": "c>p1", "parameters": {"p1": 2}}
     }
 
     out_tbl = obj.eval(expr_config)
-    assert list(out_tbl.keys()) == ["O1", "O2"]
+    assert list(out_tbl.keys()) == ["O1", "O2","O3","O4", "O5","O6","O7"]
     assert (out_tbl["O1"].nda == [5, 14, 29, 50]).all()
     assert (out_tbl["O2"].nda == [0, 8, 22, 42]).all()
+    assert (out_tbl["O3"].nda == [[ 5,  8, 11, 14],
+                                           [17, 20, 23, 26],
+                                           [29, 32, 35, 38],
+                                           [41, 44, 47, 50]]).all()
+    assert (out_tbl["O4"].nda == [[ -16.,  -14.,  -12.,  -10.],
+                                           [  -8.,   -6.,   -4.,   18.],
+                                           [   0., -178., -176., -174.],
+                                           [-172., -170., -168., -166.]]).all()
+    assert (out_tbl["O5"].nda == [10., 26., 42., 58.]).all()
+    assert (out_tbl["O6"].nda == [False, False,  True,  True]).all()
+    assert (out_tbl["O7"].nda == [[False, False,  True,  True],
+                                           [ True,  True,  True,  True],
+                                           [ True,  True,  True,  True],
+                                           [ True,  True,  True,  True]]).all()
 
 
 def test_eval_math_functions():
     obj = Table(
         col_dict={
-            "a": Array(np.array([1, 2, 3, 4], dtype=np.float32)),
-            "b": Array(np.array([5, 6, 7, 8], dtype=np.float32)),
+            "a": Array(nda=np.array([1, 2, 3, 4], dtype=np.float32)),
+            "b": Array(nda=np.array([5, 6, 7, 8], dtype=np.float32)),
+            "c": ArrayOfEqualSizedArrays(nda=np.array([[1, 2, 3, 4],
+                                                   [1, 2, 3, 4],
+                                                   [1, 2, 3, 4],
+                                                   [1, 2, 3, 4]], dtype=np.float32)),
         }
     )
 
     expr_config = {
-        "O1": {
-            "expression": "exp(log(a))",
-        }
+        "O1": {"expression": "exp(log(a))"},
+        "O2": {"expression": "exp(log(c))"}
+
     }
 
     out_tbl = obj.eval(expr_config)
-    assert list(out_tbl.keys()) == ["O1"]
+    assert list(out_tbl.keys()) == ["O1","O2"]
     assert (out_tbl["O1"].nda == [1, 2, 3, 4]).all()
+    assert (out_tbl["O2"].nda == np.array([[1, 2, 3, 4],
+                                 [1, 2, 3, 4],
+                                 [1, 2, 3, 4],
+                                 [1, 2, 3, 4]])).all()

--- a/tests/lgdo/test_table_eval.py
+++ b/tests/lgdo/test_table_eval.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from pygama.lgdo import Array, ArrayOfEqualSizedArrays,Table
+from pygama.lgdo import Array, ArrayOfEqualSizedArrays, Table
 
 
 def test_eval_dependency():
@@ -8,14 +8,23 @@ def test_eval_dependency():
         col_dict={
             "a": Array(nda=np.array([1, 2, 3, 4], dtype=np.float32)),
             "b": Array(nda=np.array([5, 6, 7, 8], dtype=np.float32)),
-            "c": ArrayOfEqualSizedArrays(nda=np.array([[1, 2, 3, 4],
-                                                   [5, 6, 7, 8],
-                                                   [9, 10, 11, 12],
-                                                   [13, 14, 15, 16]], dtype=np.float32)),
-            "d": ArrayOfEqualSizedArrays(nda=np.array([[21, 22, 23, 24],
-                                                   [25, 26, 27, 8],
-                                                   [29, 210, 211, 212],
-                                                   [213, 214, 215, 216]], dtype=np.float32)),
+            "c": ArrayOfEqualSizedArrays(
+                nda=np.array(
+                    [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12], [13, 14, 15, 16]],
+                    dtype=np.float32,
+                )
+            ),
+            "d": ArrayOfEqualSizedArrays(
+                nda=np.array(
+                    [
+                        [21, 22, 23, 24],
+                        [25, 26, 27, 8],
+                        [29, 210, 211, 212],
+                        [213, 214, 215, 216],
+                    ],
+                    dtype=np.float32,
+                )
+            ),
         }
     )
 
@@ -26,27 +35,37 @@ def test_eval_dependency():
         "O4": {"expression": "O3 - d", "parameters": {"p1": 2, "p2": 3}},
         "O5": {"expression": "sum(c,axis=1)"},
         "O6": {"expression": "a>p1", "parameters": {"p1": 2}},
-        "O7": {"expression": "c>p1", "parameters": {"p1": 2}}
+        "O7": {"expression": "c>p1", "parameters": {"p1": 2}},
     }
 
     out_tbl = obj.eval(expr_config)
-    assert list(out_tbl.keys()) == ["O1", "O2","O3","O4", "O5","O6","O7"]
+    assert list(out_tbl.keys()) == ["O1", "O2", "O3", "O4", "O5", "O6", "O7"]
     assert (out_tbl["O1"].nda == [5, 14, 29, 50]).all()
     assert (out_tbl["O2"].nda == [0, 8, 22, 42]).all()
-    assert (out_tbl["O3"].nda == [[ 5,  8, 11, 14],
-                                           [17, 20, 23, 26],
-                                           [29, 32, 35, 38],
-                                           [41, 44, 47, 50]]).all()
-    assert (out_tbl["O4"].nda == [[ -16.,  -14.,  -12.,  -10.],
-                                           [  -8.,   -6.,   -4.,   18.],
-                                           [   0., -178., -176., -174.],
-                                           [-172., -170., -168., -166.]]).all()
-    assert (out_tbl["O5"].nda == [10., 26., 42., 58.]).all()
-    assert (out_tbl["O6"].nda == [False, False,  True,  True]).all()
-    assert (out_tbl["O7"].nda == [[False, False,  True,  True],
-                                           [ True,  True,  True,  True],
-                                           [ True,  True,  True,  True],
-                                           [ True,  True,  True,  True]]).all()
+    assert (
+        out_tbl["O3"].nda
+        == [[5, 8, 11, 14], [17, 20, 23, 26], [29, 32, 35, 38], [41, 44, 47, 50]]
+    ).all()
+    assert (
+        out_tbl["O4"].nda
+        == [
+            [-16.0, -14.0, -12.0, -10.0],
+            [-8.0, -6.0, -4.0, 18.0],
+            [0.0, -178.0, -176.0, -174.0],
+            [-172.0, -170.0, -168.0, -166.0],
+        ]
+    ).all()
+    assert (out_tbl["O5"].nda == [10.0, 26.0, 42.0, 58.0]).all()
+    assert (out_tbl["O6"].nda == [False, False, True, True]).all()
+    assert (
+        out_tbl["O7"].nda
+        == [
+            [False, False, True, True],
+            [True, True, True, True],
+            [True, True, True, True],
+            [True, True, True, True],
+        ]
+    ).all()
 
 
 def test_eval_math_functions():
@@ -54,23 +73,24 @@ def test_eval_math_functions():
         col_dict={
             "a": Array(nda=np.array([1, 2, 3, 4], dtype=np.float32)),
             "b": Array(nda=np.array([5, 6, 7, 8], dtype=np.float32)),
-            "c": ArrayOfEqualSizedArrays(nda=np.array([[1, 2, 3, 4],
-                                                   [1, 2, 3, 4],
-                                                   [1, 2, 3, 4],
-                                                   [1, 2, 3, 4]], dtype=np.float32)),
+            "c": ArrayOfEqualSizedArrays(
+                nda=np.array(
+                    [[1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4]],
+                    dtype=np.float32,
+                )
+            ),
         }
     )
 
     expr_config = {
         "O1": {"expression": "exp(log(a))"},
-        "O2": {"expression": "exp(log(c))"}
-
+        "O2": {"expression": "exp(log(c))"},
     }
 
     out_tbl = obj.eval(expr_config)
-    assert list(out_tbl.keys()) == ["O1","O2"]
+    assert list(out_tbl.keys()) == ["O1", "O2"]
     assert (out_tbl["O1"].nda == [1, 2, 3, 4]).all()
-    assert (out_tbl["O2"].nda == np.array([[1, 2, 3, 4],
-                                 [1, 2, 3, 4],
-                                 [1, 2, 3, 4],
-                                 [1, 2, 3, 4]])).all()
+    assert (
+        out_tbl["O2"].nda
+        == np.array([[1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4]])
+    ).all()


### PR DESCRIPTION
Changed `LGDO::Table.eval()` from using pandas eval() function to using directly the NumExpr module.
For two reasons:
1.  `LGDO::Table` -> `pandas data frame' ->` LGDO::Table` seems inefficient to me
2. The "old" code can't evaluate `ArrayOfEqualSizedArrays` .

Further improvements:
- JSON syntax is more like DSP syntax: `expression:  "@a+@b*var" `--> `expression:"a+b*var"`

Changes to 'test_table_eval.py`:
- Included test form 'ArrayOfEqualSizedArrays' evaluations (`ArrayOfEqualSizedArrays `-> `ArrayOfEqualSizedArrays `and `ArrayOfEqualSizedArrays `-> `Array  `(i.e sum(var, axis=1)) manipulations.
- Extended tests to test logical operations

Change to `test_build_hit.py`:
- Adjusted the test JSON configs to the new format

Solves issue #362


