### PR TITLE
lh5_tables argument in build_dsp now accepts a single string

### DIFF
--- a/src/pygama/dsp/build_dsp.py
+++ b/src/pygama/dsp/build_dsp.py
@@ -118,7 +118,10 @@ def build_dsp(
         lh5_tables = lh5.ls(f_raw)
     elif isinstance(lh5_tables, str):
         lh5_tables = [lh5_tables]
-    elif not ( hasattr(lh5_tables, '__iter__') and all(isinstance(el, str) for el in lh5_tables) ):
+    elif not (
+        hasattr(lh5_tables, "__iter__")
+        and all(isinstance(el, str) for el in lh5_tables)
+    ):
         raise RuntimeError("lh5_tables must be None, a string, or a list of strings")
 
     # check if group points to raw data; sometimes 'raw' is nested, e.g g024/raw

--- a/src/pygama/dsp/build_dsp.py
+++ b/src/pygama/dsp/build_dsp.py
@@ -116,6 +116,10 @@ def build_dsp(
     # if no group is specified, assume we want to decode every table in the file
     if lh5_tables is None:
         lh5_tables = lh5.ls(f_raw)
+    elif isinstance(lh5_tables, str):
+        lh5_tables = [lh5_tables]
+    elif not ( hasattr(lh5_tables, '__iter__') and all(isinstance(el, str) for el in lh5_tables) ):
+        raise RuntimeError("lh5_tables must be None, a string, or a list of strings")
 
     # check if group points to raw data; sometimes 'raw' is nested, e.g g024/raw
     for i, tb in enumerate(lh5_tables):

--- a/src/pygama/dsp/build_dsp.py
+++ b/src/pygama/dsp/build_dsp.py
@@ -27,7 +27,7 @@ def build_dsp(
     f_raw: str,
     f_dsp: str,
     dsp_config: str | dict = None,
-    lh5_tables: list[str] = None,
+    lh5_tables: list[str] | str = None,
     database: str | dict = None,
     outputs: list[str] = None,
     n_max: int = np.inf,
@@ -118,10 +118,7 @@ def build_dsp(
         lh5_tables = lh5.ls(f_raw)
     elif isinstance(lh5_tables, str):
         lh5_tables = [lh5_tables]
-    elif not (
-        hasattr(lh5_tables, "__iter__")
-        and all(isinstance(el, str) for el in lh5_tables)
-    ):
+    elif not ( hasattr(lh5_tables, '__iter__') and all(isinstance(el, str) for el in lh5_tables) ):
         raise RuntimeError("lh5_tables must be None, a string, or a list of strings")
 
     # check if group points to raw data; sometimes 'raw' is nested, e.g g024/raw


### PR DESCRIPTION
Bugfix: the `lh5_tables` argument should have accepted a single group passes as a string, but only accepted a list of strings (or None). Now it works as intended. Also added a more informative exception in cases where it is not an acceptable type.