### PR TITLE
Fixed bug in the `overwrite` option in `write_object`

### DIFF
--- a/src/pygama/lgdo/lh5_store.py
+++ b/src/pygama/lgdo/lh5_store.py
@@ -97,7 +97,7 @@ class LH5Store:
 
     def gimme_group(
         self,
-        group: str,
+        group: str | h5py.Group,
         base_group: h5py.Group,
         grp_attrs: dict[str, Any] = None,
         overwrite: bool = False,
@@ -727,6 +727,14 @@ class LH5Store:
             group = self.gimme_group(
                 name, group, grp_attrs=obj.attrs, overwrite=(wo_mode == "o")
             )
+            # If the mode is overwrite, then we need to peek into the file's table's existing fields
+            # If we are writing a new table to the group that does not contain an old field, we should delete that old field from the file
+            if wo_mode == "o":
+                # Find the old keys in the group that are not present in the new table's keys, then delete them
+                for key in list(set(group.keys()) - set(obj.keys())):
+                    log.debug(f"{key} is not present in new table, deleting field")
+                    del group[key]
+
             for field in obj.keys():
                 self.write_object(
                     obj[field],


### PR DESCRIPTION
<!---

Before submitting a pull request, please make sure you've read and understood the pygama developer's guide: https://pygama.readthedocs.io/en/latest/developer.html. In particular, do not forget to:

- Conform to our coding conventions
- Update existing or add new tests
- Update existing or add new documentation
- Address any issue reported by GitHub checks

--->

This pull request fixes the bug that I mentioned in issue #176. This PR implements the correct behavior: a second `LH5Store.write_object` call with the `wo_mode=overwrite` will now completely delete a field from a table if that field is not present in the second table that is overwriting the first. 

I've also implemented some unit tests to show that this behavior is achieved, as well as some tests for the `write_start` argument of `LH5Store.write_object` that will increase our test coverage.