### PR TITLE
Fix for scipy bug/change

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ install_requires =
     pyfcutils
     pyfftw
     scikit-learn
-    scipy
+    scipy>=1.8.1
     tables
     tqdm
 python_requires = >=3.9

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ install_requires =
     pyfcutils
     pyfftw
     scikit-learn
-    scipy>=1.8.1
+    scipy>=1.0.1
     tables
     tqdm
 python_requires = >=3.9

--- a/src/pygama/pargen/energy_optimisation.py
+++ b/src/pygama/pargen/energy_optimisation.py
@@ -1346,7 +1346,7 @@ class BayesianOptimizer:
                 method="L-BFGS-B",
             )
             if response.fun < min_ei:
-                min_ei = response.fun[0]
+                min_ei = response.fun
                 x_optimal = [
                     y.round(dim.rounding) for y, dim in zip(response.x, self.dims)
                 ]

--- a/src/pygama/pargen/energy_optimisation.py
+++ b/src/pygama/pargen/energy_optimisation.py
@@ -1533,7 +1533,7 @@ class BayesianOptimizer:
             points = np.arange(self.dims[0].min_val, self.dims[0].max_val, 0.1)
             ys = np.zeros_like(points)
             for i, point in enumerate(points):
-                ys[i] = self._acquisition_function(np.array([point]).reshape(1, -1)[0])
+                ys[i] = self.acq_function(np.array([point]).reshape(1, -1)[0])
             fig = plt.figure()
             plt.plot(points, ys)
             plt.scatter(np.array(self.x_init), np.array(self.y_init))
@@ -1575,7 +1575,7 @@ class BayesianOptimizer:
 
             j = 0
             for i, _ in np.ndenumerate(out_grid):
-                out_grid[i] = self._acquisition_function(points[j])
+                out_grid[i] = self.acq_function(points[j])
                 j += 1
 
             fig = plt.figure()

--- a/src/pygama/pargen/energy_optimisation.py
+++ b/src/pygama/pargen/energy_optimisation.py
@@ -1290,9 +1290,9 @@ class BayesianOptimizer:
         mean_y = self.gauss_pr.predict(self.x_init)
         min_mean_y = np.min(mean_y)
         z = (mean_y_new[0] - min_mean_y - 1) / (sigma_y_new[0] + 1e-9)
-        exp_imp = (mean_y_new[0] - min_mean_y - 1) * norm.cdf(
-            z
-        ) + sigma_y_new[0] * norm.pdf(z)
+        exp_imp = (mean_y_new[0] - min_mean_y - 1) * norm.cdf(z) + sigma_y_new[
+            0
+        ] * norm.pdf(z)
         return exp_imp
 
     def _get_ucb(self, x_new):
@@ -1308,7 +1308,6 @@ class BayesianOptimizer:
             np.array([x_new]), return_std=True
         )
         return mean_y_new[0] - self.lambda_param * sigma_y_new[0]
-
 
     def _get_next_probable_point(self):
         min_ei = float(sys.maxsize)
@@ -1410,8 +1409,14 @@ class BayesianOptimizer:
             )
             self.prev_x = self.current_x
 
-        self.best_samples_ = pd.concat([self.best_samples_,
-            pd.DataFrame({"x": self.optimal_x, "y": self.y_min, "ei": self.optimal_ei})], ignore_index=True
+        self.best_samples_ = pd.concat(
+            [
+                self.best_samples_,
+                pd.DataFrame(
+                    {"x": self.optimal_x, "y": self.y_min, "ei": self.optimal_ei}
+                ),
+            ],
+            ignore_index=True,
         )
 
     def get_best_vals(self):

--- a/src/pygama/pargen/energy_optimisation.py
+++ b/src/pygama/pargen/energy_optimisation.py
@@ -1345,7 +1345,7 @@ class BayesianOptimizer:
                 bounds=[(dim.min_val, dim.max_val) for dim in self.dims],
                 method="L-BFGS-B",
             )
-            if response.fun[0] < min_ei:
+            if response.fun < min_ei:
                 min_ei = response.fun[0]
                 x_optimal = [
                     y.round(dim.rounding) for y, dim in zip(response.x, self.dims)


### PR DESCRIPTION
Erin found a bug yesterday at nersc where the scipy minimize function was returning a float instead of an array. I managed to recreate a minimal version of this:

```python
In [1]: import numpy as np

In [2]: from scipy.optimize import minimize

In [3]: import scipy

In [4]: scipy.__version__
Out[4]: '1.7.1'

In [5]: def test_func(x):
   ...:    return np.array([x**2]).reshape(1,)
   ...: 

In [6]: response = minimize(fun=test_func, x0=np.array([0.5]).reshape(1,), bounds=[(-1, 1)],method="L-BFGS-B")

In [7]: response.fun
Out[7]: array([7.70371947e-18])

In [1]: import numpy as np

In [2]: from scipy.optimize import minimize

In [3]: import scipy

In [4]: scipy.__version__
Out[4]: '1.10.0'

In [5]: def test_func(x):
   ...:     return np.array([x**2]).reshape(1,)
   ...: 

In [6]: response = minimize(fun=test_func, x0=np.array([0.5]).reshape(1,), bounds=[(-1, 1)],method="L-BFGS-B")

In [7]: response.fun
Out[7]: 7.703719366273389e-18
```

This seems to have been caused by a change in scipy version 1.8 where arrays of shape (1,) are now cast to floats. To fix this I have changed the BayesianOptimiser's acquisition functions so that they will now output a float in all cases. I have also added a minimum version of scipy at 1.0.1 as this is when  OptimiseResult was added. I'm not sure if any other parts of pygama need a newer version.