### PR TITLE
Improved handling of Numba default options, add `PYGAMA_*` shell variables

### DIFF
--- a/docs/source/manuals/build_dsp.rst
+++ b/docs/source/manuals/build_dsp.rst
@@ -16,8 +16,9 @@ to learn about their meaning.
    Some special processors override default option values.
 
 The environment variables that can be set are:
-:PYGAMA_CACHE: set caching behavior (default False)
-:PYGAMA_BOUNDSCHECK: set automatic bounds checking (default False)
+
+:``PYGAMA_CACHE``: Set caching behavior (default false)
+:``PYGAMA_BOUNDSCHECK``: Set automatic bounds checking (default false)
 
 Here's an example of how global option customization can achieved in user
 scripts:

--- a/docs/source/manuals/build_dsp.rst
+++ b/docs/source/manuals/build_dsp.rst
@@ -18,7 +18,7 @@ to learn about their meaning.
 The environment variables that can be set are:
 :PYGAMA_CACHE: set caching behavior (default False)
 :PYGAMA_BOUNDSCHECK: set automatic bounds checking (default False)
-  
+
 Here's an example of how global option customization can achieved in user
 scripts:
 

--- a/docs/source/manuals/build_dsp.rst
+++ b/docs/source/manuals/build_dsp.rst
@@ -5,8 +5,8 @@ Global Numba options
 --------------------
 
 Pygama offers the possibility to change the value of some default Numba options
-at runtime. One typical use case is to enable `caching the result of
-compilation <https://numba.readthedocs.io/en/stable/user/jit.html?#cache>`_,
+either using environment variables or at runtime. One typical use case is to enable `caching the result of compilation
+<https://numba.readthedocs.io/en/stable/user/jit.html?#cache>`_,
 which significantly reduces loading times. Numba options globally set by pygama
 are defined as attributes of the :class:`~.dsp.utils.NumbaDefaults` class. Have
 a look to the documentation for :func:`numba.jit` and :func:`numba.guvectorize`
@@ -15,6 +15,10 @@ to learn about their meaning.
 .. note::
    Some special processors override default option values.
 
+The environment variables that can be set are:
+:PYGAMA_CACHE: set caching behavior (default False)
+:PYGAMA_BOUNDCHECK: set automatic bounds checking (default False)
+  
 Here's an example of how global option customization can achieved in user
 scripts:
 

--- a/docs/source/manuals/build_dsp.rst
+++ b/docs/source/manuals/build_dsp.rst
@@ -17,8 +17,8 @@ to learn about their meaning.
 
 The environment variables that can be set are:
 :PYGAMA_CACHE: set caching behavior (default False)
-:PYGAMA_BOUNDCHECK: set automatic bounds checking (default False)
-
+:PYGAMA_BOUNDSCHECK: set automatic bounds checking (default False)
+  
 Here's an example of how global option customization can achieved in user
 scripts:
 

--- a/docs/source/manuals/build_dsp.rst
+++ b/docs/source/manuals/build_dsp.rst
@@ -18,7 +18,7 @@ to learn about their meaning.
 The environment variables that can be set are:
 :PYGAMA_CACHE: set caching behavior (default False)
 :PYGAMA_BOUNDCHECK: set automatic bounds checking (default False)
-  
+
 Here's an example of how global option customization can achieved in user
 scripts:
 

--- a/src/pygama/dsp/processors/convolutions.py
+++ b/src/pygama/dsp/processors/convolutions.py
@@ -70,8 +70,10 @@ def cusp_filter(length: int, sigma: float, flat: int, decay: int) -> Callable:
     @guvectorize(
         ["void(float32[:], float32[:])", "void(float64[:], float64[:])"],
         "(n),(m)",
-        **nb_kwargs,
-        forceobj=True,
+        **nb_kwargs(
+            cache=False,
+            forceobj=True,
+        )
     )
     def cusp_out(w_in: np.ndarray, w_out: np.ndarray) -> None:
         """
@@ -174,8 +176,10 @@ def zac_filter(length: int, sigma: float, flat: int, decay: int) -> Callable:
     @guvectorize(
         ["void(float32[:], float32[:])", "void(float64[:], float64[:])"],
         "(n),(m)",
-        **nb_kwargs,
-        forceobj=True,
+        **nb_kwargs(
+            cache=False,
+            forceobj=True,
+        )
     )
     def zac_out(w_in: np.ndarray, w_out: np.ndarray) -> None:
         """
