### PR TITLE
Adding `numpy.constants` parsing to `dsp.processing_chain`

### DIFF
--- a/src/pygama/dsp/processing_chain.py
+++ b/src/pygama/dsp/processing_chain.py
@@ -1634,7 +1634,9 @@ def build_processing_chain(
             else:    
                 for np_var in np_parser.findall(arg):
                     _,np_val =np_var.split(".")
-                    arg = arg.replace(np_var,"{:.50f}".format(np.__dict__[np_val]))
+                    vl = np.__dict__[np_val]
+                    if np.isinf(vl) or np.isnan(vl):raise ProcessingChainError(f"""Expression {arg} can't be evaluated""")
+                    arg = arg.replace(np_var,"{:.50f}".format(vl))
                 args[i]=arg
 
             

--- a/src/pygama/dsp/processing_chain.py
+++ b/src/pygama/dsp/processing_chain.py
@@ -5,6 +5,7 @@ chains on waveform data.
 from __future__ import annotations
 
 import ast
+from cmath import isnan
 import importlib
 import itertools as it
 import json
@@ -1634,9 +1635,13 @@ def build_processing_chain(
             else:    
                 for np_var in np_parser.findall(arg):
                     _,np_val =np_var.split(".")
-                    vl = np.__dict__[np_val]
-                    if np.isinf(vl) or np.isnan(vl):raise ProcessingChainError(f"""Expression {arg} can't be evaluated""")
-                    arg = arg.replace(np_var,"{:.50f}".format(vl))
+                    if np.isinf(np.__dict__[np_val]):raise ProcessingChainError(f"""Expression {arg} can't be evaluated""")
+                    #if there is anywhere a nan return nan (e.g "5*bar+np.nan" --> np.nan)
+                    elif np.isnan(np.__dict__[np_val]): 
+                        arg=np.__dict__[np_val]
+                        break
+                    else:
+                        arg = arg.replace(np_var,"{:.50f}".format(np.__dict__[np_val]))
                 args[i]=arg
 
             

--- a/src/pygama/dsp/processing_chain.py
+++ b/src/pygama/dsp/processing_chain.py
@@ -1649,7 +1649,7 @@ def build_processing_chain(
                 continue
 
             # what is left includes a variable
-            # ok, somebody put infinty and a variable into the argument. Why would you do this?
+            # ok, somebody put infinity and a variable into the argument. Why would you do this?
             elif "np.inf" in arg:
                 # we have at least one var*np.inf or np.inf*var
                 # at this stage we don't know if the variable is pos or neg which would result in +inf or -inf

--- a/src/pygama/dsp/processing_chain.py
+++ b/src/pygama/dsp/processing_chain.py
@@ -1571,7 +1571,7 @@ def build_processing_chain(
     multi_out_procs = {}
     db_parser = re.compile(r"db.[\w_.]+")
     np_parser = re.compile(r"np.[\w_]+")
-    np_arithmetic=re.compile(r"^(([-+/*\)\(]|\d+(\.\d+)?)*|(np.[\w_]+)| ?)*$")
+    np_arithmetic=re.compile(r"^((([-+/*\)\(]|\d+(\.\d+)?)*| ?)*(np.[\w_]+)| ?)+$")
     for key, node in processors.items():
         # if we have multiple outputs, add each to the processesors list
         keys = [k for k in re.split(",| ", key) if k != ""]

--- a/tests/dsp/configs/numpy-parsing.json
+++ b/tests/dsp/configs/numpy-parsing.json
@@ -1,6 +1,6 @@
 { 
     "outputs": [
-        "timestamp","calc1","calc2","calc3","calc4","calc5","calc6"
+        "timestamp","calc1","calc2","calc3","calc4","calc5","calc6","calc7","calc8"
     ],
     "processors":{   
         "calc1":{
@@ -32,6 +32,16 @@
             "function": "subtract",
             "module": "numpy",
             "args": ["timestamp-timestamp", "np.nan*timestamp", "calc6"]
+        },
+        "calc7":{
+            "function": "subtract",
+            "module": "numpy",
+            "args": ["timestamp-timestamp", "-1*np.inf-5*np.inf", "calc7"]
+        },
+        "calc8":{
+            "function": "subtract",
+            "module": "numpy",
+            "args": ["timestamp-timestamp", "np.inf+5*np.inf + timestamp", "calc8"]
         }
     }
 }

--- a/tests/dsp/configs/numpy-parsing.json
+++ b/tests/dsp/configs/numpy-parsing.json
@@ -1,47 +1,55 @@
-{ 
-    "outputs": [
-        "timestamp","calc1","calc2","calc3","calc4","calc5","calc6","calc7","calc8"
-    ],
-    "processors":{   
-        "calc1":{
-            "function": "subtract",
-            "module": "numpy",
-            "args": ["timestamp-timestamp", "np.pi*timestamp", "calc1"]
-        },
-        "calc2":{
-            "function": "subtract",
-            "module": "numpy",
-            "args": ["timestamp-timestamp", "np.pi", "calc2"]
-        },
-        "calc3":{
-            "function": "subtract",
-            "module": "numpy",
-            "args": ["timestamp-timestamp", "np.pi*np.e", "calc3"]
-        },
-        "calc4":{
-            "function": "subtract",
-            "module": "numpy",
-            "args": ["timestamp-timestamp", "np.nan", "calc4"]
-        },
-        "calc5":{
-            "function": "subtract",
-            "module": "numpy",
-            "args": ["timestamp-timestamp", "np.inf", "calc5"]
-        },
-        "calc6":{
-            "function": "subtract",
-            "module": "numpy",
-            "args": ["timestamp-timestamp", "np.nan*timestamp", "calc6"]
-        },
-        "calc7":{
-            "function": "subtract",
-            "module": "numpy",
-            "args": ["timestamp-timestamp", "-1*np.inf-5*np.inf", "calc7"]
-        },
-        "calc8":{
-            "function": "subtract",
-            "module": "numpy",
-            "args": ["timestamp-timestamp", "np.inf+5*np.inf + timestamp", "calc8"]
-        }
+{
+  "outputs": [
+    "timestamp",
+    "calc1",
+    "calc2",
+    "calc3",
+    "calc4",
+    "calc5",
+    "calc6",
+    "calc7",
+    "calc8"
+  ],
+  "processors": {
+    "calc1": {
+      "function": "subtract",
+      "module": "numpy",
+      "args": ["timestamp-timestamp", "np.pi*timestamp", "calc1"]
+    },
+    "calc2": {
+      "function": "subtract",
+      "module": "numpy",
+      "args": ["timestamp-timestamp", "np.pi", "calc2"]
+    },
+    "calc3": {
+      "function": "subtract",
+      "module": "numpy",
+      "args": ["timestamp-timestamp", "np.pi*np.e", "calc3"]
+    },
+    "calc4": {
+      "function": "subtract",
+      "module": "numpy",
+      "args": ["timestamp-timestamp", "np.nan", "calc4"]
+    },
+    "calc5": {
+      "function": "subtract",
+      "module": "numpy",
+      "args": ["timestamp-timestamp", "np.inf", "calc5"]
+    },
+    "calc6": {
+      "function": "subtract",
+      "module": "numpy",
+      "args": ["timestamp-timestamp", "np.nan*timestamp", "calc6"]
+    },
+    "calc7": {
+      "function": "subtract",
+      "module": "numpy",
+      "args": ["timestamp-timestamp", "-1*np.inf-5*np.inf", "calc7"]
+    },
+    "calc8": {
+      "function": "subtract",
+      "module": "numpy",
+      "args": ["timestamp-timestamp", "np.inf+5*np.inf + timestamp", "calc8"]
     }
+  }
 }

--- a/tests/dsp/configs/numpy-parsing.json
+++ b/tests/dsp/configs/numpy-parsing.json
@@ -1,0 +1,32 @@
+{ 
+    "outputs": [
+        "timestamp","calc1","calc2","calc3","calc4","calc5"
+    ],
+    "processors":{   
+        "calc1":{
+            "function": "subtract",
+            "module": "numpy",
+            "args": ["timestamp-timestamp", "np.pi*timestamp", "calc1"]
+        },
+        "calc2":{
+            "function": "subtract",
+            "module": "numpy",
+            "args": ["timestamp-timestamp", "np.pi", "calc2"]
+        },
+        "calc3":{
+            "function": "subtract",
+            "module": "numpy",
+            "args": ["timestamp-timestamp", "np.pi*np.e", "calc3"]
+        },
+        "calc4":{
+            "function": "subtract",
+            "module": "numpy",
+            "args": ["timestamp-timestamp", "np.nan", "calc4"]
+        },
+        "calc5":{
+            "function": "subtract",
+            "module": "numpy",
+            "args": ["timestamp-timestamp", "np.inf", "calc5"]
+        }
+    }
+}

--- a/tests/dsp/configs/numpy-parsing.json
+++ b/tests/dsp/configs/numpy-parsing.json
@@ -6,9 +6,7 @@
     "calc3",
     "calc4",
     "calc5",
-    "calc6",
-    "calc7",
-    "calc8"
+    "calc6"
   ],
   "processors": {
     "calc1": {
@@ -40,16 +38,6 @@
       "function": "subtract",
       "module": "numpy",
       "args": ["timestamp-timestamp", "np.nan*timestamp", "calc6"]
-    },
-    "calc7": {
-      "function": "subtract",
-      "module": "numpy",
-      "args": ["timestamp-timestamp", "-1*np.inf-5*np.inf", "calc7"]
-    },
-    "calc8": {
-      "function": "subtract",
-      "module": "numpy",
-      "args": ["timestamp-timestamp", "np.inf+5*np.inf + timestamp", "calc8"]
     }
   }
 }

--- a/tests/dsp/configs/numpy-parsing.json
+++ b/tests/dsp/configs/numpy-parsing.json
@@ -1,6 +1,6 @@
 { 
     "outputs": [
-        "timestamp","calc1","calc2","calc3","calc4","calc5"
+        "timestamp","calc1","calc2","calc3","calc4","calc5","calc6"
     ],
     "processors":{   
         "calc1":{
@@ -27,6 +27,11 @@
             "function": "subtract",
             "module": "numpy",
             "args": ["timestamp-timestamp", "np.inf", "calc5"]
+        },
+        "calc6":{
+            "function": "subtract",
+            "module": "numpy",
+            "args": ["timestamp-timestamp", "np.nan*timestamp", "calc6"]
         }
     }
 }

--- a/tests/dsp/test_numpy_constants_parsing.py
+++ b/tests/dsp/test_numpy_constants_parsing.py
@@ -36,8 +36,9 @@ def test_numpy_math_constants_dsp():
     assert((a3==f3).all())
 
 def test_numpy_infinity_and_nan_dsp():
-    df = store.load_nda(dsp_file, ['calc4','calc5'], 'geds/dsp/')
+    df = store.load_nda(dsp_file, ['calc4','calc5','calc6'], 'geds/dsp/')
 
     assert((np.isnan(df['calc4'])).all())
     assert((np.isneginf(df['calc5'])).all())
+    assert((np.isnan(df['calc6'])).all())
 

--- a/tests/dsp/test_numpy_constants_parsing.py
+++ b/tests/dsp/test_numpy_constants_parsing.py
@@ -36,9 +36,11 @@ def test_numpy_math_constants_dsp():
     assert((a3==f3).all())
 
 def test_numpy_infinity_and_nan_dsp():
-    df = store.load_nda(dsp_file, ['calc4','calc5','calc6'], 'geds/dsp/')
+    df = store.load_nda(dsp_file, ['calc4','calc5','calc6','calc7','calc8'], 'geds/dsp/')
 
     assert((np.isnan(df['calc4'])).all())
     assert((np.isneginf(df['calc5'])).all())
     assert((np.isnan(df['calc6'])).all())
+    assert((np.isposinf(df['calc7'])).all())
+    assert((np.isneginf(df['calc8'])).all())
 

--- a/tests/dsp/test_numpy_constants_parsing.py
+++ b/tests/dsp/test_numpy_constants_parsing.py
@@ -1,0 +1,43 @@
+import os
+from pathlib import Path
+
+import pytest
+from legend_testdata import LegendTestData
+
+import pygama.lgdo.lh5_store as store
+from pygama.dsp import build_dsp
+
+import numpy as np
+
+config_dir = Path(__file__).parent / "configs"
+dsp_file = "/tmp/LDQTA_r117_20200110T105115Z_cal_geds__numpy_test_dsp.lh5"
+
+
+def test_build_dsp(lgnd_test_data):
+    build_dsp(f_raw=lgnd_test_data.get_path("lh5/LDQTA_r117_20200110T105115Z_cal_geds_raw.lh5"),
+          f_dsp=dsp_file, 
+          dsp_config=f"{config_dir}/numpy-parsing.json",
+          write_mode='r')
+    assert os.path.exists(dsp_file)
+
+def test_numpy_math_constants_dsp():
+    df = store.load_nda(dsp_file, ['timestamp','calc1','calc2','calc3'], 'geds/dsp/')
+
+    a1= df['timestamp']-df['timestamp']-np.pi*df['timestamp']
+    a2= df['timestamp']-df['timestamp']-np.pi
+    a3= df['timestamp']-df['timestamp']-np.pi*np.e
+
+    f1=(df['calc1'])
+    f2=(df['calc2'])
+    f3=(df['calc3'])
+
+    assert((a1==f1).all())
+    assert((a2==f2).all())
+    assert((a3==f3).all())
+
+def test_numpy_infinity_and_nan_dsp():
+    df = store.load_nda(dsp_file, ['calc4','calc5'], 'geds/dsp/')
+
+    assert((np.isnan(df['calc4'])).all())
+    assert((np.isneginf(df['calc5'])).all())
+

--- a/tests/dsp/test_numpy_constants_parsing.py
+++ b/tests/dsp/test_numpy_constants_parsing.py
@@ -39,9 +39,7 @@ def test_numpy_math_constants_dsp():
 
 
 def test_numpy_infinity_and_nan_dsp():
-    df = store.load_nda(
-        dsp_file, ["calc4", "calc5", "calc6"], "geds/dsp/"
-    )
+    df = store.load_nda(dsp_file, ["calc4", "calc5", "calc6"], "geds/dsp/")
 
     assert (np.isnan(df["calc4"])).all()
     assert (np.isneginf(df["calc5"])).all()

--- a/tests/dsp/test_numpy_constants_parsing.py
+++ b/tests/dsp/test_numpy_constants_parsing.py
@@ -1,46 +1,50 @@
 import os
 from pathlib import Path
 
-import pytest
-from legend_testdata import LegendTestData
+import numpy as np
 
 import pygama.lgdo.lh5_store as store
 from pygama.dsp import build_dsp
-
-import numpy as np
 
 config_dir = Path(__file__).parent / "configs"
 dsp_file = "/tmp/LDQTA_r117_20200110T105115Z_cal_geds__numpy_test_dsp.lh5"
 
 
 def test_build_dsp(lgnd_test_data):
-    build_dsp(f_raw=lgnd_test_data.get_path("lh5/LDQTA_r117_20200110T105115Z_cal_geds_raw.lh5"),
-          f_dsp=dsp_file, 
-          dsp_config=f"{config_dir}/numpy-parsing.json",
-          write_mode='r')
+    build_dsp(
+        f_raw=lgnd_test_data.get_path(
+            "lh5/LDQTA_r117_20200110T105115Z_cal_geds_raw.lh5"
+        ),
+        f_dsp=dsp_file,
+        dsp_config=f"{config_dir}/numpy-parsing.json",
+        write_mode="r",
+    )
     assert os.path.exists(dsp_file)
 
+
 def test_numpy_math_constants_dsp():
-    df = store.load_nda(dsp_file, ['timestamp','calc1','calc2','calc3'], 'geds/dsp/')
+    df = store.load_nda(dsp_file, ["timestamp", "calc1", "calc2", "calc3"], "geds/dsp/")
 
-    a1= df['timestamp']-df['timestamp']-np.pi*df['timestamp']
-    a2= df['timestamp']-df['timestamp']-np.pi
-    a3= df['timestamp']-df['timestamp']-np.pi*np.e
+    a1 = df["timestamp"] - df["timestamp"] - np.pi * df["timestamp"]
+    a2 = df["timestamp"] - df["timestamp"] - np.pi
+    a3 = df["timestamp"] - df["timestamp"] - np.pi * np.e
 
-    f1=(df['calc1'])
-    f2=(df['calc2'])
-    f3=(df['calc3'])
+    f1 = df["calc1"]
+    f2 = df["calc2"]
+    f3 = df["calc3"]
 
-    assert((a1==f1).all())
-    assert((a2==f2).all())
-    assert((a3==f3).all())
+    assert (a1 == f1).all()
+    assert (a2 == f2).all()
+    assert (a3 == f3).all()
+
 
 def test_numpy_infinity_and_nan_dsp():
-    df = store.load_nda(dsp_file, ['calc4','calc5','calc6','calc7','calc8'], 'geds/dsp/')
+    df = store.load_nda(
+        dsp_file, ["calc4", "calc5", "calc6", "calc7", "calc8"], "geds/dsp/"
+    )
 
-    assert((np.isnan(df['calc4'])).all())
-    assert((np.isneginf(df['calc5'])).all())
-    assert((np.isnan(df['calc6'])).all())
-    assert((np.isposinf(df['calc7'])).all())
-    assert((np.isneginf(df['calc8'])).all())
-
+    assert (np.isnan(df["calc4"])).all()
+    assert (np.isneginf(df["calc5"])).all()
+    assert (np.isnan(df["calc6"])).all()
+    assert (np.isposinf(df["calc7"])).all()
+    assert (np.isneginf(df["calc8"])).all()

--- a/tests/dsp/test_numpy_constants_parsing.py
+++ b/tests/dsp/test_numpy_constants_parsing.py
@@ -40,11 +40,9 @@ def test_numpy_math_constants_dsp():
 
 def test_numpy_infinity_and_nan_dsp():
     df = store.load_nda(
-        dsp_file, ["calc4", "calc5", "calc6", "calc7", "calc8"], "geds/dsp/"
+        dsp_file, ["calc4", "calc5", "calc6"], "geds/dsp/"
     )
 
     assert (np.isnan(df["calc4"])).all()
     assert (np.isneginf(df["calc5"])).all()
     assert (np.isnan(df["calc6"])).all()
-    assert (np.isposinf(df["calc7"])).all()
-    assert (np.isneginf(df["calc8"])).all()


### PR DESCRIPTION
This allows to use numpy constants (e.g.: `np.pi` , `np.e` , `np.inf`, `np.nan`) as arguments in the JSON file:

```
"calc1":{
            "function": "subtract",
            "module": "numpy",
            "args": ["foo", "5+2*(1+np.pi)*np.e", "calc1"]
        },
"calc2":{
            "function": "subtract",
            "module": "numpy",
            "args": ["foo", "np.inf", "calc2"]
}
"calc3":{
            "function": "subtract",
            "module": "numpy",
            "args": ["foo", "np.nan", "calc3"]
}
"calc4":{
            "function": "subtract",
            "module": "numpy",
            "args": ["foo", "5*np.pi*bar", "calc4"]
}
```
Added `tests\dsp\test_numpy_constants_parsing.py` and `tests\dsp\configs\numpy-parsing.json` for testing

Limitations:
```
"calcFAIL":{
            "function": "subtract",
            "module": "numpy",
            "args": ["foo", "np.inf*bar", "calcFAIL"]
        }
```
Raises exception since the sign of bar is not known. But who would do this anyhow?

This can be very useful for processors with default values e.g.