### PR TITLE
Add function to run both the numba and pure python versions of some function

### DIFF
--- a/docs/source/developer.rst
+++ b/docs/source/developer.rst
@@ -5,11 +5,15 @@ The following rules and conventions have been established for the package
 development and are enforced throughout the entire code base. Merge requests
 that do not comply to the following directives will be rejected.
 
-To start developing :mod:`pygama`, clone the remote repository:
+To start developing :mod:`pygama`, fork the remote repository to your personal
+GitHub account (see `About Forks <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/about-forks>`_).
+If you have not set up your ssh keys on the computer you will be working on,
+please follow `GitHub's instructions <https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent>`_. Once you have your own fork, you can clone it via
+(replace "yourusername" with your GitHub username):
 
 .. code-block:: console
 
-  $ git clone https://github.com/legend-exp/pygama
+  $ git clone git@github.com:yourusername/pygama.git
 
 All extra tools needed to develop :mod:`pygama` are listed as optional
 dependencies and can be installed via pip by running:
@@ -120,6 +124,74 @@ Testing
   .. code-block:: console
 
     $ pytest --cov=pygama
+
+Testing Numba-Wrapped Functions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When using Numba to vectorize Python functions, the Python version of the function
+does not, by default, get directly tested, but the Numba version instead. In
+this case, we need to unwrap the Numba function and test the pure Python version.
+With various processors in :mod:`pygama.dsp.processors`, this means that testing
+and triggering the code coverage requires this unwrapping.
+
+Within the testing suite, we use the :func:`@pytest.fixture()<pytest.fixture>`
+decorator to include a helper function called ``compare_numba_vs_python`` that
+can be used in any test. This function runs both the Numba and pure Python versions
+of a function, asserts that they are equal up to floating precision, and returns the
+output value.
+
+As an example, we show a snippet from the test for
+:func:`pygama.dsp.processors.fixed_time_pickoff`, a processor which uses the
+:func:`@numba.guvectorize()<numba.guvectorize>` decorator.
+
+.. code-block:: python
+
+    def test_fixed_time_pickoff(compare_numba_vs_python):
+        """Testing function for the fixed_time_pickoff processor."""
+
+        len_wf = 20
+
+        # test for nan if w_in has a nan
+        w_in = np.ones(len_wf)
+        w_in[4] = np.nan
+        assert np.isnan(compare_numba_vs_python(fixed_time_pickoff, w_in, 1, ord("i")))
+
+In the assertion that the output is what we expect, we use 
+``compare_numba_vs_python(fixed_time_pickoff, w_in, 1, ord("i"))`` in place of
+``fixed_time_pickoff(w_in, 1, ord("i"))``. In general, the replacement to make is
+``func(*inputs)`` becomes ``compare_numba_vs_python(func, *inputs)``.
+
+Note, that in cases of testing for the raising of errors, it is recommended
+to instead run the function twice: once with the Numba version, and once using the
+:func:`inspect.unwrap` function. We again show a snippet from the test for
+:func:`pygama.dsp.processors.fixed_time_pickoff` below. We include the various
+required imports in the snippet for verbosity.
+
+.. code-block:: python
+
+    import inspect
+
+    import numpy as np
+    import pytest
+
+    from pygama.dsp.errors import DSPFatal
+    from pygama.dsp.processors import fixed_time_pickoff
+
+    def test_fixed_time_pickoff(compare_numba_vs_python):
+    "skipping parts of function..."
+    # test for DSPFatal errors being raised
+    # noninteger t_in with integer interpolation
+    with pytest.raises(DSPFatal):
+        w_in = np.ones(len_wf)
+        fixed_time_pickoff(w_in, 1.5, ord("i"))
+
+    with pytest.raises(DSPFatal):
+        a_out = np.empty(len_wf)
+        inspect.unwrap(fixed_time_pickoff)(w_in, 1.5, ord("i"), a_out)
+
+In this case, the general idea is to use :func:`pytest.raises` twice, once with
+``func(*inputs)``, and again with ``inspect.unwrap(func)(*inputs)``.
+
 
 Documentation
 -------------

--- a/docs/source/developer.rst
+++ b/docs/source/developer.rst
@@ -156,7 +156,7 @@ As an example, we show a snippet from the test for
         w_in[4] = np.nan
         assert np.isnan(compare_numba_vs_python(fixed_time_pickoff, w_in, 1, ord("i")))
 
