### PR TITLE
Fixed issue with cusp and zac filters, changed plots to output as a dict and cleaned them up 

### DIFF
--- a/src/pygama/dsp/processors/convolutions.py
+++ b/src/pygama/dsp/processors/convolutions.py
@@ -45,11 +45,17 @@ def cusp_filter(length: int, sigma: float, flat: int, decay: int) -> Callable:
     if length <= 0:
         raise DSPFatal("The length of the filter must be positive")
 
+    if np.floor(length) != length:
+        raise DSPFatal("The length of the filter must be an integer")
+
     if sigma < 0:
         raise DSPFatal("The curvature parameter must be positive")
 
     if flat < 0:
         raise DSPFatal("The length of the flat section must be positive")
+
+    if np.floor(flat) != flat:
+        raise DSPFatal("The length of the flat section must be an integer")
 
     if decay < 0:
         raise DSPFatal("The decay constant must be positive")
@@ -133,11 +139,17 @@ def zac_filter(length: int, sigma: float, flat: int, decay: int) -> Callable:
     if length <= 0:
         raise DSPFatal("The length of the filter must be positive")
 
+    if np.floor(length) != length:
+        raise DSPFatal("The length of the filter must be an integer")
+
     if sigma < 0:
         raise DSPFatal("The curvature parameter must be positive")
 
     if flat < 0:
         raise DSPFatal("The length of the flat section must be positive")
+
+    if np.floor(flat) != flat:
+        raise DSPFatal("The length of the flat section must be an integer")
 
     if decay < 0:
         raise DSPFatal("The decay constant must be positive")

--- a/src/pygama/pargen/AoE_cal.py
+++ b/src/pygama/pargen/AoE_cal.py
@@ -10,6 +10,7 @@ import os
 import pathlib
 
 import matplotlib as mpl
+mpl.use('agg')
 import matplotlib.cm as cmx
 import matplotlib.colors as mcolors
 import matplotlib.pyplot as plt
@@ -359,7 +360,7 @@ def AoEcorrection(
     )
 
     if display > 0:
