### PR TITLE
Fix check for if the decoded values were built in ORFlashCamADCWaveformDecoder

### DIFF
--- a/src/pygama/raw/orca/orca_flashcam.py
+++ b/src/pygama/raw/orca/orca_flashcam.py
@@ -192,8 +192,8 @@ class ORFlashCamWaveformDecoder(OrcaDecoder):
 
     def get_decoded_values(self, key: int = None) -> dict[str, Any]:
         if key is None:
-            dec_vals_list = self.decoded_values.values()
-            if len(dec_vals_list) >= 0:
+            dec_vals_list = list(self.decoded_values.values())
+            if len(dec_vals_list) > 0:
                 return dec_vals_list[0]
             raise RuntimeError("decoded_values not built")
         fcid = get_fcid(key)


### PR DESCRIPTION
I noticed that the check for if the `decoded_values` were built when trying to access them in `ORFlashCamADCWaveformDecoder` had a bug:

- `dict_values` is not subscriptable
- It would try to index into the list even if the list length was zero

So, I made a small fix to have the behavior match what was expected.

Here's a MWE:

```python
from pygama.raw.orca.orca_flashcam import ORFlashCamADCWaveformDecoder

ORFlashCamADCWaveformDecoder().get_decoded_values()
```

-----


Before submitting a pull request, please make sure you've read and understood the pygama developer's guide: https://pygama.readthedocs.io/en/latest/developer.html. In particular, do not forget to:

- [x] Conform to our **coding conventions**
- [x] Update existing or add new **tests**
- [x] Update existing or add new **documentation**
- [x] Address any issue reported by GitHub checks