-In the assertion that the output is what we expect, we use 
+In the assertion that the output is what we expect, we use
 ``compare_numba_vs_python(fixed_time_pickoff, w_in, 1, ord("i"))`` in place of
 ``fixed_time_pickoff(w_in, 1, ord("i"))``. In general, the replacement to make is
 ``func(*inputs)`` becomes ``compare_numba_vs_python(func, *inputs)``.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,8 @@
 import os
 from pathlib import Path
+import re
+import inspect
+import numpy as np
 
 import pytest
 from legend_testdata import LegendTestData
@@ -77,3 +80,37 @@ def dsp_test_file_spm(multich_raw_file):
     assert os.path.exists(out_file)
 
     return out_file
+
+
+@pytest.fixture(scope="session")
+def compare_numba_vs_python():
+    def numba_vs_python(func, *inputs):
+        # get outputs
+        all_params = list(inspect.signature(func).parameters)
+        output_sizes = re.findall(r'(\(n*\))', func.signature.split('->')[-1])
+        noutputs = len(output_sizes)
+        output_names = all_params[-noutputs:]
+
+        # numba outputs
+        outputs_numba = func(*inputs)
+        if noutputs==1:
+            outputs_numba = [outputs_numba]
+
+        # unwrapped python outputs
+        func_unwrapped = inspect.unwrap(func)
+        output_dict = {
+            key: np.empty(len(inputs[0])) for key in output_names
+        }
+        func_unwrapped(*inputs, **output_dict)
+        for spec, key in zip(output_sizes, output_dict):
+            if spec == '()':
+                output_dict[key] = output_dict[key][0]
+        outputs_python = [output_dict[key] for key in output_names]
+
+        # assert that numba and purepython should be the same (maybe use np.isclose)
+        assert np.allclose(outputs_numba, outputs_python, equal_nan=True)
+
+        # return value for comparison with expected solution
+        return outputs_numba[0] if noutputs == 1 else outputs_numba
+
+    return numba_vs_python

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,7 +85,25 @@ def dsp_test_file_spm(multich_raw_file):
 @pytest.fixture(scope="session")
 def compare_numba_vs_python():
     def numba_vs_python(func, *inputs):
-        # get outputs
+        """
+        Function for testing that the numba and python versions of a
+        function are equal.
+
+        Parameters
+        ----------
+        func
+            The Numba-wrapped function to be tested
+        *inputs
+            The various inputs to be passed to the function to be
+            tested.
+
+        Returns
+        -------
+        func_output
+            The output of the function to be used in a unit test.
+
+        """
+        # parse outputs from function signature
         all_params = list(inspect.signature(func).parameters)
         output_sizes = re.findall(r"(\(n*\))", func.signature.split("->")[-1])
         noutputs = len(output_sizes)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -107,7 +107,8 @@ def compare_numba_vs_python():
                 output_dict[key] = output_dict[key][0]
         outputs_python = [output_dict[key] for key in output_names]
 
-        # assert that numba and purepython should be the same (maybe use np.isclose)
+        # assert that numba and python are the same up to floating point
+        # precision, setting nans to be equal
         assert np.allclose(outputs_numba, outputs_python, equal_nan=True)
 
         # return value for comparison with expected solution

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,9 @@
-import os
-from pathlib import Path
-import re
 import inspect
-import numpy as np
+import os
+import re
+from pathlib import Path
 
+import numpy as np
 import pytest
 from legend_testdata import LegendTestData
 
@@ -87,23 +87,21 @@ def compare_numba_vs_python():
     def numba_vs_python(func, *inputs):
         # get outputs
         all_params = list(inspect.signature(func).parameters)
-        output_sizes = re.findall(r'(\(n*\))', func.signature.split('->')[-1])
+        output_sizes = re.findall(r"(\(n*\))", func.signature.split("->")[-1])
         noutputs = len(output_sizes)
         output_names = all_params[-noutputs:]
 
         # numba outputs
         outputs_numba = func(*inputs)
-        if noutputs==1:
+        if noutputs == 1:
             outputs_numba = [outputs_numba]
 
         # unwrapped python outputs
         func_unwrapped = inspect.unwrap(func)
-        output_dict = {
-            key: np.empty(len(inputs[0])) for key in output_names
-        }
+        output_dict = {key: np.empty(len(inputs[0])) for key in output_names}
         func_unwrapped(*inputs, **output_dict)
         for spec, key in zip(output_sizes, output_dict):
