### PR TITLE
Fix `build_hit()` file overwriting bug

### DIFF
--- a/src/pygama/hit/build_hit.py
+++ b/src/pygama/hit/build_hit.py
@@ -118,7 +118,7 @@ def build_hit(
     if outfile is None:
         outfile = os.path.splitext(os.path.basename(infile))[0]
         outfile = outfile.removesuffix("_dsp") + "_hit.lh5"
-    
+
     first_done = False
     for (tbl, cfg) in lh5_tables_config.items():
         lh5_it = LH5Iterator(infile, tbl, buffer_len=buffer_len)

--- a/src/pygama/hit/build_hit.py
+++ b/src/pygama/hit/build_hit.py
@@ -118,7 +118,8 @@ def build_hit(
     if outfile is None:
         outfile = os.path.splitext(os.path.basename(infile))[0]
         outfile = outfile.removesuffix("_dsp") + "_hit.lh5"
-
+    
+    first_done = False
     for (tbl, cfg) in lh5_tables_config.items():
         lh5_it = LH5Iterator(infile, tbl, buffer_len=buffer_len)
         tot_n_rows = store.read_n_rows(tbl, infile)
@@ -126,7 +127,6 @@ def build_hit(
 
         log.info(f"Processing table '{tbl}' in file {infile}")
 
-        first_done = False
         for tbl_obj, start_row, n_rows in lh5_it:
             n_rows = min(tot_n_rows - start_row, n_rows)
 


### PR DESCRIPTION
```py
for (tbl, cfg) in lh5_tables_config.items():
        lh5_it = LH5Iterator(infile, tbl, buffer_len=buffer_len)
        tot_n_rows = store.read_n_rows(tbl, infile)
        write_offset = 0

        log.info(f"Processing table '{tbl}' in file {infile}")

        first_done = False
        for tbl_obj, start_row, n_rows in lh5_it:
            n_rows = min(tot_n_rows - start_row, n_rows)
...
```
`first_done = False` must be moved before the first for loop. if not in case you have multichannel processing and overwrite mode is` overwrite_file` then after each processed channel the file gets deleted (instead of only once at the beginning)