### PR TITLE
Bug fix in `build_hit.build_hit()` 

### DIFF
--- a/src/pygama/hit/build_hit.py
+++ b/src/pygama/hit/build_hit.py
@@ -96,6 +96,8 @@ def build_hit(
                 with open(v) as f:
                     # order in hit configs is important (dependencies)
                     tbl_cfg[k] = json.load(f, object_pairs_hook=OrderedDict)
+        lh5_tables_config = tbl_cfg
+        
     else:
         if isinstance(hit_config, str):
             # sanitize config
@@ -112,8 +114,6 @@ def build_hit(
                 if f"{el}/dsp" in ls(infile, f"{el}/"):
                     log.debug(f"found candidate table /{el}/dsp")
                     lh5_tables_config[f"{el}/dsp"] = hit_config
-
-            lh5_tables_config = tbl_cfg
 
     if outfile is None:
         outfile = os.path.splitext(os.path.basename(infile))[0]

--- a/src/pygama/hit/build_hit.py
+++ b/src/pygama/hit/build_hit.py
@@ -112,7 +112,7 @@ def build_hit(
                 if f"{el}/dsp" in ls(infile, f"{el}/"):
                     log.debug(f"found candidate table /{el}/dsp")
                     lh5_tables_config[f"{el}/dsp"] = hit_config
-                    
+
             lh5_tables_config = tbl_cfg
 
     if outfile is None:

--- a/src/pygama/hit/build_hit.py
+++ b/src/pygama/hit/build_hit.py
@@ -97,7 +97,7 @@ def build_hit(
                     # order in hit configs is important (dependencies)
                     tbl_cfg[k] = json.load(f, object_pairs_hook=OrderedDict)
         lh5_tables_config = tbl_cfg
-        
+
     else:
         if isinstance(hit_config, str):
             # sanitize config

--- a/src/pygama/hit/build_hit.py
+++ b/src/pygama/hit/build_hit.py
@@ -112,6 +112,8 @@ def build_hit(
                 if f"{el}/dsp" in ls(infile, f"{el}/"):
                     log.debug(f"found candidate table /{el}/dsp")
                     lh5_tables_config[f"{el}/dsp"] = hit_config
+                    
+            lh5_tables_config = tbl_cfg
 
     if outfile is None:
         outfile = os.path.splitext(os.path.basename(infile))[0]


### PR DESCRIPTION

if I give `lh5_tables_config` a valid value (JSON of  DSP channels mapped to configuration blocks or JSON files containing the configuration block per channel, this code block is executed.
```
if lh5_tables_config is not None:
        tbl_cfg = lh5_tables_config
        # sanitize config
        if isinstance(tbl_cfg, str):
            with open(tbl_cfg) as f:
                tbl_cfg = json.load(f)

        for (k, v) in tbl_cfg.items():
            if isinstance(v, str):
                with open(v) as f:
                    # order in hit configs is important (dependencies)
                    tbl_cfg[k] = json.load(f, object_pairs_hook=OrderedDict)
```
the dictionary `tbl_cfg`vis created but never used, which leads to the for loop further down the code:
```
for (tbl, cfg) in lh5_tables_config.items():
...
```
raising an error since` lh5_tables_config `is still a string of the JSON file name.  At the end of the if function above `tbl_cfg` is now copied back into `lh5_tables_config` 