### PR TITLE
Adding daq to raw validation code

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,7 @@ on:
       - refactor
       - 'releases/**'
   pull_request:
+  merge_group:
   release:
 
 concurrency:

--- a/src/pygama/lgdo/lh5_store.py
+++ b/src/pygama/lgdo/lh5_store.py
@@ -307,7 +307,7 @@ class LH5Store:
         if datatype == "scalar":
             value = h5f[name][()]
             if elements == "bool":
-                value = np.bool(value)
+                value = np.bool_(value)
             if obj_buf is not None:
                 obj_buf.value = value
                 obj_buf.attrs.update(h5f[name].attrs)
@@ -631,7 +631,7 @@ class LH5Store:
             # special handling for bools
             # (c and Julia store as uint8 so cast to bool)
             if elements == "bool":
-                nda = nda.astype(np.bool)
+                nda = nda.astype(np.bool_)
 
             # Finally, set attributes and return objects
             attrs = h5f[name].attrs

--- a/tests/raw/test_daq_to_raw.py
+++ b/tests/raw/test_daq_to_raw.py
@@ -62,7 +62,7 @@ class OrcaEncoder:
 
         self.header = init_header + self.header
 
-    def encode_ORFlashCamConfig(self, ii):
+    def encode_orflashcamconfig(self, ii):
         """Convert orca flashcam config data back to byte strings."""
 
         LH5 = LH5Store()
@@ -95,7 +95,7 @@ class OrcaEncoder:
 
         return packets
 
-    def encode_ORFlashCamADCWaveform(self, ii):
+    def encode_orflashcamadcwaveform(self, ii):
         """Convert orca flashcam ADC waveform data back to byte strings."""
 
         LH5 = LH5Store()
@@ -161,7 +161,7 @@ class OrcaEncoder:
 
         return packets
 
-    def encode_ORRunDecoderForRun(self, ii):
+    def encode_orrun(self, ii):
         """Convert orca run data back to byte strings."""
 
         LH5 = LH5Store()
@@ -201,10 +201,10 @@ def test_daq_to_raw(lgnd_test_data):
     )
 
     # recreate the header
-    OE = OrcaEncoder(out_spec)
-    OE.encode_header()
+    encoder = OrcaEncoder(out_spec)
+    encoder.encode_header()
 
-    rebuilt_orca_data = OE.header
+    rebuilt_orca_data = encoder.header
 
     # get the order of all of the data IDs
     orstr = orca_streamer.OrcaStreamer()
@@ -231,13 +231,13 @@ def test_daq_to_raw(lgnd_test_data):
         ii = buffer_count[dd] - 1
 
         if dd == 7:
-            this_packet = OE.encode_ORRunDecoderForRun(ii)
+            this_packet = encoder.encode_orrun(ii)
         elif dd == 4:
-            this_packet = OE.encode_ORFlashCamConfig(ii)
+            this_packet = encoder.encode_orflashcamconfig(ii)
         elif dd == 3:
-            this_packet = OE.encode_ORFlashCamADCWaveform(ii)
+            this_packet = encoder.encode_orflashcamadcwaveform(ii)
         else:
-            raise ValueError(f"Encoder does not exist for data ID {ii}")
+            raise ValueError(f"Encoder does not exist for data ID {dd}")
 
         rebuilt_orca_data += struct.pack(f"{len(this_packet)}I", *this_packet)
 

--- a/tests/raw/test_daq_to_raw.py
+++ b/tests/raw/test_daq_to_raw.py
@@ -1,18 +1,20 @@
-from collections import Counter
-from io import BytesIO
 import json
 import plistlib
 import re
 import struct
+from collections import Counter
+from io import BytesIO
 
 from pygama.lgdo import LH5Store
 from pygama.raw import build_raw
 from pygama.raw.orca import orca_streamer
-from pygama.raw.orca.orca_flashcam import ORFlashCamListenerConfigDecoder, ORFlashCamADCWaveformDecoder
+from pygama.raw.orca.orca_flashcam import (
+    ORFlashCamListenerConfigDecoder,
+)
 from pygama.raw.orca.orca_run_decoder import ORRunDecoderForRun
 
 
