### PR TITLE
Raise RuntimeError in LH5_Iterator if no files could be found

### DIFF
--- a/src/pygama/lgdo/lh5_store.py
+++ b/src/pygama/lgdo/lh5_store.py
@@ -1139,7 +1139,7 @@ class LH5Iterator:
                 field_mask=field_mask,
             )
         else:
-            None
+            raise RuntimeError(f"can't open any files from {lh5_files}")
 
         self.n_rows = 0
         self.current_entry = 0


### PR DESCRIPTION
Added a RuntimeException when trying to use the LH5Iterator to open one or more files, when no files can be found. Without this, we tend to see very confusing errors raised further down the line. Here's what it will look like now:
```
In [4]: lh5.LH5Iterator("non_existent_files*.lh5", group="test")
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
<ipython-input-4-f9bfcaa59f8b> in <module>
----> 1 lh5.LH5Iterator("non_existent_files*.lh5", group="test")

~/.local/lib/python3.10/site-packages/pygama/lgdo/lh5_store.py in __init__(self, lh5_files, group, base_path, entry_list, entry_mask, field_mask, buffer_len)
   1140             )
   1141         else:
-> 1142             raise RuntimeError(f"can't open any files from {lh5_files}")
   1143 
   1144         self.n_rows = 0

RuntimeError: can't open any files from ['non_existent_files*.lh5']```