### PR TITLE
Implement multi-use decoders and auto-custom buffers

### DIFF
--- a/src/pygama/raw/data_decoder.py
+++ b/src/pygama/raw/data_decoder.py
@@ -58,7 +58,7 @@ class DataDecoder:
         )
 
     def get_key_lists(self) -> list[list[int | str]]:
-        """ Return a list of lists of keys available for this decoder.
+        """Return a list of lists of keys available for this decoder.
         Each list must contain keys that can share a buffer, i.e. decoded_values
         is exactly the same (including e.g. waveform length) for all keys in the list.
         Overload with lists of keys for this decoder, e.g. ``return

--- a/src/pygama/raw/data_decoder.py
+++ b/src/pygama/raw/data_decoder.py
@@ -57,11 +57,14 @@ class DataDecoder:
             "garbage_code", lgdo.Array(shape=garbage_length, dtype="uint32")
         )
 
-    def get_key_list(self) -> list[int | str]:
-        """Overload with list of keys for this decoder, e.g. ``return
-        range(n_channels)``.  The default version works for decoders with
+    def get_key_lists(self) -> list[list[int | str]]:
+        """ Return a list of lists of keys available for this decoder.
+        Each list must contain keys that can share a buffer, i.e. decoded_values
+        is exactly the same (including e.g. waveform length) for all keys in the list.
+        Overload with lists of keys for this decoder, e.g. ``return
+        [range(n_channels)]``.  The default version works for decoders with
         single / no keys."""
-        return [None]
+        return [[None]]
 
     def get_decoded_values(self, key: int | str = None) -> dict:
         """Get decoded values (optionally for a given key, typically a channel).

--- a/src/pygama/raw/data_streamer.py
+++ b/src/pygama/raw/data_streamer.py
@@ -127,7 +127,9 @@ class DataStreamer(ABC):
                 if len(rb.key_list) == 1 and rb.key_list[0] == "*":
                     key_lists = decoder.get_key_lists()
                     if len(key_lists) != 1:
-                        log.warning(f"{dec_name} has {len(key_lists)} lists of keys, need a rb for each. Only the first will be decoded.")
+                        log.warning(
+                            f"{dec_name} has {len(key_lists)} lists of keys, need a rb for each. Only the first will be decoded."
+                        )
                     rb.key_list = key_lists[0]
             keyed_name_rbs = []
             ii = 0
@@ -304,7 +306,9 @@ class DataStreamer(ABC):
                         this_name = f"{dec_key}_{key_list[0]}"
                     else:
                         this_name = f"{dec_key}_{ii}"
-                rb = RawBuffer(key_list=key_list, out_stream=out_stream, out_name=this_name)
+                rb = RawBuffer(
+                    key_list=key_list, out_stream=out_stream, out_name=this_name
+                )
                 if dec_name not in rb_lib:
                     rb_lib[dec_name] = RawBufferList()
                 rb_lib[dec_name].append(rb)

--- a/src/pygama/raw/data_streamer.py
+++ b/src/pygama/raw/data_streamer.py
@@ -106,11 +106,18 @@ class DataStreamer(ABC):
                     dec_key = dec_key.removesuffix("Decoder")
                 out_name = rb_lib["*"][0].out_name.format(name=dec_key)
                 out_stream = rb_lib["*"][0].out_stream.format(name=dec_key)
-                key_list = decoder.get_key_list()
-                rb = RawBuffer(
-                    key_list=key_list, out_stream=out_stream, out_name=out_name
-                )
-                rb_lib[dec_name].append(rb)
+                key_lists = decoder.get_key_lists()
+                for ii, key_list in enumerate(key_lists):
+                    this_name = out_name
+                    if len(key_lists > 1):
+                        if len(key_list) == 1:
+                            this_name = f"{out_name}_{key_list[0]}"
+                        else:
+                            this_name = f"{out_name}_{ii}"
+                    rb = RawBuffer(
+                        key_list=key_list, out_stream=out_stream, out_name=this_name
+                    )
+                    rb_lib[dec_name].append(rb)
 
             # dec_name is in rb_lib: store the name, and initialize its buffer lgdos
             dec_names.append(dec_name)
@@ -118,7 +125,10 @@ class DataStreamer(ABC):
             # set up wildcard key buffers
             for rb in rb_lib[dec_name]:
                 if len(rb.key_list) == 1 and rb.key_list[0] == "*":
-                    rb.key_list = decoder.get_key_list()
+                    key_lists = decoder.get_key_lists()
+                    if len(key_lists) != 1:
+                        log.warning(f"{dec_name} has {len(key_lists)} lists of keys, need a rb for each. Only the first will be decoded.")
+                    rb.key_list = key_lists[0]
             keyed_name_rbs = []
             ii = 0
             while ii < len(rb_lib[dec_name]):
