### PR TITLE
Add links to badges in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # pygama
 
-![PyPI](https://img.shields.io/pypi/v/pygama?logo=pypi)
-![GitHub tag (latest by date)](https://img.shields.io/github/v/tag/legend-exp/pygama?logo=git)
+[![PyPI](https://img.shields.io/pypi/v/pygama?logo=pypi)](https://pypi.org/project/pygama/)
+[![GitHub tag (latest by date)](https://img.shields.io/github/v/tag/legend-exp/pygama?logo=git)](https://github.com/legend-exp/pygama/tags)
 [![GitHub Workflow Status](https://img.shields.io/github/workflow/status/legend-exp/pygama/pygama/main?label=main%20branch&logo=github)](https://github.com/legend-exp/pygama/actions)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Codecov](https://img.shields.io/codecov/c/github/legend-exp/pygama?logo=codecov)](https://app.codecov.io/gh/legend-exp/pygama)
-![GitHub issues](https://img.shields.io/github/issues/legend-exp/pygama?logo=github)
-![GitHub pull requests](https://img.shields.io/github/issues-pr/legend-exp/pygama?logo=github)
-![License](https://img.shields.io/github/license/legend-exp/pygama)
+[![GitHub issues](https://img.shields.io/github/issues/legend-exp/pygama?logo=github)](https://github.com/legend-exp/pygama/issues)
+[![GitHub pull requests](https://img.shields.io/github/issues-pr/legend-exp/pygama?logo=github)](https://github.com/legend-exp/pygama/pulls)
+[![License](https://img.shields.io/github/license/legend-exp/pygama)](https://github.com/legend-exp/pygama/blob/main/LICENSE)
 [![Read the Docs](https://img.shields.io/readthedocs/pygama?logo=readthedocs)](https://pygama.readthedocs.io)
 
 *pygama* is a Python package for:


### PR DESCRIPTION
I noticed that some of the badges in the README aren't linked to a particular page, so I went through and added them, so that you navigate to the relevant page when clicking on them, rather than opening the badge. Probably most useful for the PyPI release, but added them to all badges anyways.

The only one that we might want to change is the link of the GitHub tag badge - right now I have it going to the tag list, but could instead go to the list of releases.

---

Before submitting a pull request, please make sure you've read and understood the pygama developer's guide: https://pygama.readthedocs.io/en/latest/developer.html. In particular, do not forget to:

- [x] Conform to our **coding conventions**
- [x] Update existing or add new **tests**
- [x] Update existing or add new **documentation**
- [x] Address any issue reported by GitHub checks