-        mean_fig, (ax1, ax2) = plt.subplots(2, 1, constrained_layout=True, sharex=True)
+        mean_fig, (ax1, ax2) = plt.subplots(2, 1,sharex=True)
         ax1.errorbar(
             comptBands[~ids] + 10,
             compt_aoe[~ids],
@@ -393,6 +394,7 @@ def AoEcorrection(
         )
         ax2.set_ylabel("Residuals %", ha="right", y=1)
         ax2.set_xlabel("Energy (keV)", ha="right", x=1)
+        plt.tight_layout()
         plot_dict["mean_fit"] = mean_fig
         if display > 1:
             plt.show()
@@ -400,7 +402,7 @@ def AoEcorrection(
             plt.close()
 
     if display > 0:
-        sig_fig, (ax1, ax2) = plt.subplots(2, 1, constrained_layout=True, sharex=True)
+        sig_fig, (ax1, ax2) = plt.subplots(2, 1, sharex=True)
         ax1.errorbar(
             comptBands[~ids] + 10,
             aoe_sigmas[~ids],
@@ -438,6 +440,7 @@ def AoEcorrection(
         )
         ax2.set_ylabel("Residuals", ha="right", y=1)
         ax2.set_xlabel("Energy (keV)", ha="right", x=1)
+        plt.tight_layout()
         plot_dict["sigma_fit"] = sig_fig
         if display > 1:
             plt.show()

--- a/src/pygama/pargen/AoE_cal.py
+++ b/src/pygama/pargen/AoE_cal.py
@@ -29,7 +29,7 @@ log = logging.getLogger(__name__)
 
 
 def load_aoe(
-    files: list, lh5_path: str, cal_dict: dict, energy_param: str, cal_energy_param: str
+    files: list, lh5_path: str, cal_dict: dict, energy_param: str, cal_energy_param: str, cut_field:str="Cal_cuts"
 ) -> tuple(np.array, np.array, np.array, np.array):
 
     """
@@ -1184,6 +1184,7 @@ def cal_aoe(
     energy_param: str,
     cal_energy_param: str,
     eres_pars: list,
+    cut_field:str = "Cal_cuts",
     dt_corr: bool = False,
     display: int = 0,
 ) -> tuple(dict, dict):
@@ -1192,7 +1193,7 @@ def cal_aoe(
     """
 
     aoe_uncorr, energy, dt, full_dt = load_aoe(
-        files, lh5_path, cal_dict, energy_param, cal_energy_param
+        files, lh5_path, cal_dict, energy_param, cal_energy_param, cut_field=cut_field
     )
 
     if dt_corr == True:

--- a/src/pygama/pargen/AoE_cal.py
+++ b/src/pygama/pargen/AoE_cal.py
@@ -50,9 +50,9 @@ def load_aoe(
             param_dict[param] = df[param].to_numpy()
         else:
             param_dict.update(lh5.load_nda(files, [param], lh5_path))
-    if "Quality_cuts" in df.keys():
+    if "Cal_cuts" in df.keys():
         for entry in param_dict:
-            param_dict[entry] = param_dict[entry][df["Quality_cuts"].to_numpy()]
+            param_dict[entry] = param_dict[entry][df["Cal_cuts"].to_numpy()]
 
     aoe = np.divide(param_dict["A_max"], param_dict[energy_param])
     full_dt = param_dict["tp_99"] - param_dict["tp_0_est"]

--- a/src/pygama/pargen/cuts.py
+++ b/src/pygama/pargen/cuts.py
@@ -181,7 +181,7 @@ def cut_dict_to_hit_dict(cut_dict):
     for par in list(cut_dict)[:-1]:
         quality_cut_exp += f"({par}_cut)&"
     quality_cut_exp += f"({list(cut_dict)[-1]}_cut)"
-    out_dict["Quality_cuts"] = {"expression": quality_cut_exp, "parameters": {}}
+    out_dict["Cal_cuts"] = {"expression": quality_cut_exp, "parameters": {}}
     return out_dict
 
 

--- a/src/pygama/pargen/cuts.py
+++ b/src/pygama/pargen/cuts.py
@@ -166,7 +166,7 @@ def get_cut_indexes(
     return indexes
 
 
-def cut_dict_to_hit_dict(cut_dict):
+def cut_dict_to_hit_dict(cut_dict, final_cut_field="is_valid_cal"):
     out_dict = {}
     for param in cut_dict:
 
@@ -181,7 +181,7 @@ def cut_dict_to_hit_dict(cut_dict):
     for par in list(cut_dict)[:-1]:
         quality_cut_exp += f"({par}_cut)&"
     quality_cut_exp += f"({list(cut_dict)[-1]}_cut)"
-    out_dict["Cal_cuts"] = {"expression": quality_cut_exp, "parameters": {}}
+    out_dict[final_cut_field] = {"expression": quality_cut_exp, "parameters": {}}
     return out_dict
 
 

--- a/src/pygama/pargen/ecal_th.py
+++ b/src/pygama/pargen/ecal_th.py
@@ -386,8 +386,6 @@ def energy_cal_th(
                 plt.show()
             else:
                 plt.close()
-
-                selection = (hit_data["cuspEmax_ctc_cal"]>2610) &(hit_data["cuspEmax_ctc_cal"]<2620)
     
             time_slice = 500
             utime_array = uncal_pass["timestamp"][selection]

--- a/src/pygama/pargen/ecal_th.py
+++ b/src/pygama/pargen/ecal_th.py
@@ -42,14 +42,34 @@ def load_data(
     energy_params: list[str],
     hit_dict: dict = {},
     cut_parameters: list[str] = ["bl_mean", "bl_std", "pz_std"],
+    display=0
 ) -> dict[str, np.ndarray]:
 
     df = lh5.load_dfs(files, ["timestamp", "trapTmax"], lh5_path)
     pulser_props = cts.find_pulser_properties(df, energy="trapTmax")
+    if display>0:
+        plot_dict = {}
     if len(pulser_props) > 0:
         out_df = cts.tag_pulsers(df, pulser_props, window=0.001)
         ids = ~(out_df.isPulser == 1)
         log.debug(f"pulser found: {pulser_props}")
+
+        plt.rcParams["figure.figsize"] = (12, 8)
+        plt.rcParams["font.size"] = 10
+
+        fig = plt.figure()
+        plt.hist(df["trapTmax"], bins=10000, histtype="step", label="With Pulser")
+        plt.hist(df["trapTmax"][ids], bins=10000, histtype="step", label="Pulser Removed")
+        plt.xlim([0, np.nanpercentile(df["trapTmax"], 99)])
+        plt.xlabel("Energy (ADC)")
+        plt.ylabel("Counts")
+        plt.legend(loc="upper right")
+        plot_dict["pulser"] = fig
+        if display>1:
+            plt.show()
+        else:
+            plt.close()
+
     else:
         ids = np.ones(len(df), dtype=bool)
         log.debug(f"no pulser found")
@@ -82,20 +102,22 @@ def load_data(
                 else:
                     dat = lh5.load_nda(files, [param], lh5_path)[param]
                     energy_dict.update({param: dat[ids]})
-    return energy_dict
+    if display>0:
+        return energy_dict, plot_dict
+    else:
+        return energy_dict
 
 
 def energy_cal_th(
     files: list[str],
     energy_params: list[str],
     hit_dict: dict = {},
-    save_path: str = None,
-    plot_path: str = None,
     cut_parameters: dict[str, int] = {"bl_mean": 4, "bl_std": 4, "pz_std": 4},
     lh5_path: str = "dsp",
+    display: int = 0,
     guess_keV: float = None,
     threshold: int = 0,
-    p_val: float = 0.05,
+    p_val: float = 0,
     n_events: int = 15000,
     deg: int = 1,
 ) -> tuple(dict, dict):
@@ -113,13 +135,23 @@ def energy_cal_th(
 
     log.debug(f"{len(files)} files found")
     log.debug("Loading and applying charge trapping corr...")
-    uncal_pass = load_data(
-        files,
-        lh5_path,
-        energy_params,
-        hit_dict,
-        cut_parameters=list(cut_parameters) if cut_parameters is not None else None,
-    )
+    if display>0:
+        uncal_pass,plot_dict = load_data(
+            files,
+            lh5_path,
+            energy_params,
+            hit_dict,
+            cut_parameters=list(cut_parameters) if cut_parameters is not None else None,
+            display=display
+        )
+    else:
+        uncal_pass,plot_dict = load_data(
+            files,
+            lh5_path,
+            energy_params,
+            hit_dict,
+            cut_parameters=list(cut_parameters) if cut_parameters is not None else None,
+        )
 
     total_events = len(uncal_pass[energy_params[0]])
     log.debug("Done")
@@ -258,12 +290,7 @@ def energy_cal_th(
         ecal_pass = pgf.poly(uncal_pass[energy_param], pars)
         if cut_parameters is not None:
             ecal_fail = pgf.poly(uncal_fail[energy_param], pars)
-        xpb = 1
-        xlo = 0
-        xhi = 4000
-        nb = int((xhi - xlo) / xpb)
-        hist_pass, bin_edges = np.histogram(ecal_pass, range=(xlo, xhi), bins=nb)
-        bins_pass = pgh.get_bin_centers(bin_edges)
+ 
         fitted_peaks = results["fitted_keV"]
         pk_pars = results["pk_pars"]
         pk_covs = results["pk_covs"]
@@ -283,8 +310,10 @@ def energy_cal_th(
         #####
         # Remove the Tl SEP and DEP from calibration if found
         fwhm_peaks = np.array([], dtype=np.float32)
+        all_peaks = np.array([], dtype=np.float32)
         indexes = []
         for i, peak in enumerate(fitted_peaks):
+            all_peaks = np.append(all_peaks, peak)
             if peak == 2103.53:
                 log.info(f"Tl SEP found at index {i}")
                 indexes.append(i)
@@ -332,154 +361,202 @@ def energy_cal_th(
         fit_qbb = fwhm_slope(2039.0, *fit_pars)
         log.info(f"FWHM energy resolution at Qbb: {fit_qbb:1.2f} +- {qbb_err:1.2f} keV")
 
-        if plot_path is not None:
-
-            mpl.use("pdf")
+        if display > 0 :
+            plot_dict_param = {}
             plt.rcParams["figure.figsize"] = (12, 20)
-            plt.rcParams["font.size"] = 12
+            plt.rcParams["font.size"] = 10
 
-            pathlib.Path(os.path.dirname(plot_path)).mkdir(parents=True, exist_ok=True)
+            fig1 = plt.figure()
+            range_adu = 5 / pars[0]  # 10keV window around peak in adu
+            for i, peak in enumerate(mus):
+                plt.subplot(math.ceil((len(mus)) / 2), 2, i + 1)
+                binning = np.arange(pk_ranges[i][0], pk_ranges[i][1], 1)
+                bin_cs = (binning[1:] + binning[:-1]) / 2
+                energies = uncal_pass[energy_param][
+                    (uncal_pass[energy_param] > pk_ranges[i][0])
+                    & (uncal_pass[energy_param] < pk_ranges[i][1])
+                ][:n_events]
 
-            with PdfPages(plot_path) as pdf:
-
-                plt.figure()
-                range_adu = 5 / pars[0]  # 10keV window around peak in adu
-                for i, peak in enumerate(mus):
-                    plt.subplot(math.ceil((len(mus)) / 2), 2, i + 1)
-                    binning = np.arange(pk_ranges[i][0], pk_ranges[i][1], 1)
-                    bin_cs = (binning[1:] + binning[:-1]) / 2
-                    energies = uncal_pass[energy_param][
-                        (uncal_pass[energy_param] > pk_ranges[i][0])
-                        & (uncal_pass[energy_param] < pk_ranges[i][1])
-                    ][:n_events]
-
-                    counts, bs, bars = plt.hist(energies, bins=binning, histtype="step")
-                    fit_vals = fitted_gof_funcs[i](bin_cs, *pk_pars[i]) * np.diff(bs)
-                    plt.plot(bin_cs, fit_vals)
-                    plt.step(
-                        bin_cs,
-                        [
-                            (fval - count) / count if count != 0 else (fval - count)
-                            for count, fval in zip(counts, fit_vals)
-                        ],
-                    )
-                    plt.plot(
-                        [bin_cs[10]],
-                        [0],
-                        label=get_peak_label(fitted_peaks[i]),
-                        linestyle="None",
-                    )
-                    plt.plot(
-                        [bin_cs[10]],
-                        [0],
-                        label=f"{fitted_peaks[i]:.1f} keV",
-                        linestyle="None",
-                    )
-                    plt.plot(
-                        [bin_cs[10]],
-                        [0],
-                        label=f"{fwhms[i]:.2f} +- {dfwhms[i]:.2f} keV",
-                        linestyle="None",
-                    )
-                    plt.plot(
-                        [bin_cs[10]],
-                        [0],
-                        label=f"p-value : {p_vals[i]:.2f}",
-                        linestyle="None",
-                    )
-
-                    plt.xlabel("Energy (keV)")
-                    plt.ylabel("Counts")
-                    plt.legend(loc="upper left", frameon=False)
-                    plt.xlim([peak - range_adu, peak + range_adu])
-                    locs, labels = plt.xticks()
-                    new_locs, new_labels = get_peak_labels(locs, pars)
-                    plt.xticks(ticks=new_locs, labels=new_labels)
-
-                plt.tight_layout()
-                pdf.savefig()
-                plt.close()
-
-                plt.rcParams["figure.figsize"] = (12, 8)
-                plt.rcParams["font.size"] = 8
-
-                qbb_line_hx = [2039.0, 2039.0]
-                qbb_line_hy = [np.amin(fit_fwhms), fit_qbb]
-                qbb_line_vx = [np.amin(fwhm_peaks), 2039.0]
-                qbb_line_vy = [fit_qbb, fit_qbb]
-
-                fig, (ax1, ax2) = plt.subplots(
-                    2, 1, constrained_layout=True, sharex=True
+                counts, bs, bars = plt.hist(energies, bins=binning, histtype="step")
+                fit_vals = fitted_gof_funcs[i](bin_cs, *pk_pars[i]) * np.diff(bs)
+                plt.plot(bin_cs, fit_vals)
+                plt.step(
+                    bin_cs,
+                    [
+                        (fval - count) / count if count != 0 else (fval - count)
+                        for count, fval in zip(counts, fit_vals)
+                    ],
                 )
-                ax1.errorbar(
-                    fwhm_peaks, fit_fwhms, yerr=fit_dfwhms, marker="x", lw=0, c="b"
+                plt.plot(
+                    [bin_cs[10]],
+                    [0],
+                    label=get_peak_label(fitted_peaks[i]),
+                    linestyle="None",
                 )
-                ax1.plot(fwhm_peaks, predicted_fwhms, ls=" ")
-                fwhm_slope_bins = np.arange(
-                    np.amin(fwhm_peaks), np.amax(fwhm_peaks), 10
+                plt.plot(
+                    [bin_cs[10]],
+                    [0],
+                    label=f"{fitted_peaks[i]:.1f} keV",
+                    linestyle="None",
                 )
-                ax1.plot(
-                    fwhm_slope_bins, fwhm_slope(fwhm_slope_bins, *fit_pars), lw=1, c="g"
+                plt.plot(
+                    [bin_cs[10]],
+                    [0],
+                    label=f"{fwhms[i]:.2f} +- {dfwhms[i]:.2f} keV",
+                    linestyle="None",
                 )
-                ax1.plot(qbb_line_hx, qbb_line_hy, lw=1, c="r")
-                ax1.plot(qbb_line_vx, qbb_line_vy, lw=1, c="r")
-                ax1.plot(
-                    np.nan,
-                    np.nan,
-                    "-",
-                    color="none",
-                    label=f"Qbb fwhm: {fit_qbb:1.2f} +- {qbb_err:1.2f} keV",
+                plt.plot(
+                    [bin_cs[10]],
+                    [0],
+                    label=f"p-value : {p_vals[i]:.2f}",
+                    linestyle="None",
                 )
-                ax1.legend(loc="upper left", frameon=False)
-                ax1.set_ylim(
-                    [1, 1.1 * np.nanmax(fwhm_slope(fwhm_slope_bins, *fit_pars))]
-                )
-                ax1.set_ylabel("FWHM energy resolution (keV)", ha="right", y=1)
-                ax2.plot(fwhm_peaks, pgf.poly(fit_mus, pars) - fwhm_peaks, lw=1, c="b")
-                ax2.set_xlabel("Energy (keV)", ha="right", x=1)
-                ax2.set_ylabel("Residuals (keV)", ha="right", y=1)
-                pdf.savefig()
-                plt.close()
 
-                plt.figure()
-                bins = np.linspace(0, 3000, 6000)
-                plt.hist(
-                    ecal_pass,
-                    bins=bins,
-                    histtype="step",
-                    label=f"{len(ecal_pass)} events passed quality cuts",
-                )
-                if cut_parameters is not None:
-                    plt.hist(
-                        ecal_fail,
-                        bins=bins,
-                        histtype="step",
-                        label=f"{len(ecal_fail)} events failed quality cuts",
-                    )
-                plt.yscale("log")
                 plt.xlabel("Energy (keV)")
                 plt.ylabel("Counts")
-                plt.legend(loc="upper right")
-                pdf.savefig()
+                plt.legend(loc="upper left", frameon=False)
+                plt.xlim([peak - range_adu, peak + range_adu])
+                locs, labels = plt.xticks()
+                new_locs, new_labels = get_peak_labels(locs, pars)
+                plt.xticks(ticks=new_locs, labels=new_labels)
+
+            plt.tight_layout()
+            plot_dict_param["peak_fits"] = fig1
+            if display>1:
+                plt.show()
+            else:
                 plt.close()
 
-                if cut_parameters is not None:
-                    plt.figure()
-                    n_bins = 500
-                    counts_pass, bins_pass, _ = pgh.get_hist(
-                        ecal_pass, bins=n_bins, range=(0, 3000)
-                    )
-                    counts_fail, bins_fail, _ = pgh.get_hist(
-                        ecal_fail, bins=n_bins, range=(0, 3000)
-                    )
-                    sf = 100 * counts_pass / (counts_pass + counts_fail)
+            plt.rcParams["figure.figsize"] = (12, 8)
+            plt.rcParams["font.size"] = 10
 
-                    plt.step(pgh.get_bin_centers(bins_pass), sf)
-                    plt.xlabel("Energy (keV)")
-                    plt.ylabel("Survival Fraction (%)")
-                    plt.ylim([0, 100])
-                    pdf.savefig()
+            fig2, (ax1, ax2) = plt.subplots(
+                2, 1, sharex=True, gridspec_kw={'height_ratios': [3, 1]}
+            )
+
+            cal_bins = np.arange(
+                0, np.nanmax(mus)*1.1, 10
+            )
+
+            ax1.scatter(
+                all_peaks, mus, marker="x", c="b"
+            )
+
+
+            ax1.plot(
+                pgf.poly(cal_bins, pars), cal_bins, lw=1, c="g"
+            )
+
+            ax1.grid()
+            ax1.set_xlim([200,2700])
+            ax1.set_ylabel("Energy (ADC)")
+            ax2.plot(all_peaks, pgf.poly(np.array(mus), pars) - all_peaks, lw=0, marker="x", c="b")
+            ax2.grid()
+            ax2.set_xlabel("Energy (keV)")
+            ax2.set_ylabel("Residuals (keV)")
+            plot_dict_param["cal_fit"] = fig2
+            if display>1:
+                plt.show()
+            else:
+                plt.close()
+
+
+            fig3, (ax1, ax2) = plt.subplots(
+                2, 1, sharex=True, gridspec_kw={'height_ratios': [3, 1]}
+            )
+            ax1.errorbar(
+            fwhm_peaks, fit_fwhms, yerr=fit_dfwhms, marker="x", lw=0, c="b"
+            )
+
+
+            fwhm_slope_bins = np.arange(
+                200, 2700, 10
+            )
+
+            qbb_line_vx = [2039.0, 2039.0]
+            qbb_line_vy = [0.9 * np.nanmin(fwhm_slope(fwhm_slope_bins, *fit_pars)), fit_qbb]
+            qbb_line_hx = [200, 2039.0]
+            qbb_line_hy = [fit_qbb, fit_qbb]
+
+
+            ax1.plot(
+                fwhm_slope_bins, fwhm_slope(fwhm_slope_bins, *fit_pars), lw=1, c="g"
+            )
+            ax1.plot(qbb_line_hx, qbb_line_hy, lw=1, c="r")
+            ax1.plot(qbb_line_vx, qbb_line_vy, lw=1, c="r")
+            ax1.plot(
+                np.nan,
+                np.nan,
+                "-",
+                color="none",
+                label=f"Qbb fwhm: {fit_qbb:1.2f} +- {qbb_err:1.2f} keV",
+            )
+            ax1.legend(loc="upper left", frameon=False)
+            ax1.set_ylim(
+                [0.9 * np.nanmin(fwhm_slope(fwhm_slope_bins, *fit_pars)), 1.1 * np.nanmax(fwhm_slope(fwhm_slope_bins, *fit_pars))]
+            )
+            ax1.set_xlim([200,2700])
+            ax1.grid()
+            ax1.set_ylabel("FWHM energy resolution (keV)")
+            ax2.plot(fwhm_peaks, (fit_fwhms - fwhm_slope(fwhm_peaks, *fit_pars))/fit_dfwhms, lw=0, marker="x",c="b")
+            ax2.set_xlabel("Energy (keV)")
+            ax2.set_ylabel("Normalised Residuals")
+            ax2.grid()
+            plt.tight_layout()
+            plot_dict_param["fwhm_fit"] = fig3
+            if display>1:
+                plt.show()
+            else:
+                plt.close()
+
+            fig4 = plt.figure()
+            bins = np.linspace(0, 3000, 1000)
+            plt.hist(
+                ecal_pass,
+                bins=bins,
+                histtype="step",
+                label=f"{len(ecal_pass)} events passed quality cuts",
+            )
+            if cut_parameters is not None:
+                plt.hist(
+                    ecal_fail,
+                    bins=bins,
+                    histtype="step",
+                    label=f"{len(ecal_fail)} events failed quality cuts",
+                )
+            plt.yscale("log")
+            plt.xlabel("Energy (keV)")
+            plt.ylabel("Counts")
+            plt.legend(loc="upper right")
+            plot_dict_param["spectrum"] = fig4
+            if display>1:
+                plt.show()
+            else:
+                plt.close()
+
+            if cut_parameters is not None:
+                fig5 = plt.figure()
+                n_bins = 500
+                counts_pass, bins_pass, _ = pgh.get_hist(
+                    ecal_pass, bins=n_bins, range=(0, 3000)
+                )
+                counts_fail, bins_fail, _ = pgh.get_hist(
+                    ecal_fail, bins=n_bins, range=(0, 3000)
+                )
+                sf = 100 * (counts_pass+10**(-6)) / (counts_pass + counts_fail+10**(-6))
+
+                plt.step(pgh.get_bin_centers(bins_pass), sf, where="post")
+                plt.xlabel("Energy (keV)")
+                plt.ylabel("Survival Fraction (%)")
+                plt.ylim([50, 100])
+                plt.xlim([0,3000])
+                plot_dict_param["survival_frac"] = fig5
+                if display>1:
+                    plt.show()
+                else:
                     plt.close()
+
+            plot_dict[energy_param] = plot_dict_param
 
         if fitted_peaks[-1] == 2614.50:
             fep_fwhm = round(fwhms[-1], 2)
@@ -494,10 +571,17 @@ def energy_cal_th(
             "2.6_fwhm": fep_fwhm,
             "2.6_fwhm_err": fep_dwhm,
             "eres_pars": fit_pars.tolist(),
+            "fitted_peaks": results["fitted_keV"].tolist(),
+            "fwhms":results["pk_fwhms"].tolist(),
         }
+        log.info(f"Results {energy_param}: {json.dumps(output_dict[f'{energy_param}_cal'], indent=2)}")
 
-    log.info(f"Finished : {hit_dict}")
-    return hit_dict, output_dict
+
+    log.info(f"Finished all calibrations")
+    if display>0:
+        return hit_dict, output_dict, plot_dict
+    else:
+        return hit_dict, output_dict
 
 
 def get_peak_labels(

--- a/src/pygama/pargen/energy_optimisation.py
+++ b/src/pygama/pargen/energy_optimisation.py
@@ -37,7 +37,7 @@ sto = lh5.LH5Store()
 
 
 def run_optimisation(
-    file, opt_config, dsp_config, cuts, fom, db_dict=None, n_events=8000, **fom_kwargs
+    file, opt_config, dsp_config, cuts, fom, db_dict=None, n_events=8000, wf_field="waveform",**fom_kwargs
 ):
     """
     Runs optimisation on .lh5 file
@@ -60,9 +60,9 @@ def run_optimisation(
         Number of events to run over
     """
     grid = set_par_space(opt_config)
-    waveforms = sto.read_object("/raw/waveform", file, idx=cuts, n_rows=n_events)[0]
+    waveforms = sto.read_object(f"/raw/{wf_field}", file, idx=cuts, n_rows=n_events)[0]
     baseline = sto.read_object("/raw/baseline", file, idx=cuts, n_rows=n_events)[0]
-    tb_data = lh5.Table(col_dict={"waveform": waveforms, "baseline": baseline})
+    tb_data = lh5.Table(col_dict={f"{wf_field}": waveforms, "baseline": baseline})
     return opt.run_grid(tb_data, dsp_config, grid, fom, db_dict, **fom_kwargs)
 
 
@@ -131,12 +131,12 @@ def run_optimisation_multiprocessed(
         fom_kwargs = form_dict(fom_kwargs, len(grid))
     sto = lh5.LH5Store()
     waveforms = sto.read_object(
-        f"{lh5_path}/waveform", file, idx=cuts, n_rows=n_events
+        f"{lh5_path}/{wf_field}", file, idx=cuts, n_rows=n_events
     )[0]
     baseline = sto.read_object(f"{lh5_path}/baseline", file, idx=cuts, n_rows=n_events)[
         0
     ]
-    tb_data = lh5.Table(col_dict={"waveform": waveforms, "baseline": baseline})
+    tb_data = lh5.Table(col_dict={f"{wf_field}": waveforms, "baseline": baseline})
     return opt.run_grid_multiprocess_parallel(
         tb_data,
         dsp_config,
@@ -895,6 +895,7 @@ def event_selection(
     kev_widths,
     cut_parameters={"bl_mean": 4, "bl_std": 4, "pz_std": 4},
     energy_parameter="trapTmax",
+    wf_field:str = "waveform",
     n_events=10000,
     threshold=1000,
 ):
@@ -964,12 +965,12 @@ def event_selection(
     idxs = np.array(sorted(np.concatenate(masks)))
 
     waveforms = sto.read_object(
-        f"{lh5_path}/waveform", raw_files, idx=idxs, n_rows=len(idxs)
+        f"{lh5_path}/{wf_field}", raw_files, idx=idxs, n_rows=len(idxs)
     )[0]
     baseline = sto.read_object(
         f"{lh5_path}/baseline", raw_files, idx=idxs, n_rows=len(idxs)
     )[0]
-    input_data = lh5.Table(col_dict={"waveform": waveforms, "baseline": baseline})
+    input_data = lh5.Table(col_dict={f"{wf_field}": waveforms, "baseline": baseline})
 
     if isinstance(dsp_config, str):
         with open(dsp_config) as r:

--- a/src/pygama/pargen/extract_tau.py
+++ b/src/pygama/pargen/extract_tau.py
@@ -240,16 +240,16 @@ def dsp_preprocess_decay_const(
         tau_dict["pz"].update(out_dict["pz"])
     if display>0:
         tb_out = opt.run_one_dsp(tb_data, dsp_config, db_dict = tau_dict)
-        wf_idxs = np.random.choice(len(wfs), 100)
         wfs = tb_out[wf_plot]["values"].nda[idxs]
+        wf_idxs = np.random.choice(len(wfs), 100)
         if norm_param is not None:
-            means = tb_out["norm_param"].nda[idxs]
-            wfs = np.divide(wfs[wf_idx], means[wf_idx])
+            means = tb_out[norm_param].nda[idxs]
+            wfs = np.divide(wfs[wf_idxs], np.reshape(means[wf_idxs], (len(wf_idxs),1)))
         else:
-            wfs = wfs[wf_idx]
+            wfs = wfs[wf_idxs]
         fig2 = plt.figure()
-        for wf_idx in wf_idxs:
-            plt.plot(np.arange(0, len(wfs[wf_idx]), 1), wfs)
+        for wf in wfs:
+            plt.plot(np.arange(0, len(wf), 1), wf)
         plt.axhline(1, color="black")
         plt.axhline(0, color="black")
         plt.xlabel("Samples")

--- a/src/pygama/pargen/extract_tau.py
+++ b/src/pygama/pargen/extract_tau.py
@@ -12,6 +12,7 @@ import pickle as pkl
 from collections import OrderedDict
 
 import matplotlib as mpl
+mpl.use('agg')
 import matplotlib.pyplot as plt
 import numpy as np
 


### PR DESCRIPTION
1) Added check to cusp and zac filters that the flat is an integer this is to correct an issue where a non integer flat can lead to a miscalculation of the filter with one sample at the end much higher than it should be causing energy to be overestimated.
2) Went through and refactored all the plots in pargen, also changed so that instead of outputting pdfs a dictionary of figures is returned which can be put in pickle files for data processing.
3) Added fields to specify name of waveform to be used for par_dsp steps in anticipation of data trimming