@@ -245,8 +249,10 @@ def t0_filter(rise: int, fall: int) -> Callable:
     @guvectorize(
         ["void(float32[:], float32[:])", "void(float64[:], float64[:])"],
         "(n),(m)",
-        **nb_kwargs,
-        forceobj=True,
+        **nb_kwargs(
+            cache=False,
+            forceobj=True,
+        )
     )
     def t0_filter_out(w_in: np.ndarray, w_out: np.ndarray) -> None:
         """

--- a/src/pygama/dsp/processors/convolutions.py
+++ b/src/pygama/dsp/processors/convolutions.py
@@ -73,7 +73,7 @@ def cusp_filter(length: int, sigma: float, flat: int, decay: int) -> Callable:
         **nb_kwargs(
             cache=False,
             forceobj=True,
-        )
+        ),
     )
     def cusp_out(w_in: np.ndarray, w_out: np.ndarray) -> None:
         """
@@ -179,7 +179,7 @@ def zac_filter(length: int, sigma: float, flat: int, decay: int) -> Callable:
         **nb_kwargs(
             cache=False,
             forceobj=True,
-        )
+        ),
     )
     def zac_out(w_in: np.ndarray, w_out: np.ndarray) -> None:
         """
@@ -252,7 +252,7 @@ def t0_filter(rise: int, fall: int) -> Callable:
         **nb_kwargs(
             cache=False,
             forceobj=True,
-        )
+        ),
     )
     def t0_filter_out(w_in: np.ndarray, w_out: np.ndarray) -> None:
         """

--- a/src/pygama/dsp/processors/fftw.py
+++ b/src/pygama/dsp/processors/fftw.py
@@ -53,7 +53,7 @@ def dft(buf_in: np.ndarray, buf_out: np.ndarray) -> Callable:
     typesig = "void(" + str(buf_in.dtype) + "[:, :], " + str(buf_out.dtype) + "[:, :])"
     sizesig = "(m, n)->(m, n)" if buf_in.shape == buf_out.shape else "(m, n),(m, l)"
 
-    @guvectorize([typesig], sizesig, **nb_kwargs, forceobj=True)
+    @guvectorize([typesig], sizesig, **nb_kwargs(cache=False, forceobj=True,) )
     def dft(wf_in: np.ndarray, dft_out: np.ndarray) -> None:
         dft_fun(wf_in, dft_out)
 
@@ -104,7 +104,7 @@ def inv_dft(buf_in: np.ndarray, buf_out: np.ndarray) -> Callable:
     typesig = "void(" + str(buf_in.dtype) + "[:, :], " + str(buf_out.dtype) + "[:, :])"
     sizesig = "(m, n)->(m, n)" if buf_in.shape == buf_out.shape else "(m, n),(m, l)"
 
-    @guvectorize([typesig], sizesig, **nb_kwargs, forceobj=True)
+    @guvectorize([typesig], sizesig, **nb_kwargs(cache=False, forceobj=True,) )
     def inv_dft(wf_in: np.ndarray, dft_out: np.ndarray) -> None:
         idft_fun(wf_in, dft_out)
 
@@ -161,7 +161,7 @@ def psd(buf_in: np.ndarray, buf_out: np.ndarray) -> Callable:
     typesig = "void(" + str(buf_in.dtype) + "[:, :], " + str(buf_out.dtype) + "[:, :])"
     sizesig = "(m, n)->(m, n)" if buf_in.shape == buf_out.shape else "(m, n),(m, l)"
 
-    @guvectorize([typesig], sizesig, **nb_kwargs, forceobj=True)
+    @guvectorize([typesig], sizesig, **nb_kwargs(cache=False, forceobj=True,) )
     def psd(wf_in: np.ndarray, psd_out: np.ndarray) -> None:
         dft_fun(wf_in, buf_dft)
         np.abs(buf_dft, psd_out)

