### PR TITLE
Bug fixes and improvements to the waveform browser

### DIFF
--- a/src/pygama/dsp/build_dsp.py
+++ b/src/pygama/dsp/build_dsp.py
@@ -17,9 +17,9 @@ from tqdm import tqdm
 import pygama
 import pygama.lgdo as lgdo
 import pygama.lgdo.lh5_store as lh5
-from pygama.lgdo.lgdo_utils import expand_path
 from pygama.dsp.errors import DSPFatal
 from pygama.dsp.processing_chain import build_processing_chain
+from pygama.lgdo.lgdo_utils import expand_path
 
 log = logging.getLogger(__name__)
 

--- a/src/pygama/dsp/build_dsp.py
+++ b/src/pygama/dsp/build_dsp.py
@@ -17,6 +17,7 @@ from tqdm import tqdm
 import pygama
 import pygama.lgdo as lgdo
 import pygama.lgdo.lh5_store as lh5
+from pygama.lgdo.lgdo_utils import expand_path
 from pygama.dsp.errors import DSPFatal
 from pygama.dsp.processing_chain import build_processing_chain
 
@@ -100,13 +101,6 @@ def build_dsp(
                 log.debug(f"table {tb} not found")
         return
 
-    if isinstance(dsp_config, str):
-        with open(dsp_config) as config_file:
-            dsp_config = json.load(config_file)
-
-    if not isinstance(dsp_config, dict):
-        raise ValueError("dsp_config must be a dict")
-
     raw_store = lh5.LH5Store()
     lh5_file = raw_store.gimme_file(f_raw, "r")
     if lh5_file is None:
@@ -134,19 +128,13 @@ def build_dsp(
     if len(lh5_tables) == 0:
         raise RuntimeError(f"could not find any valid LH5 table in {f_raw}")
 
-    # load DSP config (default: one config file for all tables)
-    if isinstance(dsp_config, str):
-        with open(dsp_config) as config_file:
-            dsp_config = json.load(config_file)
-
     # get the database parameters. For now, this will just be a dict in a json
     # file, but eventually we will want to interface with the metadata repo
     if isinstance(database, str):
-        with open(database) as db_file:
+        with open(expand_path(database)) as db_file:
             database = json.load(db_file)
 
     if database and not isinstance(database, dict):
-        database = None
         raise ValueError("input database is not a valid JSON file or dict")
 
     if write_mode is None and os.path.isfile(f_dsp):

--- a/src/pygama/dsp/processing_chain.py
+++ b/src/pygama/dsp/processing_chain.py
@@ -19,8 +19,8 @@ import numpy as np
 from numba import vectorize
 
 import pygama.lgdo as lgdo
-from pygama.lgdo.lgdo_utils import expand_path
 from pygama.dsp.errors import DSPFatal, ProcessingChainError
+from pygama.lgdo.lgdo_utils import expand_path
 from pygama.math.units import Quantity, Unit
 from pygama.math.units import unit_registry as ureg
 

--- a/src/pygama/dsp/processing_chain.py
+++ b/src/pygama/dsp/processing_chain.py
@@ -19,6 +19,7 @@ import numpy as np
 from numba import vectorize
 
 import pygama.lgdo as lgdo
+from pygama.lgdo.lgdo_utils import expand_path
 from pygama.dsp.errors import DSPFatal, ProcessingChainError
 from pygama.math.units import Quantity, Unit
 from pygama.math.units import unit_registry as ureg
@@ -1606,13 +1607,15 @@ def build_processing_chain(
     proc_chain = ProcessingChain(block_width, lh5_in.size)
 
     if isinstance(dsp_config, str):
-        with open(dsp_config) as f:
+        with open(expand_path(dsp_config)) as f:
             dsp_config = json.load(f)
     elif dsp_config is None:
         dsp_config = {"outputs": [], "processors": {}}
-    else:
+    elif isinstance(dsp_config, dict):
         # We don't want to modify the input!
         dsp_config = deepcopy(dsp_config)
+    else:
+        raise ValueError("dsp_config must be a dict, json file, or None")
 
     if outputs is None:
         outputs = dsp_config["outputs"]

--- a/src/pygama/lgdo/lgdo_utils.py
+++ b/src/pygama/lgdo/lgdo_utils.py
@@ -3,8 +3,8 @@ Implements utilities for LEGEND Data Objects.
 """
 from __future__ import annotations
 
-import logging
 import glob
+import logging
 import os
 
 import numpy as np
@@ -89,7 +89,8 @@ def parse_datatype(datatype: str) -> tuple[str, tuple[int, ...], str | list[str]
     else:
         return datatype, None, element_description.split(",")
 
-def expand_path(path: str, list: bool=False) -> str | list:
+
+def expand_path(path: str, list: bool = False) -> str | list:
     """Expand environment variables and wildcards to return absolute path
 
     Parameters
@@ -106,11 +107,11 @@ def expand_path(path: str, list: bool=False) -> str | list:
         Unique absolute path, or list of all absolute paths
     """
 
-    paths = glob.glob(os.path.expanduser(os.path.expandvars((path))))
+    paths = glob.glob(os.path.expanduser(os.path.expandvars(path)))
     if not list:
         if len(paths) == 0:
             raise FileNotFoundError(f"could not find path matching {path}")
-        elif len(paths) >1:
+        elif len(paths) > 1:
             raise FileNotFoundError(f"found multiple paths matching {path}")
         else:
             return paths[0]

--- a/src/pygama/lgdo/lgdo_utils.py
+++ b/src/pygama/lgdo/lgdo_utils.py
@@ -109,9 +109,9 @@ def expand_path(path: str, list: bool=False) -> str | list:
     paths = glob.glob(os.path.expanduser(os.path.expandvars((path))))
     if not list:
         if len(paths) == 0:
-            raise RuntimeError(f"could not find path matching {path}")
+            raise FileNotFoundError(f"could not find path matching {path}")
         elif len(paths) >1:
-            raise RuntimeError(f"found multiple paths matching {path}")
+            raise FileNotFoundError(f"found multiple paths matching {path}")
         else:
             return paths[0]
     else:

--- a/src/pygama/lgdo/lgdo_utils.py
+++ b/src/pygama/lgdo/lgdo_utils.py
@@ -4,6 +4,8 @@ Implements utilities for LEGEND Data Objects.
 from __future__ import annotations
 
 import logging
+import glob
+import os
 
 import numpy as np
 
@@ -86,3 +88,31 @@ def parse_datatype(datatype: str) -> tuple[str, tuple[int, ...], str | list[str]
         return datatype, tuple(dims), element_description
     else:
         return datatype, None, element_description.split(",")
+
+def expand_path(path: str, list: bool=False) -> str | list:
+    """Expand environment variables and wildcards to return absolute path
+
+    Parameters
+    ----------
+    path
+        name of path, which may include environment variables and wildcards
+    list
+        if True, return a list. If False, return a string; if False and a
+        unique file is not found, raise an Exception
+
+    Returns
+    -------
+    path or list of paths
+        Unique absolute path, or list of all absolute paths
+    """
+
+    paths = glob.glob(os.path.expanduser(os.path.expandvars((path))))
+    if not list:
+        if len(paths) == 0:
+            raise RuntimeError(f"could not find path matching {path}")
+        elif len(paths) >1:
+            raise RuntimeError(f"found multiple paths matching {path}")
+        else:
+            return paths[0]
+    else:
+        return paths

--- a/src/pygama/lgdo/lh5_store.py
+++ b/src/pygama/lgdo/lh5_store.py
@@ -21,7 +21,7 @@ import pandas as pd
 from pygama.lgdo.array import Array
 from pygama.lgdo.arrayofequalsizedarrays import ArrayOfEqualSizedArrays
 from pygama.lgdo.fixedsizearray import FixedSizeArray
-from pygama.lgdo.lgdo_utils import parse_datatype
+from pygama.lgdo.lgdo_utils import parse_datatype, expand_path
 from pygama.lgdo.scalar import Scalar
 from pygama.lgdo.struct import Struct
 from pygama.lgdo.table import Table
@@ -57,7 +57,7 @@ class LH5Store:
             whether to keep files open by storing the :mod:`h5py` objects as
             class attributes.
         """
-        self.base_path = base_path
+        self.base_path = "" if base_path == "" else expand_path(base_path)
         self.keep_open = keep_open
         self.files = {}
 
@@ -73,6 +73,7 @@ class LH5Store:
         """
         if isinstance(lh5_file, h5py.File):
             return lh5_file
+        lh5_file = expand_path(lh5_file)
         if lh5_file in self.files.keys():
             return self.files[lh5_file]
         if self.base_path != "":
@@ -974,7 +975,7 @@ def show(
     """
     # open file
     if isinstance(lh5_file, str):
-        lh5_file = h5py.File(lh5_file, "r")
+        lh5_file = h5py.File(expand_path(lh5_file), "r")
 
     # go to group
     if lh5_group != "/":
@@ -1177,7 +1178,7 @@ class LH5Iterator:
 
         # List of files, with wildcards and env vars expanded
         if isinstance(lh5_files, str):
-            lh5_files = [lh5_files]
+            lh5_files = expand_path(lh5_files, True)
         elif not isinstance(lh5_files, list):
             raise ValueError("lh5_files must be a string or list of strings")
 
@@ -1187,7 +1188,7 @@ class LH5Iterator:
             )
 
         self.lh5_files = [
-            f for f_wc in lh5_files for f in sorted(glob.glob(os.path.expandvars(f_wc)))
+            f for f_wc in lh5_files for f in expand_path(f_wc, True)
         ]
 
         # Map to last row in each file

--- a/src/pygama/lgdo/lh5_store.py
+++ b/src/pygama/lgdo/lh5_store.py
@@ -73,7 +73,8 @@ class LH5Store:
         """
         if isinstance(lh5_file, h5py.File):
             return lh5_file
-        lh5_file = expand_path(lh5_file)
+        if mode == "r":
+            lh5_file = expand_path(lh5_file)
         if lh5_file in self.files.keys():
             return self.files[lh5_file]
         if self.base_path != "":

--- a/src/pygama/lgdo/lh5_store.py
+++ b/src/pygama/lgdo/lh5_store.py
@@ -21,7 +21,7 @@ import pandas as pd
 from pygama.lgdo.array import Array
 from pygama.lgdo.arrayofequalsizedarrays import ArrayOfEqualSizedArrays
 from pygama.lgdo.fixedsizearray import FixedSizeArray
-from pygama.lgdo.lgdo_utils import parse_datatype, expand_path
+from pygama.lgdo.lgdo_utils import expand_path, parse_datatype
 from pygama.lgdo.scalar import Scalar
 from pygama.lgdo.struct import Struct
 from pygama.lgdo.table import Table
@@ -1188,9 +1188,7 @@ class LH5Iterator:
                 "entry_list and entry_mask arguments are mutually exclusive"
             )
 
-        self.lh5_files = [
-            f for f_wc in lh5_files for f in expand_path(f_wc, True)
-        ]
+        self.lh5_files = [f for f_wc in lh5_files for f in expand_path(f_wc, True)]
 
         # Map to last row in each file
         self.file_map = np.array(

--- a/src/pygama/vis/waveform_browser.py
+++ b/src/pygama/vis/waveform_browser.py
@@ -417,18 +417,18 @@ class WaveformBrowser:
                 unit = data.attrs.get("units", None)
                 if unit and unit in ureg and ureg.is_compatible_with(unit, self.x_unit):
                     # Vertical line
-                    val = val * float(ureg(unit) / self.x_unit) - ref_time
-                    lines.append(Line2D([val] * 2, [-lim, lim]))
+                    val = np.array([val * float(ureg(unit) / self.x_unit) - ref_time])
+                    lines.append(Line2D(np.tile(val, 2), [-lim, lim]))
                     self._update_auto_limit(val, None)
                 else:
                     # Horizontal line
-                    lines.append(Line2D([-lim, lim], [val / norm] * 2))
+                    lines.append(Line2D([-lim, lim], np.tile(val/norm, 2)))
                     self._update_auto_limit(None, val)
 
             elif data is None:
                 # Check for data in auxiliary table. It's unitless so I guess just do an hline...
-                val = self.aux_vals[name][entry] / norm
-                lines.append(Line2D([-lim, lim], [val] * 2))
+                val = np.array([self.aux_vals[name][entry] / norm])
+                lines.append(Line2D([-lim, lim], np.tile(val, 2)))
                 self._update_auto_limit(None, val)
 
             else:
@@ -531,18 +531,29 @@ class WaveformBrowser:
 
     def _update_auto_limit(self, x: np.ndarray, y: np.ndarray) -> None:
         # Helper to update the automatic limits
-        y_where = {}
-        if isinstance(y, np.ndarray) and self.y_lim is not None:
-            y_where["where"] = (y >= self.y_lim[0]) & (y <= self.y_lim[1])
-        x_where = {}
-        if isinstance(x, np.ndarray) and self.x_lim is not None:
-            x_where["where"] = (x >= self.x_lim[0]) & (x <= self.x_lim[1])
+        where = True
+        
         if x is not None:
-            self.auto_x_lim[0] = np.amin(x, **y_where, initial=self.auto_x_lim[0])
-            self.auto_x_lim[1] = np.amax(x, **y_where, initial=self.auto_x_lim[1])
+            where &= np.isfinite(x)
+            if self.x_lim is not None:
+                where &= (x >= self.x_lim[0]) & (x <= self.x_lim[1])
+
         if y is not None:
-            self.auto_y_lim[0] = np.amin(y, **y_where, initial=self.auto_y_lim[0])
-            self.auto_y_lim[1] = np.amax(y, **y_where, initial=self.auto_y_lim[1])
+            where &= np.isfinite(y)
+            if self.y_lim is not None:
+                where &= (y >= self.y_lim[0]) & (y <= self.y_lim[1])
+
+        if x is not None:
+            self.auto_x_lim = [
+                np.amin(x, where=where, initial=self.auto_x_lim[0]),
+                np.amax(x, where=where, initial=self.auto_x_lim[1])
+            ]
+
+        if y is not None:
+            self.auto_y_lim = [
+                np.amin(y, where=where, initial=self.auto_y_lim[0]),
+                np.amax(y, where=where, initial=self.auto_y_lim[1])
+            ]
 
     def draw_entry(
         self,

--- a/src/pygama/vis/waveform_browser.py
+++ b/src/pygama/vis/waveform_browser.py
@@ -355,7 +355,7 @@ class WaveformBrowser:
             return
 
         if entry > len(self.lh5_it):
-            if safe:
+            if not safe:
                 raise IndexError
             else:
                 return

--- a/src/pygama/vis/waveform_browser.py
+++ b/src/pygama/vis/waveform_browser.py
@@ -182,7 +182,7 @@ class WaveformBrowser:
             self.lines = {line: [] for line in lines}
 
         # styles
-        default_style = cycler(plt.rcParams['axes.prop_cycle'])
+        default_style = cycler(plt.rcParams["axes.prop_cycle"])
         if isinstance(styles, (list, tuple)):
             self.styles = [None for _ in self.lines]
             for i, sty in enumerate(styles):
@@ -422,7 +422,7 @@ class WaveformBrowser:
                     self._update_auto_limit(val, None)
                 else:
                     # Horizontal line
-                    lines.append(Line2D([-lim, lim], np.tile(val/norm, 2)))
+                    lines.append(Line2D([-lim, lim], np.tile(val / norm, 2)))
                     self._update_auto_limit(None, val)
 
             elif data is None:
@@ -486,7 +486,7 @@ class WaveformBrowser:
             styles = self.styles
 
         # draw lines
-        default_style = cycler(plt.rcParams['axes.prop_cycle'])
+        default_style = cycler(plt.rcParams["axes.prop_cycle"])
         for i, lines in enumerate(self.lines.values()):
             if isinstance(self.styles, list):
                 styles = self.styles[i]
@@ -532,7 +532,7 @@ class WaveformBrowser:
     def _update_auto_limit(self, x: np.ndarray, y: np.ndarray) -> None:
         # Helper to update the automatic limits
         where = True
-        
+
         if x is not None:
             where &= np.isfinite(x)
             if self.x_lim is not None:
@@ -546,13 +546,13 @@ class WaveformBrowser:
         if x is not None:
             self.auto_x_lim = [
                 np.amin(x, where=where, initial=self.auto_x_lim[0]),
-                np.amax(x, where=where, initial=self.auto_x_lim[1])
+                np.amax(x, where=where, initial=self.auto_x_lim[1]),
             ]
 
         if y is not None:
             self.auto_y_lim = [
                 np.amin(y, where=where, initial=self.auto_y_lim[0]),
-                np.amax(y, where=where, initial=self.auto_y_lim[1])
+                np.amax(y, where=where, initial=self.auto_y_lim[1]),
             ]
 
     def draw_entry(

--- a/src/pygama/vis/waveform_browser.py
+++ b/src/pygama/vis/waveform_browser.py
@@ -182,6 +182,7 @@ class WaveformBrowser:
             self.lines = {line: [] for line in lines}
 
         # styles
+        default_style = cycler(plt.rcParams['axes.prop_cycle'])
         if isinstance(styles, (list, tuple)):
             self.styles = [None for _ in self.lines]
             for i, sty in enumerate(styles):
@@ -191,7 +192,7 @@ class WaveformBrowser:
                     except KeyError:
                         self.styles[i] = itertools.repeat(None)
                 elif sty is None:
-                    self.styles[i] = itertools.repeat(None)
+                    self.styles[i] = default_style
                 else:
                     self.styles[i] = cycler(**sty)
         else:
@@ -201,7 +202,7 @@ class WaveformBrowser:
                 except KeyError:
                     self.styles = itertools.repeat(None)
             elif styles is None:
-                self.styles = itertools.repeat(None)
+                self.styles = default_style
             else:
                 self.styles = cycler(**styles)
 
@@ -485,11 +486,12 @@ class WaveformBrowser:
             styles = self.styles
 
         # draw lines
+        default_style = cycler(plt.rcParams['axes.prop_cycle'])
         for i, lines in enumerate(self.lines.values()):
             if isinstance(self.styles, list):
                 styles = self.styles[i]
             if styles is None:
-                styles = cycler(plt.rcparams)
+                styles = default_style
 
             for line, sty in zip(lines, styles):
                 if sty is not None:

--- a/tests/lgdo/test_lgdo_utils.py
+++ b/tests/lgdo/test_lgdo_utils.py
@@ -1,4 +1,6 @@
 import numpy as np
+import os
+import pytest
 
 import pygama.lgdo.lgdo_utils as lgdo_utils
 
@@ -43,3 +45,23 @@ def test_parse_datatype():
     for string, dt_tuple in datatypes:
         pd_dt_tuple = lgdo_utils.parse_datatype(string)
         assert pd_dt_tuple == dt_tuple
+
+def test_expand_path(lgnd_test_data):
+    files = [
+        lgnd_test_data.get_path("lh5/prod-ref-l200/generated/tier/dsp/cal/p01/r014/l60-p01-r014-cal-20220716T104550Z-tier_dsp.lh5"),
+        lgnd_test_data.get_path("lh5/prod-ref-l200/generated/tier/dsp/cal/p01/r014/l60-p01-r014-cal-20220716T105236Z-tier_dsp.lh5"),
+    ]
+    base_dir = os.path.dirname(files[0])
+
+    assert lgdo_utils.expand_path(f"{base_dir}/*20220716T104550Z*") == files[0]
+    
+    # Should fail if file not found
+    with pytest.raises(FileNotFoundError):
+        lgdo_utils.expand_path(f"{base_dir}/not_a_real_file.lh5")
+
+    # Should fail if multiple files found
+    with pytest.raises(FileNotFoundError):
+        lgdo_utils.expand_path(f"{base_dir}/*.lh5")
+
+    # Check if it finds a list of files correctly
+    assert sorted(lgdo_utils.expand_path(f"{base_dir}/*.lh5", True)) == sorted(files)

--- a/tests/lgdo/test_lgdo_utils.py
+++ b/tests/lgdo/test_lgdo_utils.py
@@ -1,5 +1,6 @@
-import numpy as np
 import os
+
+import numpy as np
 import pytest
 
 import pygama.lgdo.lgdo_utils as lgdo_utils
@@ -46,15 +47,20 @@ def test_parse_datatype():
         pd_dt_tuple = lgdo_utils.parse_datatype(string)
         assert pd_dt_tuple == dt_tuple
 
+
 def test_expand_path(lgnd_test_data):
     files = [
-        lgnd_test_data.get_path("lh5/prod-ref-l200/generated/tier/dsp/cal/p01/r014/l60-p01-r014-cal-20220716T104550Z-tier_dsp.lh5"),
-        lgnd_test_data.get_path("lh5/prod-ref-l200/generated/tier/dsp/cal/p01/r014/l60-p01-r014-cal-20220716T105236Z-tier_dsp.lh5"),
+        lgnd_test_data.get_path(
+            "lh5/prod-ref-l200/generated/tier/dsp/cal/p01/r014/l60-p01-r014-cal-20220716T104550Z-tier_dsp.lh5"
+        ),
+        lgnd_test_data.get_path(
+            "lh5/prod-ref-l200/generated/tier/dsp/cal/p01/r014/l60-p01-r014-cal-20220716T105236Z-tier_dsp.lh5"
+        ),
     ]
     base_dir = os.path.dirname(files[0])
 
     assert lgdo_utils.expand_path(f"{base_dir}/*20220716T104550Z*") == files[0]
-    
+
     # Should fail if file not found
     with pytest.raises(FileNotFoundError):
         lgdo_utils.expand_path(f"{base_dir}/not_a_real_file.lh5")


### PR DESCRIPTION
1) Fixed bug where Error wasn't being thrown when an out of range waveform index is given to the browser
2) Fixed the waveform browser's use of the default style; instead of by default drawing all waveforms blue, it will now cycle through the rcParams color cycle
3) Automatically expand wildcards, environment variables and the home directory (~) with many of our file opening functions. Added `pygama.lgdo.lgdo_utils.expand_path`, which uses glob and os.path to do its work. It also has an option for whether to ask for a single path or a list of paths; if it is a single path, it will raise an Error if there is not a single file that uniquely matches the wildcards. If it is a list of paths no Error will be raised. Reading of lh5 files (`'r'` mode only), dsp_config files, database json files, and LH5Iterators all use this now (and by extension other utilities that evoke these such as the waveform browser)
4) Fixed auto limit calculation failing with NaNs

Before submitting a pull request, please make sure you've read and understood the pygama developer's guide: https://pygama.readthedocs.io/en/latest/developer.html. In particular, do not forget to:

- [x] Conform to our **coding conventions**
- [x] Update existing or add new **tests**
- [x] Update existing or add new **documentation**
- [x] Address any issue reported by GitHub checks