-            if spec == '()':
+            if spec == "()":
                 output_dict[key] = output_dict[key][0]
         outputs_python = [output_dict[key] for key in output_names]
 

--- a/tests/dsp/processors/test_fixed_time_pickoff.py
+++ b/tests/dsp/processors/test_fixed_time_pickoff.py
@@ -1,11 +1,12 @@
 import numpy as np
 import pytest
+import inspect
 
 from pygama.dsp.errors import DSPFatal
 from pygama.dsp.processors import fixed_time_pickoff
 
 
-def test_fixed_time_pickoff():
+def test_fixed_time_pickoff(compare_numba_vs_python):
     """Testing function for the fixed_time_pickoff processor."""
 
     len_wf = 20
@@ -13,72 +14,46 @@ def test_fixed_time_pickoff():
     # test for nan if w_in has a nan
     w_in = np.ones(len_wf)
     w_in[4] = np.nan
-    assert np.isnan(fixed_time_pickoff(w_in, 1, ord("i")))
-
-    a_out = np.empty(len_wf)
-    fixed_time_pickoff.__wrapped__(w_in, 1, ord("i"), a_out)
-    assert np.isnan(a_out[0])
+    assert np.isnan(compare_numba_vs_python(fixed_time_pickoff, w_in, 1, ord("i")))
 
     # test for nan if nan is passed to t_in
     w_in = np.ones(len_wf)
-    assert np.isnan(fixed_time_pickoff(w_in, np.nan, ord("i")))
-
-    a_out = np.empty(len_wf)
-    fixed_time_pickoff.__wrapped__(w_in, np.nan, ord("i"), a_out)
-    assert np.isnan(a_out[0])
+    assert np.isnan(compare_numba_vs_python(fixed_time_pickoff, w_in, np.nan, ord("i")))
 
     # test for nan if t_in is negative
     w_in = np.ones(len_wf)
-    assert np.isnan(fixed_time_pickoff(w_in, -1, ord("i")))
-
-    a_out = np.empty(len_wf)
-    fixed_time_pickoff.__wrapped__(w_in, -1, ord("i"), a_out)
-    assert np.isnan(a_out[0])
+    assert np.isnan(compare_numba_vs_python(fixed_time_pickoff, w_in, -1, ord("i")))
 
     # test for nan if t_in is too large
     w_in = np.ones(len_wf)
-    assert np.isnan(fixed_time_pickoff(w_in, len_wf, ord("i")))
-
-    a_out = np.empty(len_wf)
-    fixed_time_pickoff.__wrapped__(w_in, len_wf, ord("i"), a_out)
-    assert np.isnan(a_out[0])
+    assert np.isnan(compare_numba_vs_python(fixed_time_pickoff, w_in, len_wf, ord("i")))
 
     # test for DSPFatal errors being raised
     # noninteger t_in with integer interpolation
     with pytest.raises(DSPFatal):
         w_in = np.ones(len_wf)
         fixed_time_pickoff(w_in, 1.5, ord("i"))
-
     with pytest.raises(DSPFatal):
         a_out = np.empty(len_wf)
-        fixed_time_pickoff.__wrapped__(w_in, 1.5, ord("i"), a_out)
+        inspect.unwrap(fixed_time_pickoff)(w_in, 1.5, ord("i"), a_out)
 
     # unsupported mode_in character
     with pytest.raises(DSPFatal):
         w_in = np.ones(len_wf)
         fixed_time_pickoff(w_in, 1.5, ord(" "))
-
     with pytest.raises(DSPFatal):
         a_out = np.empty(len_wf)
-        fixed_time_pickoff.__wrapped__(w_in, 1.5, ord(" "), a_out)
+        inspect.unwrap(fixed_time_pickoff)(w_in, 1.5, ord(" "), a_out)
 
     # linear tests
     w_in = np.arange(len_wf, dtype=float)
-    assert fixed_time_pickoff(w_in, 3, ord("i")) == 3
-
-    a_out = np.empty(len_wf)
-    fixed_time_pickoff.__wrapped__(w_in, 3, ord("i"), a_out)
-    assert a_out[0] == 3
+    assert compare_numba_vs_python(fixed_time_pickoff, w_in, 3, ord("i")) == 3
 
     chars = ["n", "f", "c", "l", "h", "s"]
     sols = [4, 3, 4, 3.5, 3.5, 3.5]
 
     for char, sol in zip(chars, sols):