--- a/src/pygama/dsp/processors/fftw.py
+++ b/src/pygama/dsp/processors/fftw.py
@@ -53,7 +53,14 @@ def dft(buf_in: np.ndarray, buf_out: np.ndarray) -> Callable:
     typesig = "void(" + str(buf_in.dtype) + "[:, :], " + str(buf_out.dtype) + "[:, :])"
     sizesig = "(m, n)->(m, n)" if buf_in.shape == buf_out.shape else "(m, n),(m, l)"
 
-    @guvectorize([typesig], sizesig, **nb_kwargs(cache=False, forceobj=True,) )
+    @guvectorize(
+        [typesig],
+        sizesig,
+        **nb_kwargs(
+            cache=False,
+            forceobj=True,
+        ),
+    )
     def dft(wf_in: np.ndarray, dft_out: np.ndarray) -> None:
         dft_fun(wf_in, dft_out)
 
@@ -104,7 +111,14 @@ def inv_dft(buf_in: np.ndarray, buf_out: np.ndarray) -> Callable:
     typesig = "void(" + str(buf_in.dtype) + "[:, :], " + str(buf_out.dtype) + "[:, :])"
     sizesig = "(m, n)->(m, n)" if buf_in.shape == buf_out.shape else "(m, n),(m, l)"
 
-    @guvectorize([typesig], sizesig, **nb_kwargs(cache=False, forceobj=True,) )
+    @guvectorize(
+        [typesig],
+        sizesig,
+        **nb_kwargs(
+            cache=False,
+            forceobj=True,
+        ),
+    )
     def inv_dft(wf_in: np.ndarray, dft_out: np.ndarray) -> None:
         idft_fun(wf_in, dft_out)
 
@@ -161,7 +175,14 @@ def psd(buf_in: np.ndarray, buf_out: np.ndarray) -> Callable:
     typesig = "void(" + str(buf_in.dtype) + "[:, :], " + str(buf_out.dtype) + "[:, :])"
     sizesig = "(m, n)->(m, n)" if buf_in.shape == buf_out.shape else "(m, n),(m, l)"
 
-    @guvectorize([typesig], sizesig, **nb_kwargs(cache=False, forceobj=True,) )
+    @guvectorize(
+        [typesig],
+        sizesig,
+        **nb_kwargs(
+            cache=False,
+            forceobj=True,
+        ),
+    )
     def psd(wf_in: np.ndarray, psd_out: np.ndarray) -> None:
         dft_fun(wf_in, buf_dft)
         np.abs(buf_dft, psd_out)

--- a/src/pygama/dsp/processors/gaussian_filter1d.py
+++ b/src/pygama/dsp/processors/gaussian_filter1d.py
@@ -94,7 +94,7 @@ def gaussian_filter1d(sigma: int, truncate: float = 4.0) -> numpy.ndarray:
         **nb_kwargs(
             cache=False,
             forceobj=True,
-        )
+        ),
     )
     def gaussian_filter1d_out(wf_in, wf_out):
 

--- a/src/pygama/dsp/processors/gaussian_filter1d.py
+++ b/src/pygama/dsp/processors/gaussian_filter1d.py
@@ -91,8 +91,10 @@ def gaussian_filter1d(sigma: int, truncate: float = 4.0) -> numpy.ndarray:
             "void(int64[:], int64[:])",
         ],
         "(n),(m)",
-        **nb_kwargs,
-        forceobj=True,
+        **nb_kwargs(
+            cache=False,
+            forceobj=True,
+        )
     )
     def gaussian_filter1d_out(wf_in, wf_out):
 