-class OrcaEncoder(object):
+class OrcaEncoder:
     """Encoding function for recreating raw Orca files."""
 
     def __init__(self, file):
@@ -26,37 +28,37 @@ class OrcaEncoder(object):
 
         LH5 = LH5Store()
         test_file, _ = LH5.read_object(
-            'OrcaHeader',
+            "OrcaHeader",
             self.file,
         )
-        test_str = str(test_file.value, 'utf-8')
+        test_str = str(test_file.value, "utf-8")
         xml_dict = json.loads(test_str)
         xml_header = BytesIO()
         plistlib.dump(xml_dict, xml_header, fmt=plistlib.FMT_XML)
         xml_header.seek(0)
-        compiled_header = str(xml_header.read(), 'utf-8')
+        compiled_header = str(xml_header.read(), "utf-8")
         xml_header.close()
         fixed_header = re.sub(
             r"([1-9]\d*\.0)+",
             lambda x: str(int(float(x.group(0)))),
             compiled_header,
-        ).replace('1', '1.0', 4)
+        ).replace("1", "1.0", 4)
 
-        self.header = bytes(fixed_header, 'utf-8')
+        self.header = bytes(fixed_header, "utf-8")
         len_header_true = len(self.header)
 
         if (len_header_true + 8) % 16 != 0:
             extra_zeros = 16 - ((len_header_true + 8) % 16)
             extra_bytes = struct.pack(
-                f'{extra_zeros}b',
+                f"{extra_zeros}b",
                 *([0] * extra_zeros),
             )
             self.header += extra_bytes
 
         len_header_full = len(self.header) + 8
 
