### PR TITLE
Remove hardcoded value from test for `ORRunDecoderForRun`

### DIFF
--- a/tests/raw/orca/test_or_run_decoder_for_run.py
+++ b/tests/raw/orca/test_or_run_decoder_for_run.py
@@ -17,7 +17,7 @@ def run_rbkd(orca_stream):
     orca_stream.close_stream()  # avoid leaving file open
 
     # assert correct type for ORRunDecoderForRun
-    assert (this_packet[0] >> 18) == 7
+    assert (this_packet[0] >> 18) == orca_stream.header["dataDescription"]["ORRunModel"]["Run"]["dataId"]
 
     # assert that it worked and the buffer is full
     assert decoder.decode_packet(packet=this_packet, packet_id=1, rbl=rbkd)

--- a/tests/raw/orca/test_or_run_decoder_for_run.py
+++ b/tests/raw/orca/test_or_run_decoder_for_run.py
@@ -17,7 +17,9 @@ def run_rbkd(orca_stream):
     orca_stream.close_stream()  # avoid leaving file open
 
     # assert correct type for ORRunDecoderForRun
-    assert (this_packet[0] >> 18) == orca_stream.header["dataDescription"]["ORRunModel"]["Run"]["dataId"] >> 18
+    assert (this_packet[0] >> 18) == orca_stream.header["dataDescription"][
+        "ORRunModel"
+    ]["Run"]["dataId"] >> 18
 
     # assert that it worked and the buffer is full
     assert decoder.decode_packet(packet=this_packet, packet_id=1, rbl=rbkd)

--- a/tests/raw/orca/test_or_run_decoder_for_run.py
+++ b/tests/raw/orca/test_or_run_decoder_for_run.py
@@ -17,7 +17,7 @@ def run_rbkd(orca_stream):
     orca_stream.close_stream()  # avoid leaving file open
 
     # assert correct type for ORRunDecoderForRun
-    assert (this_packet[0] >> 18) == orca_stream.header["dataDescription"]["ORRunModel"]["Run"]["dataId"]
+    assert (this_packet[0] >> 18) == orca_stream.header["dataDescription"]["ORRunModel"]["Run"]["dataId"] >> 18
 
     # assert that it worked and the buffer is full
     assert decoder.decode_packet(packet=this_packet, packet_id=1, rbl=rbkd)


### PR DESCRIPTION
Small edit to the test for `ORRunDecoderForRun`. I initially assumed the data ID was the same for every file, but that doesn't seem to be the case (in different raw ORCA files that I've looked at, the dataId for, e.g., the ORRunModel can be different, as is the case for other data types). I am now checking if the data ID matches what is expected from the header file, instead of assuming a value.

<!---

Before submitting a pull request, please make sure you've read and understood the pygama developer's guide: https://pygama.readthedocs.io/en/latest/developer.html. In particular, do not forget to:

- Conform to our coding conventions
- Update existing or add new tests
- Update existing or add new documentation
- Address any issue reported by GitHub checks

--->
