### PR TITLE
Added windowing processor that takes t0 and tf as parameters for data trimming

### DIFF
--- a/src/pygama/dsp/processors/__init__.py
+++ b/src/pygama/dsp/processors/__init__.py
@@ -61,6 +61,7 @@ several advantages:
 
 from .bl_subtract import bl_subtract
 from .convolutions import cusp_filter, t0_filter, zac_filter
+from .double_windower import double_windower
 from .dwt import discrete_wavelet_transform
 from .fftw import dft, inv_dft, psd
 from .fixed_time_pickoff import fixed_time_pickoff
@@ -98,6 +99,7 @@ __all__ = [
     "cusp_filter",
     "t0_filter",
     "zac_filter",
+    "double_windower",
     "discrete_wavelet_transform",
     "dft",
     "inv_dft",

--- a/src/pygama/dsp/processors/double_windower.py
+++ b/src/pygama/dsp/processors/double_windower.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import numpy as np
+from numba import guvectorize
+
+from pygama.dsp.errors import DSPFatal
+
+
+@guvectorize(
+    [
+        "void(float32[:], float32, float32, float32[:])",
+        "void(float64[:], float64, float64, float64[:])",
+    ],
+    "(n),(), (), (m)",
+    nopython=True,
+    cache=True,
+)
+def double_windower(
+    w_in: np.ndarray, t0_in: int, tf_in: int, w_out: np.ndarray
+) -> None:
+    """
+    Return a shorter sample of the waveform, starting and stopping at the
+    specified indices.  Note that the length of the output waveform
+    is determined by the length of "w_out" rather than an input
+    parameter. If the length of "w_out" plus "t0_in" plus "tf_in" is
+    different from the length of "w_in", a DSPFatal is raised.
+
+
+    Parameters
+    ----------
+    w_in
+        The input waveform
+    t0_in
+        The starting index of the window
+    tf_in
+        The index to stop the windowing, measured from the end of the w_in
+    w_out
+        The windowed waveform
+
+    Notes
+    -----
+    For normal dsp routines, it is better to use windower twice; this way, the output array is padded with numpy nans
+    Use this if you don't want an output array that contains nan values, such as in circumstances where memory usage is critical.
+    """
+    w_out[:] = np.nan
+
+    if np.isnan(w_in).any() or np.isnan(t0_in) or np.isnan(tf_in):
+        return
+
+    if len(w_out) >= len(w_in):
+        raise DSPFatal("The windowed waveform must be smaller than the input waveform")
+
+    if len(w_out) + t0_in + tf_in != len(w_in):
+        raise DSPFatal(
+            "The windowed waveform length must be equal the input waveform length minus t0_in minus tf_in"
+        )
+
+    if t0_in < 0 or t0_in > len(w_in):
+        raise DSPFatal("The start of the window must be inside the waveform")
+    if tf_in < 0 or tf_in > len(w_in):
+        raise DSPFatal(
+            "The end of the window must be inside the waveform, and tf_in must be positive"
+        )
+    if t0_in > len(w_in) - tf_in:
+        raise DSPFatal("t0_in must occur before tf_in")
+
+    w_out[:] = w_in[int(t0_in) : -1 * int(tf_in)]


### PR DESCRIPTION
If we choose to adopt a `build_dsp` approach to trimming raw waveforms, then we cannot use the current `windower.py` processor because that pads the array with numpy nans when a negative t0 index is used. This is a quick fix and is only intended for use in `data_trimmer.py`, which will live the legend-dataflow repo until the functionality is incorporated into pygama.

Before submitting a pull request, please make sure you've read and understood the pygama developer's guide: https://pygama.readthedocs.io/en/latest/developer.html. In particular, do not forget to:

- [ ] Conform to our **coding conventions**
- [ ] Update existing or add new **tests**
- [ ] Update existing or add new **documentation**
- [ ] Address any issue reported by GitHub checks