@@ -286,8 +296,16 @@ class DataStreamer(ABC):
             dec_key = dec_name
             if dec_key.endswith("Decoder"):
                 dec_key = dec_key.removesuffix("Decoder")
-            key_list = decoder.get_key_list()
-            rb = RawBuffer(key_list=key_list, out_stream=out_stream, out_name=dec_key)
-            rb_lib[dec_name] = RawBufferList()
-            rb_lib[dec_name].append(rb)
+            key_lists = decoder.get_key_lists()
+            for ii, key_list in enumerate(key_lists):
+                this_name = dec_key
+                if len(key_lists) > 1:
+                    if len(key_list) == 1:
+                        this_name = f"{dec_key}_{key_list[0]}"
+                    else:
+                        this_name = f"{dec_key}_{ii}"
+                rb = RawBuffer(key_list=key_list, out_stream=out_stream, out_name=this_name)
+                if dec_name not in rb_lib:
+                    rb_lib[dec_name] = RawBufferList()
+                rb_lib[dec_name].append(rb)
         return rb_lib

--- a/src/pygama/raw/fc/fc_event_decoder.py
+++ b/src/pygama/raw/fc/fc_event_decoder.py
@@ -143,8 +143,8 @@ class FCEventDecoder(DataDecoder):
         self.fc_config = None
         self.max_numtraces = 1
 
-    def get_key_list(self) -> range:
-        return range(self.fc_config["nadcs"].value)
+    def get_key_lists(self) -> range:
+        return [range(self.fc_config["nadcs"].value)]
 
     def get_decoded_values(self, channel: int = None) -> dict[str, dict[str, Any]]:
         # FC uses the same values for all channels

--- a/src/pygama/raw/orca/orca_digitizers.py
+++ b/src/pygama/raw/orca/orca_digitizers.py
@@ -93,11 +93,11 @@ class ORSIS3302DecoderForEnergy(OrcaDecoder):
                         sys.exit()
                     self.decoded_values[ccc]["waveform"]["wf_len"] = trace_length
 
-    def get_key_list(self) -> list[str]:
-        key_list = []
+    def get_key_lists(self) -> list[str]:
+        key_lists = []
         for key in self.decoded_values.keys():
-            key_list += [key]
-        return key_list
+            key_lists.append([key])
+        return key_lists
 
     def get_decoded_values(self, key: int = None) -> dict[str, Any]:
         if key is None:
@@ -344,11 +344,11 @@ class ORSIS3316WaveformDecoder(OrcaDecoder):
                     else:
                         continue
 
-    def get_key_list(self) -> list[int]:
-        key_list = []
+    def get_key_lists(self) -> list[int]:
+        key_lists = []
         for key in self.decoded_values.keys():
-            key_list += [key]
-        return key_list
+            key_lists.append([key])
+        return key_lists
 
     def get_decoded_values(self, key: int = None) -> dict[str, Any]:
         if key is None:

--- a/src/pygama/raw/orca/orca_flashcam.py
+++ b/src/pygama/raw/orca/orca_flashcam.py
@@ -189,12 +189,13 @@ class ORFlashCamWaveformDecoder(OrcaDecoder):
             ]
             self.decoded_values[fcid] = copy.deepcopy(self.decoded_values_template)
             self.decoded_values[fcid]["waveform"]["wf_len"] = wf_len
+            log.debug(f"fcid {fcid}: {self.nadc[fcid]} adcs, wf_len = {wf_len}")
 
-    def get_key_list(self) -> list[int]:
-        key_list = []
+    def get_key_lists(self) -> list[list[int]]:
+        key_lists = []
         for fcid, nadc in self.nadc.items():
-            key_list += list(get_key(fcid, np.array(range(nadc))))
-        return key_list
+            key_lists.append(list(get_key(fcid, np.array(range(nadc)))))
+        return key_lists
 
     def get_decoded_values(self, key: int = None) -> dict[str, Any]:
         if key is None:

--- a/src/pygama/raw/orca/orca_header.py
+++ b/src/pygama/raw/orca/orca_header.py
@@ -11,13 +11,11 @@ log = logging.getLogger(__name__)
 class OrcaHeader(dict):
     """ORCA file header object."""
 
-
     def __init__(self, jsons: str = None, lgdo_scalar: lgdo.Scalar = None) -> None:
         if jsons is not None:
             self.update(json.loads(jsons))
         elif lgdo_scalar is not None:
             self.set_from_lgdo(lgdo_scalar)
-
 
     def set_from_lgdo(self, lgdo_scalar: lgdo.Scalar) -> None:
         if not isinstance(lgdo_scalar, lgdo.Scalar):
@@ -25,13 +23,11 @@ class OrcaHeader(dict):
         else:
             self.update(json.loads(lgdo_scalar.value))
 