--- a/src/pygama/dsp/processors/param_lookup.py
+++ b/src/pygama/dsp/processors/param_lookup.py
@@ -21,8 +21,9 @@ def param_lookup(
     default_val = out_type(default_val)
 
     @guvectorize(
-        ["void(uint32, " + out_type.name + "[:])"], "()->()",
-        **nb_kwargs(cache=False, forceobj=True)
+        ["void(uint32, " + out_type.name + "[:])"],
+        "()->()",
+        **nb_kwargs(cache=False, forceobj=True),
     )
     def lookup(channel: int, val: np.ndarray) -> None:
         """Look up a value for the provided channel from a dictionary provided

--- a/src/pygama/dsp/processors/param_lookup.py
+++ b/src/pygama/dsp/processors/param_lookup.py
@@ -21,7 +21,8 @@ def param_lookup(
     default_val = out_type(default_val)
 
     @guvectorize(
-        ["void(uint32, " + out_type.name + "[:])"], "()->()", **nb_kwargs, forceobj=True
+        ["void(uint32, " + out_type.name + "[:])"], "()->()",
+        **nb_kwargs(cache=False, forceobj=True)
     )
     def lookup(channel: int, val: np.ndarray) -> None:
         """Look up a value for the provided channel from a dictionary provided

--- a/src/pygama/dsp/processors/wiener_filter.py
+++ b/src/pygama/dsp/processors/wiener_filter.py
@@ -119,7 +119,7 @@ def wiener_filter(file_name_array: list[str]) -> np.ndarray:
         **nb_kwargs(
             cache=False,
             forceobj=True,
-        )
+        ),
     )
     def wiener_out(fft_w_in: np.ndarray, fft_w_out: np.ndarray) -> None:
         """

--- a/src/pygama/dsp/processors/wiener_filter.py
+++ b/src/pygama/dsp/processors/wiener_filter.py
@@ -116,8 +116,10 @@ def wiener_filter(file_name_array: list[str]) -> np.ndarray:
     @guvectorize(
         ["void(complex64[:], complex64[:])", "void(complex128[:], complex128[:])"],
         "(n)->(n)",
-        **nb_kwargs,
-        forceobj=True,
+        **nb_kwargs(
+            cache=False,
+            forceobj=True,
+        )
     )
     def wiener_out(fft_w_in: np.ndarray, fft_w_out: np.ndarray) -> None:
         """

--- a/src/pygama/dsp/utils.py
+++ b/src/pygama/dsp/utils.py
@@ -1,6 +1,8 @@
 import os
+from collections.abc import MutableMapping
+from typing import Any, Iterator
 
-class NumbaDefaults:
+class NumbaDefaults(MutableMapping):
     """Bare-bones class to store some Numba default options.
 
     Examples
@@ -15,7 +17,7 @@ class NumbaDefaults:
     Customize one argument but still set defaults for the others:
 
     >>> from pygama.dsp.utils import numba_defaults as nb_defaults
-    >>> @guvectorize([], "", cache=True, boundscheck=nb_defaults.boundscheck) # def proc(...): ...
+    >>> @guvectorize([], "", **nb_defaults(cache=False) # def proc(...): ...
 
     Set global options at runtime:
 
@@ -35,6 +37,31 @@ class NumbaDefaults:
             self.cache: bool = True
         self.boundscheck: bool = False
 
+    def __getitem__(self, item: str) -> Any:
+        return self.__dict__[item]
+
+    def __setitem__(self, item: str, val: Any) -> None:
+        self.__dict__[item] = val
+
+    def __delitem__(self, item: str) -> None:
+        del self.__dict__[item]
+
+    def __iter__(self) -> Iterator:
+        return self.__dict__.__iter__()
+
+    def __len__(self) -> int:
+        return len(self.__dict__)
+    
+    def __call__(self, **kwargs) -> dict:
+        mapping = self.__dict__.copy()
+        mapping.update(**kwargs)
+        return mapping
+
+    def __str__(self) -> str:
+        return str(self.__dict__)
+
+    def __repr__(self) -> str:
+        return str(self.__dict__)
 
 numba_defaults = NumbaDefaults()
-numba_defaults_kwargs = numba_defaults.__dict__
+numba_defaults_kwargs = numba_defaults

--- a/src/pygama/dsp/utils.py
+++ b/src/pygama/dsp/utils.py
@@ -2,6 +2,7 @@ import os
 from collections.abc import MutableMapping
 from typing import Any, Iterator
 
+
 def getenv_bool(name: str, default: bool = False) -> bool:
     """Get environment value as a boolean, returning True for 1, t and true
     (caps-insensitive), and False for any other value and default if undefined.
@@ -13,6 +14,7 @@ def getenv_bool(name: str, default: bool = False) -> bool:
         return True
     else:
         return False
+
 
 class NumbaDefaults(MutableMapping):
     """Bare-bones class to store some Numba default options. Defaults values

--- a/src/pygama/dsp/utils.py
+++ b/src/pygama/dsp/utils.py
@@ -1,3 +1,5 @@
+import os
+
 class NumbaDefaults:
     """Bare-bones class to store some Numba default options.
 
