### PR TITLE
Fix for seaborn deprecation in matplotlib

### DIFF
--- a/tests/vis/test_waveform_browser.py
+++ b/tests/vis/test_waveform_browser.py
@@ -12,7 +12,7 @@ def test_basics(lgnd_test_data):
         dsp_config=f"{config_dir}/hpge-dsp-config.json",
         lines=["wf_blsub", "wf_trap", "trapEmax"],
         legend=["waveform", "trapezoidal", "energy = {trapEmax:0.1f}"],
-        # styles="seaborn",
+        styles="seaborn-v0.8",
         n_drawn=2,
         x_lim=("20*us", "60*us"),
         x_unit="us",


### PR DESCRIPTION
A fix for the seaborn deprecation in https://github.com/legend-exp/pygama/issues/410. I am unable to test this myself due to some weird python environment stuff, so I'm relying on the git tests here.

Before submitting a pull request, please make sure you've read and understood the pygama developer's guide: https://pygama.readthedocs.io/en/latest/developer.html. In particular, do not forget to:

- [ ] Conform to our **coding conventions**
- [ ] Update existing or add new **tests**
- [ ] Update existing or add new **documentation**
- [ ] Address any issue reported by GitHub checks
