### PR TITLE
Fixed a pretty big sign error

### DIFF
--- a/src/pygama/dsp/processing_chain.py
+++ b/src/pygama/dsp/processing_chain.py
@@ -1243,7 +1243,7 @@ class UnitConversionManager(ProcessorManager):
 
     @vectorize(nopython=True, cache=True)
     def convert(buf_in, offset_in, offset_out, period_ratio):  # noqa: N805
-        return (buf_in - offset_in) * period_ratio + offset_out
+        return (buf_in + offset_in) * period_ratio - offset_out
 
     def __init__(self, var: ProcChainVar, unit: str | Unit) -> None:
         # reference back to our processing chain


### PR DESCRIPTION
When transforming between periods/offsets mixed up the signs in the offset. This completely broke windowing.

Before submitting a pull request, please make sure you've read and understood the pygama developer's guide: https://pygama.readthedocs.io/en/latest/developer.html. In particular, do not forget to:

- [x] Conform to our **coding conventions**
- [x] Update existing or add new **tests**
- [x] Update existing or add new **documentation**
- [x] Address any issue reported by GitHub checks