-
     def get_decoder_list(self) -> list[str]:
         return list(set(self.get_id_to_decoder_name_dict().values()))
 
-
     def get_id_to_decoder_name_dict(self, shift_data_id: bool = True) -> dict[int, str]:
-        id_dict = { 0 : "OrcaHeaderDecoder" }
+        id_dict = {0: "OrcaHeaderDecoder"}
         dd = self["dataDescription"]
         for class_key in dd.keys():
             for super_key in dd[class_key].keys():
@@ -44,13 +40,11 @@ class OrcaHeader(dict):
                 id_dict[data_id] = dd[class_key][super_key]["decoder"]
         return id_dict
 
-
     def get_run_number(self) -> int:
         for d in self["ObjectInfo"]["DataChain"]:
             if "Run Control" in d:
                 return d["Run Control"]["RunNumber"]
         raise ValueError("No run number found in header!")
-
 
     def get_object_info(self, orca_class_name: str) -> dict[int, dict[int, dict]]:
         """Returns a ``dict[crate][card]`` with all info from the header for
@@ -67,7 +61,6 @@ class OrcaHeader(dict):
                     object_info_dict[crate["CrateNumber"]][card["Card"]] = card
 
         return object_info_dict
-
 
     def get_readout_info(self, orca_class_name: str, unique_id: int = -1) -> list:
         """Returns a list with all the readout list info from the header with
@@ -92,7 +85,6 @@ class OrcaHeader(dict):
         if len(readout_info_list) == 0:
             log.warning(f"no readout info for class name '{orca_class_name}'")
         return readout_info_list
