### PR TITLE
Added adc_bit_depth to an lgdo waveform's values attributes

### DIFF
--- a/src/pygama/lgdo/waveform_table.py
+++ b/src/pygama/lgdo/waveform_table.py
@@ -33,7 +33,7 @@ class WaveformTable(Table):
       waveforms values may be either an LGDO :class:`.ArrayOfEqualSizedArrays`\
       ``<1,1>`` or as an LGDO :class:`.VectorOfVectors` that supports
       waveforms of unequal length. Can optionally be given a ``units``
-      attribute.
+      attribute, as well as an ``adc_bit_depth`` attribute.
 
     Note
     ----
@@ -50,6 +50,7 @@ class WaveformTable(Table):
         dt_units: str = None,
         values: ArrayOfEqualSizedArrays | VectorOfVectors | np.ndarray = None,
         values_units: str = None,
+        values_adc_bit_depth: int = None,
         wf_len: int = None,
         dtype: np.dtype = None,
         attrs: dict[str, Any] = None,
@@ -81,6 +82,8 @@ class WaveformTable(Table):
         values_units
             units for the waveform values. If not ``None`` and `values` is an
             LGDO :class:`.Array`, overrides what's in `values`.
+        values_adc_bit_depth
+            an integer for storing the ADC bit depth used to record this waveform
         wf_len
             The length of the waveforms in each entry of a table. If ``None``
             (the default), unequal lengths are assumed and
@@ -173,6 +176,8 @@ class WaveformTable(Table):
                 values = ArrayOfEqualSizedArrays(dims=(1, 1), nda=nda)
         if values_units is not None:
             values.attrs["units"] = f"{values_units}"
+        if values_adc_bit_depth is not None:
+            values.attrs["adc_bit_depth"] = values_adc_bit_depth
 
         col_dict = {}
         col_dict["t0"] = t0
@@ -188,9 +193,17 @@ class WaveformTable(Table):
     def values_units(self) -> str:
         return self.values.attrs.get("units", None)
 
+    @property
+    def values_adc_bit_depth(self) -> str:
+        return self.values.attrs.get("adc_bit_depth", None)
+
     @values_units.setter
     def values_units(self, units) -> None:
         self.values.attrs["units"] = f"{units}"
+
+    @values_adc_bit_depth.setter
+    def values_adc_bit_depth(self, adc_bit_depth) -> None:
+        self.values.attrs["adc_bit_depth"] = adc_bit_depth
 
     @property
     def wf_len(self) -> int:

--- a/src/pygama/raw/data_decoder.py
+++ b/src/pygama/raw/data_decoder.py
@@ -138,12 +138,13 @@ class DataDecoder:
             # get datatype for complex objects
             datatype = attrs.pop("datatype")
 
-            # waveforms: must have attributes t0_units, dt, dt_units, wf_len
+            # waveforms: must have attributes t0_units, dt, dt_units, wf_len, adc_bit_depth
             if datatype == "waveform":
                 t0_units = attrs.pop("t0_units")
                 dt = attrs.pop("dt")
                 dt_units = attrs.pop("dt_units")
                 wf_len = attrs.pop("wf_len")
+                adc_bit_depth = attrs.pop("adc_bit_depth")
                 wf_table = lgdo.WaveformTable(
                     size=size,
                     t0=0,
@@ -151,6 +152,7 @@ class DataDecoder:
                     dt=dt,
                     dt_units=dt_units,
                     wf_len=wf_len,
+                    values_adc_bit_depth=adc_bit_depth,
                     dtype=dtype,
                     attrs=attrs,
                 )

--- a/src/pygama/raw/fc/fc_event_decoder.py
+++ b/src/pygama/raw/fc/fc_event_decoder.py
@@ -126,6 +126,7 @@ fc_decoded_values = {
         "dt": 16,  # override if a different clock rate is used
         "dt_units": "ns",
         "t0_units": "ns",
+        "adc_bit_depth": 16,  # override if a different ADC bit depth is used
     },
 }
 

--- a/src/pygama/raw/orca/orca_digitizers.py
+++ b/src/pygama/raw/orca/orca_digitizers.py
@@ -51,6 +51,7 @@ class ORSIS3302DecoderForEnergy(OrcaDecoder):
                 "dt": 10,  # override if a different clock rate is used
                 "dt_units": "ns",
                 "t0_units": "ns",
+                "adc_bit_depth": 16,  # override if a different ADC bit depth is used
             },
         }
         self.decoded_values = {}
@@ -308,6 +309,7 @@ class ORSIS3316WaveformDecoder(OrcaDecoder):
                 "dt": 8,  # override if a different clock rate is used
                 "dt_units": "ns",
                 "t0_units": "ns",
+                "adc_bit_depth": 16,  # override if a different ADC bit depth is used
             },
         }
 

--- a/tests/raw/fc/test_fc_event_decoder.py
+++ b/tests/raw/fc/test_fc_event_decoder.py
@@ -109,3 +109,4 @@ def test_values(event_rbkd, fcio_obj):
         assert tbl["waveform"]["t0"].nda[loc] == 0
         assert tbl["waveform"]["dt"].nda[loc] == 16
         assert np.array_equal(tbl["waveform"]["values"].nda[loc], fc.traces[ch])
+        assert tbl["waveform"]["values"].attrs["adc_bit_depth"] == 16


### PR DESCRIPTION
<!---

Before submitting a pull request, please make sure you've read and understood the pygama developer's guide: https://pygama.readthedocs.io/en/latest/developer.html. In particular, do not forget to:

- Conform to our coding conventions
- Update existing or add new tests
- Update existing or add new documentation
- Address any issue reported by GitHub checks

--->

Added an attribute to `lgdo.waveform.values` that stores the ADC bit depth provided. I also changed the `raw` data decoders to be able to write the `adc_bit_depth`, and also I've added this to `dsp` so that processors can access the bit depth, as requested in #418  