### PR TITLE
Created a temporary table for buffer_processor to write to file during build_raw

### DIFF
--- a/src/pygama/raw/buffer_processor/lh5_buffer_processor.py
+++ b/src/pygama/raw/buffer_processor/lh5_buffer_processor.py
@@ -105,7 +105,7 @@ def lh5_buffer_processor(
     if isinstance(out_spec, dict):
         RawBufferLibrary(json_dict=out_spec)
 
-    # Write everything in the raw file to the new file, process appropriately
+    # Write everything in the raw file to the new file, check for proc_spec under either the group name, out_name, or the name
     for tb in lh5_tables:
         lgdo_obj, _ = raw_store.read_object(f"{tb}", lh5_file)
 
@@ -131,9 +131,9 @@ def lh5_buffer_processor(
                         out_name=out_name,
                         proc_spec=out_spec[decoder_name][group_name]["proc_spec"],
                     )
-                    buffer_processor(rb)
+                    tmp_table = buffer_processor(rb)
                     # Update the lgdo_obj to be written to the processed file
-                    lgdo_obj = rb.lgdo
+                    lgdo_obj = tmp_table
                 else:
                     pass
 
@@ -147,9 +147,9 @@ def lh5_buffer_processor(
                         out_name=out_name,
                         proc_spec=out_spec[decoder_name][out_name]["proc_spec"],
                     )
-                    buffer_processor(rb)
+                    tmp_table = buffer_processor(rb)
                     # Update the lgdo_obj to be written to the processed file
-                    lgdo_obj = rb.lgdo
+                    lgdo_obj = tmp_table
                 else:
                     pass
 
@@ -183,9 +183,9 @@ def lh5_buffer_processor(
                             list(out_spec[decoder_name].keys())[0]
                         ]["proc_spec"],
                     )
-                    buffer_processor(rb)
+                    tmp_table = buffer_processor(rb)
                     # Update the lgdo_obj to be written to the processed file
-                    lgdo_obj = rb.lgdo
+                    lgdo_obj = tmp_table
                 else:
                     pass
             else:

--- a/src/pygama/raw/raw_buffer.py
+++ b/src/pygama/raw/raw_buffer.py
@@ -452,14 +452,14 @@ def write_to_lh5_and_clear(
         # If a proc_spec if present for this RawBuffer, process that data and then write to the file!
         if rb.proc_spec is not None:
             # Perform the processing as requested in the `proc_spec` from `out_spec` in build_raw
-            table_to_write = buffer_processor(rb)
+            lgdo_to_write = buffer_processor(rb)
         else:
-            table_to_write = rb.lgdo
+            lgdo_to_write = rb.lgdo
 
         # write if requested...
         if filename != "":
             lh5_store.write_object(
-                table_to_write,
+                lgdo_to_write,
                 rb.out_name,
                 filename,
                 group=group,

--- a/src/pygama/raw/raw_buffer.py
+++ b/src/pygama/raw/raw_buffer.py
@@ -452,12 +452,14 @@ def write_to_lh5_and_clear(
         # If a proc_spec if present for this RawBuffer, process that data and then write to the file!
         if rb.proc_spec is not None:
             # Perform the processing as requested in the `proc_spec` from `out_spec` in build_raw
-            buffer_processor(rb)
+            table_to_write = buffer_processor(rb)
+        else:
+            table_to_write = rb.lgdo
 
         # write if requested...
         if filename != "":
             lh5_store.write_object(
-                rb.lgdo,
+                table_to_write,
                 rb.out_name,
                 filename,
                 group=group,

--- a/tests/raw/buffer_processor/test_buffer_processor.py
+++ b/tests/raw/buffer_processor/test_buffer_processor.py
@@ -575,7 +575,7 @@ def test_proc_geds_no_proc_spms(lgnd_test_data):
     }
     """
 
-    # Do the data procming
+    # Do the data processing
     build_raw(in_stream=daq_file, out_spec=out_spec, overwrite=True)
 
     # Grab the proc_spec after keylist expansion from build_raw
@@ -612,8 +612,8 @@ def test_proc_geds_no_proc_spms(lgnd_test_data):
         # Read in the presummed rate from the config file to modify the clock rate later
         group_name = raw_group.split("/raw")[0]
         pass_flag = False
-        # If the user passes procming on a group, then the presum_rate is just 1 and there is no windowing
-        # If a group_name is absent from the jsonfile, then that means no procming was performed
+        # If the user passes processing on a group, then the presum_rate is just 1 and there is no windowing
+        # If a group_name is absent from the jsonfile, then that means no processing was performed
         if group_name not in jsonfile.keys():
             presum_rate = 1
             window_start_index = 0
@@ -835,7 +835,7 @@ def test_buffer_processor_multiple_keys(lgnd_test_data):
         }
     }
     """
-    # Do the data procming
+    # Do the data processing
     build_raw(in_stream=daq_file, out_spec=out_spec, overwrite=True)
 
     # Grab the proc_spec after keylist expansion from build_raw
@@ -875,8 +875,8 @@ def test_buffer_processor_multiple_keys(lgnd_test_data):
         group_name = raw_group.split("/raw")[0]
 
         pass_flag = False
-        # If the user passes procming on a group, then the presum_rate is just 1 and there is no windowing
-        # If the group_name is absent from the jsonfile, then no procming was done
+        # If the user passes processing on a group, then the presum_rate is just 1 and there is no windowing
+        # If the group_name is absent from the jsonfile, then no processing was done
         if group_name not in jsonfile.keys():
             presum_rate = 1
             window_start_index = 0
@@ -1088,3 +1088,293 @@ def test_buffer_processor_all_pass(lgnd_test_data):
                         proc_df = proc[obj].get_dataframe([str(sub_obj)])
 
             assert raw_df.equals(proc_df)
+
+
+# check that packet indexes match in verification test
+def test_buffer_processor_drop_waveform_small_buffer(lgnd_test_data):
+
+    # Set up I/O files, including config
+    daq_file = lgnd_test_data.get_path("orca/fc/L200-comm-20220519-phy-geds.orca")
+    processed_file = daq_file.replace(
+        "L200-comm-20220519-phy-geds.orca",
+        "L200-comm-20220519-phy-geds-key-test_proc.lh5",
+    )
+    raw_file = daq_file.replace(
+        "L200-comm-20220519-phy-geds.orca", "L200-comm-20220519-phy-geds-key-test.lh5"
+    )
+
+    out_spec = {
+        "ORFlashCamADCWaveformDecoder": {
+            "ch{key}": {
+                "key_list": [0, 1],
+                "out_stream": processed_file + ":{name}",
+                "out_name": "raw",
+                "proc_spec": {
+                    "window": ["waveform", 2000, -1000, "windowed_waveform"],
+                    "dsp_config": {
+                        "outputs": [
+                            "presum_rate",
+                            "presummed_waveform",
+                            "t_sat_lo",
+                            "t_sat_hi",
+                        ],
+                        "processors": {
+                            "presum_rate, presummed_waveform": {
+                                "function": "presum",
+                                "module": "pygama.dsp.processors",
+                                "args": [
+                                    "waveform",
+                                    0,
+                                    "presum_rate",
+                                    "presummed_waveform(shape=len(waveform)/16, period=waveform.period*16, offset=waveform.offset)",
+                                ],
+                                "unit": "ADC",
+                            },
+                            "t_sat_lo, t_sat_hi": {
+                                "function": "saturation",
+                                "module": "pygama.dsp.processors",
+                                "args": ["waveform", 16, "t_sat_lo", "t_sat_hi"],
+                                "unit": "ADC",
+                            },
+                        },
+                    },
+                    "drop": ["waveform"],
+                    "dtype_conv": {
+                        "presummed_waveform/values": "uint32",
+                        "t_sat_lo": "uint16",
+                        "t_sat_hi": "uint16",
+                        "presum_rate": "uint16",
+                    },
+                },
+            },
+            "chan{key}": {
+                "key_list": [3, 4],
+                "out_stream": processed_file + ":{name}",
+                "out_name": "raw",
+            },
+        }
+    }
+
+    copy_out_spec = {
+        "ORFlashCamADCWaveformDecoder": {
+            "ch{key}": {
+                "key_list": [0, 1],
+                "out_stream": raw_file + ":{name}",
+                "out_name": "raw",
+            },
+            "chan{key}": {
+                "key_list": [3, 4],
+                "out_stream": raw_file + ":{name}",
+                "out_name": "raw",
+            },
+        }
+    }
+
+    raw_dsp_config = """
+    {
+        "outputs": ["t_sat_lo", "t_sat_hi"],
+        "processors": {
+            "t_sat_lo, t_sat_hi": {
+                "function": "saturation",
+                "module": "pygama.dsp.processors",
+                "args": ["waveform", 16, "t_sat_lo", "t_sat_hi"],
+                "unit": "ADC"
+                }
+        }
+    }
+    """
+    # Do the data processing
+    build_raw(in_stream=daq_file, out_spec=out_spec, overwrite=True, buffer_size=2)
+
+    # Grab the proc_spec after keylist expansion from build_raw
+    proc_spec = {}
+    for key in out_spec["ORFlashCamADCWaveformDecoder"].keys():
+        if "proc_spec" in out_spec["ORFlashCamADCWaveformDecoder"][key].keys():
+            proc_spec[key] = out_spec["ORFlashCamADCWaveformDecoder"][key].pop(
+                "proc_spec"
+            )
+
+    # Build the unprocessed raw file for comparison
+    build_raw(in_stream=daq_file, out_spec=copy_out_spec, overwrite=True, buffer_size=2)
+
+    lh5_tables = lgdo.ls(raw_file)
+    # check if group points to raw data; sometimes 'raw' is nested, e.g g024/raw
+    for i, tb in enumerate(lh5_tables):
+        if "raw" not in tb and lgdo.ls(raw_file, f"{tb}/raw"):
+            lh5_tables[i] = f"{tb}/raw"
+        elif not lgdo.ls(raw_file, tb):
+            del lh5_tables[i]
+
+    jsonfile = proc_spec
+
+    sto = lgdo.LH5Store()
+
+    for raw_group in lh5_tables:
+
+        # First, check the packet ids
+        raw_packet_ids, _ = sto.read_object(str(raw_group) + "/packet_id", raw_file)
+        processed_packet_ids, _ = sto.read_object(
+            str(raw_group) + "/packet_id", processed_file
+        )
+
+        assert np.array_equal(raw_packet_ids.nda, processed_packet_ids.nda)
+
+        # Read in the presummed rate from the config file to modify the clock rate later
+        group_name = raw_group.split("/raw")[0]
+
+        pass_flag = False
+        # If the user passes processing on a group, then the presum_rate is just 1 and there is no windowing
+        # If the group_name is absent from the jsonfile, then no processing was done
+        if group_name not in jsonfile.keys():
+            presum_rate = 1
+            window_start_index = 0
+            window_end_index = 0
+            pass_flag = True
+        else:
+            presum_rate_string = jsonfile[group_name]["dsp_config"]["processors"][
+                "presum_rate, presummed_waveform"
+            ]["args"][3]
+            presum_rate_start_idx = presum_rate_string.find("/") + 1
+            presum_rate_end_idx = presum_rate_string.find(",")
+            presum_rate = int(
+                presum_rate_string[presum_rate_start_idx:presum_rate_end_idx]
+            )
+
+            # This needs to be overwritten with the correct windowing values set in buffer_processor.py
+            window_start_index = int(jsonfile[group_name]["window"][1])
+            window_end_index = int(jsonfile[group_name]["window"][2])
+
+        # Read in the waveforms
+        raw_packet_waveform_values = sto.read_object(
+            str(raw_group) + "/waveform/values", raw_file
+        )
+        if pass_flag:
+            presummed_packet_waveform_values = sto.read_object(
+                str(raw_group) + "/waveform/values", processed_file
+            )
+            windowed_packet_waveform_values = sto.read_object(
+                str(raw_group) + "/waveform/values", processed_file
+            )
+        else:
+            presummed_packet_waveform_values = sto.read_object(
+                str(raw_group) + "/presummed_waveform/values", processed_file
+            )
+            windowed_packet_waveform_values = sto.read_object(
+                str(raw_group) + "/windowed_waveform/values", processed_file
+            )
+
+        # Check that the lengths of the waveforms match what we expect
+        assert (
+            len(raw_packet_waveform_values[0].nda[0])
+            // len(presummed_packet_waveform_values[0].nda[0])
+            == presum_rate
+        )
+        assert len(raw_packet_waveform_values[0].nda[0]) == len(
+            windowed_packet_waveform_values[0].nda[0]
+        ) + np.abs(window_start_index) + np.abs(window_end_index)
+        assert isinstance(windowed_packet_waveform_values[0].nda[0][0], np.uint16)
+
+        # Check that the waveforms match
+        # These are the channels that should be unprocessed
+        if group_name == "chan3" or group_name == "chan4":
+            raw_packet_waveform_values, _ = sto.read_object(
+                str(raw_group) + "/waveform/values", raw_file
+            )
+            windowed_packet_waveform_values, _ = sto.read_object(
+                str(raw_group) + "/waveform/values", processed_file
+            )
+            assert np.array_equal(
+                raw_packet_waveform_values.nda, windowed_packet_waveform_values.nda
+            )
+        else:
+            raw_packet_waveform_values, _ = sto.read_object(
+                str(raw_group) + "/waveform/values", raw_file
+            )
+            windowed_packet_waveform_values, _ = sto.read_object(
+                str(raw_group) + "/windowed_waveform/values", processed_file
+            )
+            assert np.array_equal(
+                raw_packet_waveform_values.nda[:, window_start_index:window_end_index],
+                windowed_packet_waveform_values.nda,
+            )
+
+        # Check the t0 and dts are what we expect
+        raw_packet_waveform_t0s, _ = sto.read_object(
+            str(raw_group) + "/waveform/t0", raw_file
+        )
+        raw_packet_waveform_dts, _ = sto.read_object(
+            str(raw_group) + "/waveform/dt", raw_file
+        )
+
+        if pass_flag:
+            windowed_packet_waveform_t0s, _ = sto.read_object(
+                str(raw_group) + "/waveform/t0", processed_file
+            )
+            presummed_packet_waveform_t0s, _ = sto.read_object(
+                str(raw_group) + "/waveform/t0", processed_file
+            )
+        else:
+            windowed_packet_waveform_t0s, _ = sto.read_object(
+                str(raw_group) + "/windowed_waveform/t0", processed_file
+            )
+            presummed_packet_waveform_t0s, _ = sto.read_object(
+                str(raw_group) + "/presummed_waveform/t0", processed_file
+            )
+
+        # Check that the t0s match what we expect, with the correct units
+        assert (
+            raw_packet_waveform_t0s.nda[0]
+            == windowed_packet_waveform_t0s.nda[0]
+            - raw_packet_waveform_dts.nda[0] * window_start_index
+        )
+        assert (
+            windowed_packet_waveform_t0s.attrs["units"]
+            == raw_packet_waveform_t0s.attrs["units"]
+        )
+        assert raw_packet_waveform_t0s.nda[0] == presummed_packet_waveform_t0s.nda[0]
+        assert (
+            presummed_packet_waveform_t0s.attrs["units"]
+            == raw_packet_waveform_t0s.attrs["units"]
+        )
+
+        if pass_flag:
+
+            presummed_packet_waveform_dts, _ = sto.read_object(
+                str(raw_group) + "/waveform/dt", processed_file
+            )
+        else:
+
+            presummed_packet_waveform_dts, _ = sto.read_object(
+                str(raw_group) + "/presummed_waveform/dt", processed_file
+            )
+
+            # Check that the presum_rate is correctly identified
+            presum_rate_from_file, _ = sto.read_object(
+                str(raw_group) + "/presum_rate", processed_file
+            )
+            assert presum_rate_from_file.nda[0] == presum_rate
+        # Check that the dts match what we expect, with the correct units
+        assert (
+            raw_packet_waveform_dts.nda[0]
+            == presummed_packet_waveform_dts.nda[0] / presum_rate
+        )
+
+        # check that the t_lo_sat and t_sat_hi are correct
+        if not pass_flag:
+            wf_table, _ = sto.read_object(str(raw_group), raw_file)
+            pc, _, wf_out = bpc(wf_table, json.loads(raw_dsp_config))
+            pc.execute()
+            raw_sat_lo = wf_out["t_sat_lo"]
+            raw_sat_hi = wf_out["t_sat_hi"]
+
+            proc_sat_lo, _ = sto.read_object(
+                str(raw_group) + "/t_sat_lo", processed_file
+            )
+
+            proc_sat_hi, _ = sto.read_object(
+                str(raw_group) + "/t_sat_hi", processed_file
+            )
+
+            assert np.array_equal(raw_sat_lo.nda, proc_sat_lo.nda)
+            assert np.array_equal(raw_sat_hi.nda, proc_sat_hi.nda)
+            assert type(proc_sat_lo.nda[0]) == np.uint16

--- a/tests/raw/buffer_processor/test_lh5_buffer_processor.py
+++ b/tests/raw/buffer_processor/test_lh5_buffer_processor.py
@@ -277,7 +277,7 @@ def test_lh5_buffer_processor_file_size_decrease(lgnd_test_data):
             sto.read_object(str(raw_group) + "/waveform/values", raw_file)[0].nda
         )
 
-        # Make sure that we are actually procming the waveforms
+        # Make sure that we are actually processing the waveforms
         raw_packet_waveform_values = sto.read_object(
             str(raw_group) + "/waveform/values", raw_file
         )
@@ -625,8 +625,8 @@ def test_raw_geds_no_proc_spms(lgnd_test_data):
         # Read in the presummed rate from the config file to modify the clock rate later
         group_name = raw_group.split("/raw")[0]
         pass_flag = False
-        # If the user passes procming on a group, then the presum_rate is just 1 and there is no windowing
-        # If a group_name is absent from the jsonfile, then that means no procming was performed
+        # If the user passes processing on a group, then the presum_rate is just 1 and there is no windowing
+        # If a group_name is absent from the jsonfile, then that means no processing was performed
         if group_name not in jsonfile.keys():
             presum_rate = 1
             window_start_index = 0
@@ -844,7 +844,7 @@ def test_lh5_buffer_processor_multiple_keys(lgnd_test_data):
     # Build the raw file
     build_raw(in_stream=daq_file, out_spec=raw_out_spec, overwrite=True)
 
-    # Do the data procming on the raw file
+    # Do the data processing on the raw file
     lh5_buffer_processor(
         lh5_raw_file_in=raw_file, overwrite=True, out_spec=proc_out_spec
     )
@@ -883,8 +883,8 @@ def test_lh5_buffer_processor_multiple_keys(lgnd_test_data):
         group_name = raw_group.split("/raw")[0]
 
         pass_flag = False
-        # If the user passes procming on a group, then the presum_rate is just 1 and there is no windowing
-        # If the group_name is absent from the jsonfile, then no procming was done
+        # If the user passes processing on a group, then the presum_rate is just 1 and there is no windowing
+        # If the group_name is absent from the jsonfile, then no processing was done
         if group_name not in jsonfile.keys():
             presum_rate = 1
             window_start_index = 0


### PR DESCRIPTION
<!---

Before submitting a pull request, please make sure you've read and understood the pygama developer's guide: https://pygama.readthedocs.io/en/latest/developer.html. In particular, do not forget to:

- Conform to our coding conventions
- Update existing or add new tests
- Update existing or add new documentation
- Address any issue reported by GitHub checks

--->
This update fixes the unwanted behavior of the `buffer_processor` dropping fields in a buffer before `build_raw` is done writing to the buffer. The major change is that `buffer_processor.py` now returns a temporary `lgdo.Table` that shares columns with an `rb.lgdo`, and all processing is done on this temporary table instead of directly on the `rb.lgdo`. 