-        assert fixed_time_pickoff(w_in, 3.5, ord(char)) == sol
-
-        a_out = np.empty(len_wf)
-        fixed_time_pickoff.__wrapped__(w_in, 3.5, ord(char), a_out)
-        assert a_out[0] == sol
+        assert compare_numba_vs_python(fixed_time_pickoff, w_in, 3.5, ord(char)) == sol
 
     # sine wave tests
     w_in = np.sin(np.arange(len_wf))
@@ -94,11 +69,7 @@ def test_fixed_time_pickoff():
     ]
 
     for char, sol in zip(chars, sols):
-        assert np.isclose(fixed_time_pickoff(w_in, 3.25, ord(char)), sol)
-
-        a_out = np.empty(len_wf)
-        fixed_time_pickoff.__wrapped__(w_in, 3.25, ord(char), a_out)
-        assert np.isclose(a_out[0], sol)
+        assert np.isclose(compare_numba_vs_python(fixed_time_pickoff, w_in, 3.25, ord(char)), sol)
 
     # last few corner cases of 'h'
     w_in = np.sin(np.arange(len_wf))
@@ -109,8 +80,4 @@ def test_fixed_time_pickoff():
     ]
 
     for ftp, sol in zip(ftps, sols):
-        assert np.isclose(fixed_time_pickoff(w_in, ftp, ord("h")), sol)
-
-        a_out = np.empty(len_wf)
-        fixed_time_pickoff.__wrapped__(w_in, ftp, ord("h"), a_out)
-        assert np.isclose(a_out[0], sol)
+        assert np.isclose(compare_numba_vs_python(fixed_time_pickoff, w_in, ftp, ord("h")), sol)

--- a/tests/dsp/processors/test_fixed_time_pickoff.py
+++ b/tests/dsp/processors/test_fixed_time_pickoff.py
@@ -1,6 +1,7 @@
+import inspect
+
 import numpy as np
 import pytest
-import inspect
 
 from pygama.dsp.errors import DSPFatal
 from pygama.dsp.processors import fixed_time_pickoff
@@ -69,7 +70,9 @@ def test_fixed_time_pickoff(compare_numba_vs_python):
     ]
 
     for char, sol in zip(chars, sols):
-        assert np.isclose(compare_numba_vs_python(fixed_time_pickoff, w_in, 3.25, ord(char)), sol)
+        assert np.isclose(
+            compare_numba_vs_python(fixed_time_pickoff, w_in, 3.25, ord(char)), sol
+        )
 
     # last few corner cases of 'h'
     w_in = np.sin(np.arange(len_wf))
@@ -80,4 +83,6 @@ def test_fixed_time_pickoff(compare_numba_vs_python):
     ]
 
     for ftp, sol in zip(ftps, sols):
-        assert np.isclose(compare_numba_vs_python(fixed_time_pickoff, w_in, ftp, ord("h")), sol)
+        assert np.isclose(
+            compare_numba_vs_python(fixed_time_pickoff, w_in, ftp, ord("h")), sol
+        )


### PR DESCRIPTION
As discussed in #241 and proposed in https://github.com/legend-exp/pygama/issues/241#issuecomment-1289774168, we can write a function that takes a numba-wrapped function, and automatically runs both the numba version and the unwrapped pure python version. For testing these numba-wrapped functions, it is necessary to run the pure python version to trigger the code coverage.

I've added a fixture to `tests/conftest.py`, which returns such a function for some generic wrapped function in, e.g., `dsp`. I've also updated the `fixed_pickoff_time` test to use this function as an example, which cleans up the test substantially.

I'll keep this as a draft for now, as I'm curious if there's a better place to store this function or if there are any thoughts on how I'm using it. I also want to point out that it doesn't work well with `pytest.raises`, so I'm just using `inspect.unwrap` for checking if the errors are being raised for both cases.

----

Before submitting a pull request, please make sure you've read and understood the pygama developer's guide: https://pygama.readthedocs.io/en/latest/developer.html. In particular, do not forget to:

- [x] Conform to our **coding conventions**
- [x] Update existing or add new **tests**
- [x] Update existing or add new **documentation**
- [x] Address any issue reported by GitHub checks
