### PR TITLE
Fix hardcoded dtype for output buffer

### DIFF
--- a/src/pygama/dsp/processing_chain.py
+++ b/src/pygama/dsp/processing_chain.py
@@ -1250,7 +1250,7 @@ class UnitConversionManager(ProcessorManager):
     def convert_int(buf_in, offset_in, offset_out, period_ratio):  # noqa: N805
         tmp = (buf_in + offset_in) * period_ratio - offset_out
         ret = round(tmp)
-        if np.abs(tmp-ret)<1.e-5:
+        if np.abs(tmp - ret) < 1.0e-5:
             return ret
         else:
             raise DSPFatal(f"Cannot convert to integer")

--- a/src/pygama/dsp/processing_chain.py
+++ b/src/pygama/dsp/processing_chain.py
@@ -1257,7 +1257,7 @@ class UnitConversionManager(ProcessorManager):
 
         from_buffer, from_grid = var._buffer[0]
         period_ratio = from_grid.get_period(unit.period)
-        self.out_buffer = np.zeros_like(from_buffer, dtype="float64")
+        self.out_buffer = np.zeros_like(from_buffer, dtype=var.dtype)
         self.args = [
             from_buffer,
             from_grid.get_offset(),

--- a/src/pygama/dsp/processing_chain.py
+++ b/src/pygama/dsp/processing_chain.py
@@ -1253,7 +1253,7 @@ class UnitConversionManager(ProcessorManager):
         if np.abs(tmp - ret) < 1.0e-5:
             return ret
         else:
-            raise DSPFatal(f"Cannot convert to integer")
+            raise DSPFatal("Cannot convert to integer")
 
     def __init__(self, var: ProcChainVar, unit: str | Unit) -> None:
         # reference back to our processing chain

--- a/src/pygama/dsp/processing_chain.py
+++ b/src/pygama/dsp/processing_chain.py
@@ -1245,7 +1245,7 @@ class UnitConversionManager(ProcessorManager):
     @vectorize(nopython=True, cache=True)
     def convert(buf_in, offset_in, offset_out, period_ratio):  # noqa: N805
         return (buf_in + offset_in) * period_ratio - offset_out
-    
+
     @vectorize(nopython=True, cache=True)
     def convert_int(buf_in, offset_in, offset_out, period_ratio):  # noqa: N805
         tmp = (buf_in + offset_in) * period_ratio - offset_out

--- a/src/pygama/dsp/processing_chain.py
+++ b/src/pygama/dsp/processing_chain.py
@@ -1245,12 +1245,24 @@ class UnitConversionManager(ProcessorManager):
     @vectorize(nopython=True, cache=True)
     def convert(buf_in, offset_in, offset_out, period_ratio):  # noqa: N805
         return (buf_in + offset_in) * period_ratio - offset_out
+    
+    @vectorize(nopython=True, cache=True)
+    def convert_int(buf_in, offset_in, offset_out, period_ratio):  # noqa: N805
+        tmp = (buf_in + offset_in) * period_ratio - offset_out
+        ret = round(tmp)
+        if np.abs(tmp-ret)<1.e-5:
+            return ret
+        else:
+            raise DSPFatal(f"Cannot convert to integer")
 
     def __init__(self, var: ProcChainVar, unit: str | Unit) -> None:
         # reference back to our processing chain
         self.proc_chain = var.proc_chain
         # callable function used to process data
-        self.processor = UnitConversionManager.convert
+        if np.issubdtype(var.dtype, np.integer):
+            self.processor = UnitConversionManager.convert_int
+        else
+            self.processor = UnitConversionManager.convert
         # list of parameters prior to converting to internal representation
         self.params = [var, unit]
         self.kw_params = {}

--- a/src/pygama/dsp/processing_chain.py
+++ b/src/pygama/dsp/processing_chain.py
@@ -1261,7 +1261,7 @@ class UnitConversionManager(ProcessorManager):
         # callable function used to process data
         if np.issubdtype(var.dtype, np.integer):
             self.processor = UnitConversionManager.convert_int
-        else
+        else:
             self.processor = UnitConversionManager.convert
         # list of parameters prior to converting to internal representation
         self.params = [var, unit]


### PR DESCRIPTION
The dtype for the UnitConversionManager out_buffer was hardcoded to be a float64, causing bugs with some processors. This is fixed by changing the dtype to be var.dtype.

<!---

Before submitting a pull request, please make sure you've read and understood the pygama developer's guide: https://pygama.readthedocs.io/en/latest/developer.html. In particular, do not forget to:

- Conform to our coding conventions
- Update existing or add new tests
- Update existing or add new documentation
- Address any issue reported by GitHub checks

--->