-
 
     def get_auxhw_info(self, orca_class_name: str, unique_id: int = -1) -> list:
         """Returns a list with all the info from the ``AuxHw`` table of the header

--- a/src/pygama/raw/orca/orca_streamer.py
+++ b/src/pygama/raw/orca/orca_streamer.py
@@ -247,7 +247,7 @@ class OrcaStreamer(DataStreamer):
         for data_id in self.decoder_id_dict.keys():
             name = id_to_dec_name_dict[data_id]
             if name not in self.rb_lib:
-                raise RuntimeError(f"{name} not in rb_lib")
+                log.info(f"skipping data from {name}")
             self.rbl_id_dict[data_id] = self.rb_lib[name]
             good_buffers.append(name)
         # check that we have instantiated decoders for all buffers

--- a/src/pygama/raw/orca/orca_streamer.py
+++ b/src/pygama/raw/orca/orca_streamer.py
@@ -34,7 +34,6 @@ class OrcaStreamer(DataStreamer):
         self.header = None
         self.header_decoder = OrcaHeaderDecoder()
         self.decoder_id_dict = {}  # dict of data_id to decoder object
-        self.decoder_name_dict = {}  # dict of name to decoder object
         self.rbl_id_dict = {}  # dict of RawBufferLists for each data_id
 
     # TODO: need to correct for endianness?
@@ -204,9 +203,8 @@ class OrcaStreamer(DataStreamer):
         self.any_full |= self.header_decoder.decode_packet(packet, self.packet_id)
         self.header = self.header_decoder.header
 
-        # instantiate decoders listed in the header AND in the rb_lib (if specified)
-        decoder_names = ["OrcaHeaderDecoder"]
-        decoder_names += self.header.get_decoder_list()
+        # find the names of all decoders listed in the header AND in the rb_lib (if specified)
+        decoder_names = self.header.get_decoder_list()
         if rb_lib is not None and "*" not in rb_lib:
             keep_decoders = []
             for name in decoder_names:
@@ -219,22 +217,21 @@ class OrcaStreamer(DataStreamer):
                     log.warning(
                         f"decoder {name} (requested in rb_lib) not in data description in header"
                     )
-        for name in decoder_names:
-            # handle header decoder specially
-            if name == "OrcaHeaderDecoder":
-                self.decoder_id_dict[0] = self.header_decoder
-                self.decoder_name_dict["OrcaHeaderDecoder"] = 0
-                continue
-            # instantiate other decoders by name
-            if name not in globals():
-                log.warning(
-                    f"no implementation of {name}, corresponding packets will be skipped"
-                )
-                continue
-            decoder = globals()[name]
-            decoder.data_id = self.header.get_data_id(name)
-            self.decoder_id_dict[decoder.data_id] = decoder(header=self.header)
-            self.decoder_name_dict[name] = decoder.data_id
+
+        # get a mapping of data_ids-of-interest to instantiated decoders
+        id_to_dec_name_dict = self.header.get_id_to_decoder_name_dict(shift_data_id=False)
+        instantiated_decoders = { 'OrcaHeaderDecoder' : self.header_decoder }
+        for data_id in id_to_dec_name_dict.keys():
+            name = id_to_dec_name_dict[data_id]
+            if name not in instantiated_decoders:
+                if name not in globals():
+                    log.warning(
+                        f"no implementation of {name}, corresponding packets will be skipped"
+                    )
+                    continue
+                decoder = globals()[name]
+                instantiated_decoders[name] = decoder(header=self.header)
+            self.decoder_id_dict[data_id] = instantiated_decoders[name]
 
         # initialize the buffers in rb_lib. Store them for fast lookup
         super().open_stream(
@@ -246,9 +243,17 @@ class OrcaStreamer(DataStreamer):
         )
         if rb_lib is None:
             rb_lib = self.rb_lib
-        for name in self.rb_lib.keys():
-            data_id = self.decoder_name_dict[name]
+        good_buffers = []
+        for data_id in self.decoder_id_dict.keys():
+            name = id_to_dec_name_dict[data_id]
+            if name not in self.rb_lib:
+                raise RuntimeError(f"{name} not in rb_lib")
             self.rbl_id_dict[data_id] = self.rb_lib[name]
+            good_buffers.append(name)
+        # check that we have instantiated decoders for all buffers
+        for key in self.rb_lib:
+            if key not in good_buffers:
+                log.warning(f"buffer for {key} has no decoder")
         log.debug(f"rb_lib = {self.rb_lib}")
 
         # return header raw buffer
@@ -279,7 +284,7 @@ class OrcaStreamer(DataStreamer):
 
             # look up the data id, decoder, and rbl
             data_id = orca_packet.get_data_id(packet, shift=False)
-            log.debug(f"packet {self.packet_id}: data_id = {data_id}")
+            log.debug(f"packet {self.packet_id}: data_id = {data_id}, decoder = {'None' if data_id not in self.decoder_id_dict else type(self.decoder_id_dict[data_id]).__name__}")
             if data_id in self.decoder_id_dict:
                 break
 

--- a/src/pygama/raw/orca/orca_streamer.py
+++ b/src/pygama/raw/orca/orca_streamer.py
@@ -286,7 +286,7 @@ class OrcaStreamer(DataStreamer):
             # look up the data id, decoder, and rbl
             data_id = orca_packet.get_data_id(packet, shift=False)
             log.debug(f"packet {self.packet_id}: data_id = {data_id}, decoder = {'None' if data_id not in self.decoder_id_dict else type(self.decoder_id_dict[data_id]).__name__}")
-            if data_id in self.decoder_id_dict:
+            if data_id in self.rbl_id_dict:
                 break
 
         # now decode

--- a/src/pygama/raw/orca/orca_streamer.py
+++ b/src/pygama/raw/orca/orca_streamer.py
@@ -248,6 +248,7 @@ class OrcaStreamer(DataStreamer):
             name = id_to_dec_name_dict[data_id]
             if name not in self.rb_lib:
                 log.info(f"skipping data from {name}")
+                continue
             self.rbl_id_dict[data_id] = self.rb_lib[name]
             good_buffers.append(name)
         # check that we have instantiated decoders for all buffers

--- a/src/pygama/raw/orca/orca_streamer.py
+++ b/src/pygama/raw/orca/orca_streamer.py
@@ -219,8 +219,10 @@ class OrcaStreamer(DataStreamer):
                     )
 
         # get a mapping of data_ids-of-interest to instantiated decoders
-        id_to_dec_name_dict = self.header.get_id_to_decoder_name_dict(shift_data_id=False)
-        instantiated_decoders = { 'OrcaHeaderDecoder' : self.header_decoder }
+        id_to_dec_name_dict = self.header.get_id_to_decoder_name_dict(
+            shift_data_id=False
+        )
+        instantiated_decoders = {"OrcaHeaderDecoder": self.header_decoder}
         for data_id in id_to_dec_name_dict.keys():
             name = id_to_dec_name_dict[data_id]
             if name not in instantiated_decoders:
@@ -285,7 +287,9 @@ class OrcaStreamer(DataStreamer):
 
             # look up the data id, decoder, and rbl
             data_id = orca_packet.get_data_id(packet, shift=False)
-            log.debug(f"packet {self.packet_id}: data_id = {data_id}, decoder = {'None' if data_id not in self.decoder_id_dict else type(self.decoder_id_dict[data_id]).__name__}")
+            log.debug(
+                f"packet {self.packet_id}: data_id = {data_id}, decoder = {'None' if data_id not in self.decoder_id_dict else type(self.decoder_id_dict[data_id]).__name__}"
+            )
             if data_id in self.rbl_id_dict:
                 break
 


### PR DESCRIPTION
This is needed to process LEGEND data with -both- ged/spm AND muon veto data in it.

Also solves a previously unnoticed problem that auto-setup of buffers needs to account for the fact that different keys from one decoder might need different buffers.