### PR TITLE
Add functionality for testing factory functions in DSP, Add discrete_wavelet_transform test

### DIFF
--- a/docs/source/developer.rst
+++ b/docs/source/developer.rst
@@ -215,7 +215,7 @@ a factory function to return a function wrapped by the
     from pygama.dsp.processors import discrete_wavelet_transform
 
     def test_discrete_wavelet_transform(compare_numba_vs_python):
-        """Testing function for the fixed_time_pickoff processor."""
+        """Testing function for the discrete_wavelet_transform processor."""
 
         # set up values to use for each test case
         len_wf_in = 16

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import copy
 import inspect
 import os
 import re
@@ -130,12 +131,12 @@ def compare_numba_vs_python():
             noutputs = 1
             # numba outputs
             func(*inputs)
-            outputs_numba = inputs[-noutputs:]
+            outputs_numba = copy.deepcopy(inputs[-noutputs:])
 
             # unwrapped python outputs
             func_unwrapped = inspect.unwrap(func)
             func_unwrapped(*inputs)
-            outputs_python = inputs[-noutputs:]
+            outputs_python = copy.deepcopy(inputs[-noutputs:])
 
         # assert that numba and python are the same up to floating point
         # precision, setting nans to be equal

--- a/tests/dsp/processors/test_dwt.py
+++ b/tests/dsp/processors/test_dwt.py
@@ -1,0 +1,38 @@
+import numpy as np
+import pytest
+import pywt
+
+from pygama.dsp.errors import DSPFatal
+from pygama.dsp.processors import discrete_wavelet_transform
+
+def test_discrete_wavelet_transform(compare_numba_vs_python):
+    """Testing function for the fixed_time_pickoff processor."""
+
+    # set up values to use for each test case
+    len_wf_in = 16
+    wave_type = 'haar'
+    level = 2
+    len_wf_out = 4
+
+    # ensure the DSPFatal is raised for a negative level
+    with pytest.raises(DSPFatal):
+        discrete_wavelet_transform(wave_type, -1)
+
+    # ensure that a valid input gives the expected output
+    w_in = np.ones(len_wf_in)
+    w_out = np.empty(len_wf_out)
+    w_out_expected = np.ones(len_wf_out) * 2**(level / 2)
+
+    dwt_func = discrete_wavelet_transform(wave_type, level)
+    assert np.allclose(
+        compare_numba_vs_python(dwt_func, w_in, w_out),
+        w_out_expected,
+    )
+
+    # ensure that if there is a nan in w_in, all nans are outputted
+    w_in = np.ones(len_wf_in)
+    w_in[4] = np.nan
+    w_out = np.empty(len_wf_out)
+
+    dwt_func = discrete_wavelet_transform(wave_type, level)
+    assert np.all(np.isnan(compare_numba_vs_python(dwt_func, w_in, w_out)))

--- a/tests/dsp/processors/test_dwt.py
+++ b/tests/dsp/processors/test_dwt.py
@@ -4,12 +4,13 @@ import pytest
 from pygama.dsp.errors import DSPFatal
 from pygama.dsp.processors import discrete_wavelet_transform
 
+
 def test_discrete_wavelet_transform(compare_numba_vs_python):
     """Testing function for the discrete_wavelet_transform processor."""
 
     # set up values to use for each test case
     len_wf_in = 16
-    wave_type = 'haar'
+    wave_type = "haar"
     level = 2
     len_wf_out = 4
 
@@ -20,7 +21,7 @@ def test_discrete_wavelet_transform(compare_numba_vs_python):
     # ensure that a valid input gives the expected output
     w_in = np.ones(len_wf_in)
     w_out = np.empty(len_wf_out)
-    w_out_expected = np.ones(len_wf_out) * 2**(level / 2)
+    w_out_expected = np.ones(len_wf_out) * 2 ** (level / 2)
 
     dwt_func = discrete_wavelet_transform(wave_type, level)
     assert np.allclose(

--- a/tests/dsp/processors/test_dwt.py
+++ b/tests/dsp/processors/test_dwt.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pytest
-import pywt
 
 from pygama.dsp.errors import DSPFatal
 from pygama.dsp.processors import discrete_wavelet_transform

--- a/tests/dsp/processors/test_dwt.py
+++ b/tests/dsp/processors/test_dwt.py
@@ -5,7 +5,7 @@ from pygama.dsp.errors import DSPFatal
 from pygama.dsp.processors import discrete_wavelet_transform
 
 def test_discrete_wavelet_transform(compare_numba_vs_python):
-    """Testing function for the fixed_time_pickoff processor."""
+    """Testing function for the discrete_wavelet_transform processor."""
 
     # set up values to use for each test case
     len_wf_in = 16


### PR DESCRIPTION
I've updated the fixture `compare_numba_vs_python` to work with factory functions for making processors in `dsp`. Since the function signature is a special case for these, the current version of the fixture was not working.

In this PR, I've added:
 - A check of the function signature in `compare_numba_vs_python` for if a value is returned by the function (as opposed to updated in-place)
   - If True, the previously written version is run (no changes here)
   - If False, then a pre-initialized output must be passed as an input, which will then be changed in-place and the Numba and Python versions of the function will be properly compared
- A test for `discrete_wavelet_transform` as a simple example for testing one of the factory functions in the processors
- Updated the developer documentation to mention this way of testing these cases

This was done to help #411 write the needed tests, as this new processor relies on a factory function. With this change, it should be easy to write the test for that processor.

-----

Before submitting a pull request, please make sure you've read and understood the pygama developer's guide: https://pygama.readthedocs.io/en/latest/developer.html. In particular, do not forget to:

- [x] Conform to our **coding conventions**
- [x] Update existing or add new **tests**
- [x] Update existing or add new **documentation**
- [x] Address any issue reported by GitHub checks
