### PR TITLE
Update path for the main branch build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![PyPI](https://img.shields.io/pypi/v/pygama?logo=pypi)](https://pypi.org/project/pygama/)
 [![GitHub tag (latest by date)](https://img.shields.io/github/v/tag/legend-exp/pygama?logo=git)](https://github.com/legend-exp/pygama/tags)
-[![GitHub Workflow Status](https://img.shields.io/github/workflow/status/legend-exp/pygama/pygama/main?label=main%20branch&logo=github)](https://github.com/legend-exp/pygama/actions)
+[![GitHub Workflow Status](https://img.shields.io/github/checks-status/legend-exp/pygama/main?label=main%20branch&logo=github)](https://github.com/legend-exp/pygama/actions)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Codecov](https://img.shields.io/codecov/c/github/legend-exp/pygama?logo=codecov)](https://app.codecov.io/gh/legend-exp/pygama)


### PR DESCRIPTION
I noticed that the build status badge in the README is broken and references an issue at https://github.com/badges/shields/issues/8671, where this was a non-backwards compatible change by [shields.io](https://shields.io).

Old badge: [![GitHub Workflow Status](https://img.shields.io/github/workflow/status/legend-exp/pygama/pygama/main?label=main%20branch&logo=github)](https://github.com/legend-exp/pygama/actions)

New badge: [![GitHub Workflow Status](https://img.shields.io/github/checks-status/legend-exp/pygama/main?label=main%20branch&logo=github)](https://github.com/legend-exp/pygama/actions)

Where I've updated the badge URL so that it is checking if all the status checks on the most recent commit to the main branch are successful, which I believe is what the previous badge used to do.

----

Before submitting a pull request, please make sure you've read and understood the pygama developer's guide: https://pygama.readthedocs.io/en/latest/developer.html. In particular, do not forget to:

- [x] Conform to our **coding conventions**
- [x] Update existing or add new **tests**
- [x] Update existing or add new **documentation**
- [x] Address any issue reported by GitHub checks