-        init_header = struct.pack('i', (len_header_full) // 4)
-        init_header += struct.pack('i', len_header_true)
+        init_header = struct.pack("i", (len_header_full) // 4)
+        init_header += struct.pack("i", len_header_true)
 
         self.header = init_header + self.header
 
@@ -65,12 +67,13 @@ class OrcaEncoder(object):
 
         LH5 = LH5Store()
         tbl, _ = LH5.read_object(
-            'ORFlashCamListenerConfig', self.file,
+            "ORFlashCamListenerConfig",
+            self.file,
         )
 
         packets = []
         packets.append(4 << 18)
-        packets.append((tbl['readout_id'].nda[ii] << 16) + tbl['fcid'].nda[ii])
+        packets.append((tbl["readout_id"].nda[ii] << 16) + tbl["fcid"].nda[ii])
 
         decoded_values = ORFlashCamListenerConfigDecoder().get_decoded_values()
 
@@ -81,10 +84,12 @@ class OrcaEncoder(object):
             if k == "gps":
                 break
 
-        npacks = tbl['ch_boardid'].nda.shape[-1]
+        npacks = tbl["ch_boardid"].nda.shape[-1]
 
         for jj in range(npacks):
-            packets.append((tbl['ch_boardid'].nda[ii, jj] << 16) + tbl['ch_inputnum'].nda[ii, jj])
+            packets.append(
+                (tbl["ch_boardid"].nda[ii, jj] << 16) + tbl["ch_inputnum"].nda[ii, jj]
+            )
 
         packets[0] += len(packets)
 
@@ -95,7 +100,8 @@ class OrcaEncoder(object):
 
         LH5 = LH5Store()
         tbl, _ = LH5.read_object(
-            'ORFlashCamADCWaveform', self.file,
+            "ORFlashCamADCWaveform",
+            self.file,
         )
 
         orca_header_length = 3
@@ -104,49 +110,53 @@ class OrcaEncoder(object):
         packets = []
         packets.append(3 << 18)
         packets.append(1)
-        packets[1] += (orca_header_length << 28)
-        packets[1] += (fcio_header_length << 22)
+        packets[1] += orca_header_length << 28
+        packets[1] += fcio_header_length << 22
 
         packet3 = 0x80000
-        packet3 += tbl['channel'].nda[ii]
-        packet3 += tbl['ch_orca'].nda[ii] << 10
-        packet3 += tbl['crate'].nda[ii] << 22
-        packet3 += tbl['card'].nda[ii] << 27
+        packet3 += tbl["channel"].nda[ii]
+        packet3 += tbl["ch_orca"].nda[ii] << 10
+        packet3 += tbl["crate"].nda[ii] << 22
+        packet3 += tbl["card"].nda[ii] << 27
         packets.append(packet3)
 
         # time offsets
-        packets.append(tbl['to_mu_sec'].nda[ii])
-        packets.append(tbl['to_mu_usec'].nda[ii])
-        packets.append(tbl['to_master_sec'].nda[ii])
-        packets.append(tbl['to_dt_mu_usec'].nda[ii])
-        packets.append(tbl['to_abs_mu_usec'].nda[ii])
-        packets.append(tbl['to_start_sec'].nda[ii])
-        packets.append(tbl['to_start_usec'].nda[ii])
+        packets.append(tbl["to_mu_sec"].nda[ii])
+        packets.append(tbl["to_mu_usec"].nda[ii])
+        packets.append(tbl["to_master_sec"].nda[ii])
+        packets.append(tbl["to_dt_mu_usec"].nda[ii])
+        packets.append(tbl["to_abs_mu_usec"].nda[ii])
+        packets.append(tbl["to_start_sec"].nda[ii])
+        packets.append(tbl["to_start_usec"].nda[ii])
 
         # set the dead region values
-        packets.append(tbl['dr_start_pps'].nda[ii])
-        packets.append(tbl['dr_start_ticks'].nda[ii])
-        packets.append(tbl['dr_stop_pps'].nda[ii])
-        packets.append(tbl['dr_stop_ticks'].nda[ii])
-        packets.append(tbl['dr_maxticks'].nda[ii])
+        packets.append(tbl["dr_start_pps"].nda[ii])
+        packets.append(tbl["dr_start_ticks"].nda[ii])
+        packets.append(tbl["dr_stop_pps"].nda[ii])
+        packets.append(tbl["dr_stop_ticks"].nda[ii])
+        packets.append(tbl["dr_maxticks"].nda[ii])
 
         # set event number and clock counters
-        packets.append(tbl['eventnumber'].nda[ii])
-        packets.append(tbl['ts_pps'].nda[ii])
-        packets.append(tbl['ts_ticks'].nda[ii])
-        packets.append(tbl['ts_maxticks'].nda[ii])
+        packets.append(tbl["eventnumber"].nda[ii])
+        packets.append(tbl["ts_pps"].nda[ii])
+        packets.append(tbl["ts_ticks"].nda[ii])
+        packets.append(tbl["ts_maxticks"].nda[ii])
 
-        packets.append(tbl['baseline'].nda[ii] + (tbl['daqenergy'].nda[ii] << 16))
+        packets.append(tbl["baseline"].nda[ii] + (tbl["daqenergy"].nda[ii] << 16))
 
-
-        packets.extend([xx + (yy << 16) for xx, yy in zip(
-            tbl['waveform']['values'].nda[ii, ::2],
-            tbl['waveform']['values'].nda[ii, 1::2],
-        )])
+        packets.extend(
+            [
+                xx + (yy << 16)
+                for xx, yy in zip(
+                    tbl["waveform"]["values"].nda[ii, ::2],
+                    tbl["waveform"]["values"].nda[ii, 1::2],
+                )
+            ]
+        )
 
         wf_samples = 2 * (len(packets) - orca_header_length - fcio_header_length)
 
-        packets[1] += (wf_samples << 6)
+        packets[1] += wf_samples << 6
         packets[0] += len(packets)
 
         return packets
@@ -156,12 +166,13 @@ class OrcaEncoder(object):
 
         LH5 = LH5Store()
         tbl, _ = LH5.read_object(
-            'ORRunDecoderForRun', self.file,
+            "ORRunDecoderForRun",
+            self.file,
         )
 
         packets = []
         packets.append(7 << 18)
-        packets.append(tbl['subrun_number'].nda[ii] << 16)
+        packets.append(tbl["subrun_number"].nda[ii] << 16)
         decoded_values = ORRunDecoderForRun().get_decoded_values()
         for i, k in enumerate(decoded_values):
             if 0 < i < 7:
@@ -179,14 +190,12 @@ def test_daq_to_raw(lgnd_test_data):
     """Test function for the daq to raw validation."""
 
     # open orca daq file and create LH5 file
-    orca_file = lgnd_test_data.get_path(
-        'orca/fc/L200-comm-20220519-phy-geds.orca'
-    )
-    out_spec = '/tmp/L200-comm-20220519-phy-geds_test.lh5'
+    orca_file = lgnd_test_data.get_path("orca/fc/L200-comm-20220519-phy-geds.orca")
+    out_spec = "/tmp/L200-comm-20220519-phy-geds_test.lh5"
 
     build_raw(
         orca_file,
-        in_stream_type='ORCA',
+        in_stream_type="ORCA",
         out_spec=out_spec,
         overwrite=True,
     )
@@ -228,12 +237,12 @@ def test_daq_to_raw(lgnd_test_data):
         elif dd == 3:
             this_packet = OE.encode_ORFlashCamADCWaveform(ii)
         else:
-            raise ValueError(f'Encoder does not exist for data ID {ii}')
+            raise ValueError(f"Encoder does not exist for data ID {ii}")
 
-        rebuilt_orca_data += struct.pack(f'{len(this_packet)}I', *this_packet)
+        rebuilt_orca_data += struct.pack(f"{len(this_packet)}I", *this_packet)
 
     # load the original raw orca file as a byte string
-    with open(orca_file, 'rb') as ff:
+    with open(orca_file, "rb") as ff:
         orig_orca_data = ff.read()
 
     # assert the byte strings are the same

--- a/tests/raw/test_daq_to_raw.py
+++ b/tests/raw/test_daq_to_raw.py
@@ -8,9 +8,7 @@ from io import BytesIO
 from pygama.lgdo import LH5Store
 from pygama.raw import build_raw
 from pygama.raw.orca import orca_streamer
-from pygama.raw.orca.orca_flashcam import (
-    ORFlashCamListenerConfigDecoder,
-)
+from pygama.raw.orca.orca_flashcam import ORFlashCamListenerConfigDecoder
 from pygama.raw.orca.orca_run_decoder import ORRunDecoderForRun
 
 

--- a/tests/raw/test_daq_to_raw.py
+++ b/tests/raw/test_daq_to_raw.py
@@ -24,8 +24,8 @@ class OrcaEncoder:
     def encode_header(self):
         """Convert orca header back to a byte string."""
 
-        LH5 = LH5Store()
-        test_file, _ = LH5.read_object(
+        lh5 = LH5Store()
+        test_file, _ = lh5.read_object(
             "OrcaHeader",
             self.file,
         )
@@ -63,8 +63,8 @@ class OrcaEncoder:
     def encode_orflashcamconfig(self, ii):
         """Convert orca flashcam config data back to byte strings."""
 
-        LH5 = LH5Store()
-        tbl, _ = LH5.read_object(
+        lh5 = LH5Store()
+        tbl, _ = lh5.read_object(
             "ORFlashCamListenerConfig",
             self.file,
         )
@@ -96,8 +96,8 @@ class OrcaEncoder:
     def encode_orflashcamadcwaveform(self, ii):
         """Convert orca flashcam ADC waveform data back to byte strings."""
 
-        LH5 = LH5Store()
-        tbl, _ = LH5.read_object(
+        lh5 = LH5Store()
+        tbl, _ = lh5.read_object(
             "ORFlashCamADCWaveform",
             self.file,
         )
@@ -162,8 +162,8 @@ class OrcaEncoder:
     def encode_orrun(self, ii):
         """Convert orca run data back to byte strings."""
 
-        LH5 = LH5Store()
-        tbl, _ = LH5.read_object(
+        lh5 = LH5Store()
+        tbl, _ = lh5.read_object(
             "ORRunDecoderForRun",
             self.file,
         )

--- a/tests/raw/test_daq_to_raw.py
+++ b/tests/raw/test_daq_to_raw.py
@@ -1,0 +1,211 @@
+from io import BytesIO
+import json
+import plistlib
+import re
+import struct
+
+from pygama.lgdo import LH5Store
+from pygama.raw import build_raw
+from pygama.raw.orca.orca_flashcam import ORFlashCamListenerConfigDecoder, ORFlashCamADCWaveformDecoder
+from pygama.raw.orca.orca_run_decoder import ORRunDecoderForRun
+
+
+class OrcaEncoder(object):
+    
+    def __init__(self, file):
+
+        self.file = file
+        self.header = None
+
+    def encode_header(self):
+
+        LH5 = LH5Store()
+        test_file, _ = LH5.read_object(
+            'OrcaHeader',
+            self.file,
+        )
+        test_str = str(test_file.value, 'utf-8')
+        xml_dict = json.loads(test_str)
+        xml_header = BytesIO()
+        plistlib.dump(xml_dict, xml_header, fmt=plistlib.FMT_XML)
+        xml_header.seek(0)
+        compiled_header = str(xml_header.read(), 'utf-8')
+        xml_header.close()
+        fixed_header = re.sub(
+            r"([1-9]\d*\.0)+",
+            lambda x: str(int(float(x.group(0)))),
+            compiled_header,
+        ).replace('1', '1.0', 4)
+
+        self.header = bytes(fixed_header, 'utf-8')
+        len_header_true = len(self.header)
+
+        if (len_header_true + 8) % 16 != 0:
+            extra_zeros = 16 - ((len_header_true + 8) % 16)
+            extra_bytes = struct.pack(
+                f'{extra_zeros}b',
+                *([0] * extra_zeros),
+            )
+            self.header += extra_bytes
+
+        len_header_full = len(self.header) + 8
+
+        init_header = struct.pack('i', (len_header_full) // 4)
+        init_header += struct.pack('i', len_header_true)
+
+        self.header = init_header + self.header
+
+    def encode_ORFlashCamConfig(self):
+
+        LH5 = LH5Store()
+        tbl, _ = LH5.read_object(
+            'ORFlashCamListenerConfig', self.file,
+        )
+
+        packets = []
+        packets.append(4 << 18)
+        packets.append((tbl['readout_id'].nda[0] << 16) + tbl['fcid'].nda[0])
+
+        decoded_values = ORFlashCamListenerConfigDecoder().get_decoded_values()
+
+        for i, k in enumerate(decoded_values):
+            if i < 2:
+                continue
+            packets.append(tbl[k].nda[0])
+            if k == "gps":
+                break
+
+        npacks = tbl['ch_boardid'].nda.shape[-1]
+
+        for ii in range(npacks):
+            packets.append((tbl['ch_boardid'].nda[0, ii] << 16) + tbl['ch_inputnum'].nda[0, ii])
+
+        packets[0] += len(packets)
+
+        return packets
+
+    def encode_ORFlashCamADCWaveform(self, ii):
+
+        LH5 = LH5Store()
+        tbl, _ = LH5.read_object(
+            'ORFlashCamADCWaveform', self.file,
+        )
+
+        orca_header_length = 3
+        fcio_header_length = 17
+
+        packets = []
+        packets.append(3 << 18)
+        packets.append(1)
+        packets[1] += (orca_header_length << 28)
+        packets[1] += (fcio_header_length << 22)
+
+        packet3 = 0x80000
+        packet3 += tbl['channel'].nda[ii]
+        packet3 += tbl['ch_orca'].nda[ii] << 10
+        packet3 += tbl['crate'].nda[ii] << 22
+        packet3 += tbl['card'].nda[ii] << 27
+        packets.append(packet3)
+
+        # time offsets
+        packets.append(tbl['to_mu_sec'].nda[ii])
+        packets.append(tbl['to_mu_usec'].nda[ii])
+        packets.append(tbl['to_master_sec'].nda[ii])
+        packets.append(tbl['to_dt_mu_usec'].nda[ii])
+        packets.append(tbl['to_abs_mu_usec'].nda[ii])
+        packets.append(tbl['to_start_sec'].nda[ii])
+        packets.append(tbl['to_start_usec'].nda[ii])
+
+        # set the dead region values
+        packets.append(tbl['dr_start_pps'].nda[ii])
+        packets.append(tbl['dr_start_ticks'].nda[ii])
+        packets.append(tbl['dr_stop_pps'].nda[ii])
+        packets.append(tbl['dr_stop_ticks'].nda[ii])
+        packets.append(tbl['dr_maxticks'].nda[ii])
+
+        # set event number and clock counters
+        packets.append(tbl['eventnumber'].nda[ii])
+        packets.append(tbl['ts_pps'].nda[ii])
+        packets.append(tbl['ts_ticks'].nda[ii])
+        packets.append(tbl['ts_maxticks'].nda[ii])
+
+        packets.append(tbl['baseline'].nda[ii] + (tbl['daqenergy'].nda[ii] << 16))
+
+
+        packets.extend([xx + (yy << 16) for xx, yy in zip(
+            tbl['waveform']['values'].nda[ii, ::2],
+            tbl['waveform']['values'].nda[ii, 1::2],
+        )])
+
+        wf_samples = 2 * (len(packets) - orca_header_length - fcio_header_length)
+
+        packets[1] += (wf_samples << 6)
+        packets[0] += len(packets)
+
+        return packets
+
+    def encode_ORRunDecoderForRun(self, ii):
+
+        LH5 = LH5Store()
+        tbl, _ = LH5.read_object(
+            'ORRunDecoderForRun', self.file,
+        )
+
+        packets = []
+        packets.append(7 << 18)
+        packets.append(tbl['subrun_number'].nda[ii] << 16)
+        decoded_values = ORRunDecoderForRun().get_decoded_values()
+        for i, k in enumerate(decoded_values):
+            if 0 < i < 7:
+                packets[1] += tbl[k].nda[ii] << (i - 1)
+
+        packets.append(tbl["run_number"].nda[ii])
+        packets.append(tbl["time"].nda[ii])
+
+        packets[0] += len(packets)
+
+        return packets
+
+
+def test_daq_to_raw(lgnd_test_data):
+
+    orca_file = lgnd_test_data.get_path(
+        'orca/fc/L200-comm-20220519-phy-geds.orca'
+    )
+    out_spec = '/tmp/L200-comm-20220519-phy-geds_test.lh5'
+
+    build_raw(
+        orca_file,
+        in_stream_type='ORCA',
+        out_spec=out_spec,
+        overwrite=True,
+    )
+
+    OE = OrcaEncoder(out_spec)
+    OE.encode_header()
+
+    packets_run = []
+    for ii in range(2):
+        packets_run.append(OE.encode_ORRunDecoderForRun(ii))
+
+    packets_fcconfig = OE.encode_ORFlashCamConfig()
+
+    packets_wf = []
+    for ii in range(67):
+        packets_wf.append(OE.encode_ORFlashCamADCWaveform(ii))
+
+    rebuilt_orca_data = OE.header 
+    rebuilt_orca_data += b''.join(
+        struct.pack(f'{len(pp)}I', *pp) for pp in packets_run
+    )
+    rebuilt_orca_data += struct.pack(
+        f'{len(packets_fcconfig)}I', *packets_fcconfig
+    )
+    rebuilt_orca_data += b''.join(
+        struct.pack(f'{len(pp)}I', *pp) for pp in packets_wf
+    )
+
+    with open(orca_file, 'rb') as ff:
+        orig_orca_data = ff.read()
+
+    assert rebuilt_orca_data == orig_orca_data


### PR DESCRIPTION
I've written up a first draft of an option for the daq to raw validation code. Right now it's written all in one test file, which makes an LH5 file via `build_raw` on a LEGEND test data file, recreates the orca file from the LH5 file, and then does a direct comparison to the original orca file.

I was hoping to get some feedback on this, I think a few questions are:
 - Should the `OrcaEncoder` live elsewhere?
   - Someone may want to use this to create "fake" orca files
 - Should we make a new test data file with data IDs other than those currently being supported by pygama?
   - If so, we'd need to add the orphaned packets functionality to `build_raw` (likely relatively simple)
   - Or we would need to write up the rest of the decoders (probably would take a while)
 - Any other thoughts on the validation?

I'm going to leave this PR as a draft, as there's likely a fair amount of work left - mostly wanted to start a conversation about the current state of the validation. FYI, this branch was made off of the one related to #421.

-----

Before submitting a pull request, please make sure you've read and understood the pygama developer's guide: https://pygama.readthedocs.io/en/latest/developer.html. In particular, do not forget to:

- [ ] Conform to our **coding conventions**
- [ ] Update existing or add new **tests**
- [ ] Update existing or add new **documentation**
- [ ] Address any issue reported by GitHub checks