@@ -26,7 +28,11 @@ class NumbaDefaults:
     """
 
     def __init__(self) -> None:
-        self.cache: bool = False
+        cache = os.getenv("PYGAMA_CACHE")
+        if not cache or not cache.lower() in ('1', 't', 'true'):
+            self.cache: bool = False
+        else:
+            self.cache: bool = True
         self.boundscheck: bool = False
 
 

--- a/src/pygama/dsp/utils.py
+++ b/src/pygama/dsp/utils.py
@@ -2,9 +2,21 @@ import os
 from collections.abc import MutableMapping
 from typing import Any, Iterator
 
+def getenv_bool(name: str, default: bool = False) -> bool:
+    """Get environment value as a boolean, returning True for 1, t and true
+    (caps-insensitive), and False for any other value and default if undefined.
+    """
+    val = os.getenv(name)
+    if not val:
+        return default
+    elif val.lower() in ("1", "t", "true"):
+        return True
+    else:
+        return False
 
 class NumbaDefaults(MutableMapping):
-    """Bare-bones class to store some Numba default options.
+    """Bare-bones class to store some Numba default options. Defaults values
+    are set from environment variables
 
     Examples
     --------
@@ -20,7 +32,7 @@ class NumbaDefaults(MutableMapping):
     >>> from pygama.dsp.utils import numba_defaults as nb_defaults
     >>> @guvectorize([], "", **nb_defaults(cache=False) # def proc(...): ...
 
-    Set global options at runtime:
+    Override global options at runtime:
 
     >>> from pygama.dsp.utils import numba_defaults
     >>> from pygama.dsp import build_dsp
@@ -31,12 +43,8 @@ class NumbaDefaults(MutableMapping):
     """
 
     def __init__(self) -> None:
-        cache = os.getenv("PYGAMA_CACHE")
-        if not cache or not cache.lower() in ("1", "t", "true"):
-            self.cache: bool = False
-        else:
-            self.cache: bool = True
-        self.boundscheck: bool = False
+        self.cache: bool = getenv_bool("PYGAMA_CACHE")
+        self.boundscheck: bool = getenv_bool("PYGAMA_BOUNDSCHECK")
 
     def __getitem__(self, item: str) -> Any:
         return self.__dict__[item]

--- a/src/pygama/dsp/utils.py
+++ b/src/pygama/dsp/utils.py
@@ -2,6 +2,7 @@ import os
 from collections.abc import MutableMapping
 from typing import Any, Iterator
 
+
 class NumbaDefaults(MutableMapping):
     """Bare-bones class to store some Numba default options.
 
@@ -31,7 +32,7 @@ class NumbaDefaults(MutableMapping):
 
     def __init__(self) -> None:
         cache = os.getenv("PYGAMA_CACHE")
-        if not cache or not cache.lower() in ('1', 't', 'true'):
+        if not cache or not cache.lower() in ("1", "t", "true"):
             self.cache: bool = False
         else:
             self.cache: bool = True
@@ -51,7 +52,7 @@ class NumbaDefaults(MutableMapping):
 
     def __len__(self) -> int:
         return len(self.__dict__)
-    
+
     def __call__(self, **kwargs) -> dict:
         mapping = self.__dict__.copy()
         mapping.update(**kwargs)
@@ -62,6 +63,7 @@ class NumbaDefaults(MutableMapping):
 
     def __repr__(self) -> str:
         return str(self.__dict__)
+
 
 numba_defaults = NumbaDefaults()
 numba_defaults_kwargs = numba_defaults


### PR DESCRIPTION
1. Instead of defaulting to no caching, default to no caching unless the `PYGAMA_CACHE` environment variable is set to `1`, `t` or `true`. Overriding at the start of the program is still possible
2. Changed the numba_defaults object to make it easier to change a single value from default for a specific processor. Instead of having to specifically invoke the default values in the `@guvectorize` decorator, now you can call `**nb_kwargs(cache=False)` to override that specific kwarg while using defaults in other cases.
The default values object now inherits from `MutableMapping` so that it acts like a dict itself; this enables us to still use `**nb_kwargs` as before.
4. For all (I think) of the processors that rely on factories, set caching to false regardless of the default. For these processors, the kernels get hard-compiled into the numba IR; if we cache these, then we will not be able to change the kernels!