### PR TITLE
Option to pass filter coefficients to DPLMS processor

### DIFF
--- a/src/pygama/dsp/processors/dplms.py
+++ b/src/pygama/dsp/processors/dplms.py
@@ -11,13 +11,13 @@ from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
 
 def dplms(
     length: int,
-    noise_mat: list = [],
-    reference: list = [],
-    a1: float = 1.0,
-    a2: float = 1.0,
-    a3: float = 1.0,
-    ff: int = 1,
-    coefficients: list = [],
+    noise_mat: list,
+    reference: list,
+    a1: float,
+    a2: float,
+    a3: float,
+    ff: int,
+    coefficients: list,
 ) -> Callable:
     """Calculate and apply an optimum DPLMS filter to the waveform.
 

--- a/src/pygama/dsp/processors/dplms.py
+++ b/src/pygama/dsp/processors/dplms.py
@@ -17,7 +17,7 @@ def dplms(
     a2: float = 1.0,
     a3: float = 1.0,
     ff: int = 1,
-    coefficients: list = []
+    coefficients: list = [],
 ) -> Callable:
     """Calculate and apply an optimum DPLMS filter to the waveform.
 
@@ -74,12 +74,12 @@ def dplms(
 
     if length <= 0:
         raise DSPFatal("The length of the filter must be positive")
-    
+
     if len(coefficients) > 0:
-        
+
         if length != len(coefficients):
             raise DSPFatal("The length and the provided filter are not matching")
-            
+
         x = np.array(coefficients)
     else:
         noise_mat = np.array(noise_mat)
@@ -97,13 +97,19 @@ def dplms(
             raise DSPFatal("The penalized coefficient for the noise must be positive")
 
         if a2 <= 0:
-            raise DSPFatal("The penalized coefficient for the reference must be positive")
+            raise DSPFatal(
+                "The penalized coefficient for the reference must be positive"
+            )
 
         if a3 <= 0:
-            raise DSPFatal("The penalized coefficient for the zero area must be positive")
+            raise DSPFatal(
+                "The penalized coefficient for the zero area must be positive"
+            )
 
         if ff <= 0:
-            raise DSPFatal("The penalized coefficient for the ref matrix must be positive")
+            raise DSPFatal(
+                "The penalized coefficient for the ref matrix must be positive"
+            )
 
         # reference matrix
         ssize = len(reference)
@@ -116,9 +122,13 @@ def dplms(
         elif ff == 1:
             ff = [-1, 0, 1]
         else:
-            raise DSPFatal("The penalized coefficient for the ref matrix must be 0 or 1")
+            raise DSPFatal(
+                "The penalized coefficient for the ref matrix must be 0 or 1"
+            )
         for i in ff:
-            ref_mat += np.outer(reference[flo + i : fhi + i], reference[flo + i : fhi + i])
+            ref_mat += np.outer(
+                reference[flo + i : fhi + i], reference[flo + i : fhi + i]
+            )
             ref_sig += reference[flo + i : fhi + i]
         ref_mat /= len(ff)
 

--- a/src/pygama/dsp/processors/dplms.py
+++ b/src/pygama/dsp/processors/dplms.py
@@ -10,13 +10,14 @@ from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
 
 
 def dplms(
-    noise_mat: list,
-    reference: list,
     length: int,
-    a1: float,
-    a2: float,
-    a3: float,
-    ff: int,
+    noise_mat: list = [],
+    reference: list = [],
+    a1: float = 1.0,
+    a2: float = 1.0,
+    a3: float = 1.0,
+    ff: int = 1,
+    coefficients: list = []
 ) -> Callable:
     """Calculate and apply an optimum DPLMS filter to the waveform.
 
@@ -25,8 +26,8 @@ def dplms(
     penalized coefficients [DPLMS]_.
 
     .. [DPLMS] V. D'Andrea et al. “Optimum Filter Synthesis with DPLMS
-        Method for Energy Reconstruction” In: arXiv (Sept. 2022).
-        https://arxiv.org/abs/2209.09863
+        Method for Energy Reconstruction” Eur. Phys. J. C 83, 149 (2023).
+        https://doi.org/10.1140/epjc/s10052-023-11299-z
 
     Note
     ----
@@ -50,6 +51,8 @@ def dplms(
         penalized coefficient for the zero area matrix
     ff
         flat top length for the reference signal
+    coefficients
+        filter coefficients (if given avoid filter calculation)
 
 
     JSON Configuration Example
@@ -71,54 +74,61 @@ def dplms(
 
     if length <= 0:
         raise DSPFatal("The length of the filter must be positive")
-
-    noise_mat = np.array(noise_mat)
-    reference = np.array(reference)
-
-    if length != noise_mat.shape[0]:
-        raise DSPFatal(
-            "The length of the filter is not consistent with the noise matrix"
-        )
-
-    if len(reference) <= 0:
-        raise DSPFatal("The length of the reference signal must be positive")
-
-    if a1 <= 0:
-        raise DSPFatal("The penalized coefficient for the noise must be positive")
-
-    if a2 <= 0:
-        raise DSPFatal("The penalized coefficient for the reference must be positive")
-
-    if a3 <= 0:
-        raise DSPFatal("The penalized coefficient for the zero area must be positive")
-
-    if ff <= 0:
-        raise DSPFatal("The penalized coefficient for the ref matrix must be positive")
-
-    # reference matrix
-    ssize = len(reference)
-    flo = int(ssize / 2 - length / 2)
-    fhi = int(ssize / 2 + length / 2)
-    ref_mat = np.zeros([length, length])
-    ref_sig = np.zeros([length])
-    if ff == 0:
-        ff = [0]
-    elif ff == 1:
-        ff = [-1, 0, 1]
+    
+    if len(coefficients) > 0:
+        
+        if length != len(coefficients):
+            raise DSPFatal("The length and the provided filter are not matching")
+            
+        x = np.array(coefficients)
     else:
-        raise DSPFatal("The penalized coefficient for the ref matrix must be 0 or 1")
-    for i in ff:
-        ref_mat += np.outer(reference[flo + i : fhi + i], reference[flo + i : fhi + i])
-        ref_sig += reference[flo + i : fhi + i]
-    ref_mat /= len(ff)
+        noise_mat = np.array(noise_mat)
+        reference = np.array(reference)
 
-    # filter calculation
-    mat = a1 * noise_mat + a2 * ref_mat + a3 * np.ones([length, length])
-    x = np.linalg.solve(mat, ref_sig)
-    y = np.convolve(reference, np.flip(x), mode="valid")
-    maxy = np.amax(y)
-    x /= maxy
-    y /= maxy
+        if length != noise_mat.shape[0]:
+            raise DSPFatal(
+                "The length of the filter is not consistent with the noise matrix"
+            )
+
+        if len(reference) <= 0:
+            raise DSPFatal("The length of the reference signal must be positive")
+
+        if a1 <= 0:
+            raise DSPFatal("The penalized coefficient for the noise must be positive")
+
+        if a2 <= 0:
+            raise DSPFatal("The penalized coefficient for the reference must be positive")
+
+        if a3 <= 0:
+            raise DSPFatal("The penalized coefficient for the zero area must be positive")
+
+        if ff <= 0:
+            raise DSPFatal("The penalized coefficient for the ref matrix must be positive")
+
+        # reference matrix
+        ssize = len(reference)
+        flo = int(ssize / 2 - length / 2)
+        fhi = int(ssize / 2 + length / 2)
+        ref_mat = np.zeros([length, length])
+        ref_sig = np.zeros([length])
+        if ff == 0:
+            ff = [0]
+        elif ff == 1:
+            ff = [-1, 0, 1]
+        else:
+            raise DSPFatal("The penalized coefficient for the ref matrix must be 0 or 1")
+        for i in ff:
+            ref_mat += np.outer(reference[flo + i : fhi + i], reference[flo + i : fhi + i])
+            ref_sig += reference[flo + i : fhi + i]
+        ref_mat /= len(ff)
+
+        # filter calculation
+        mat = a1 * noise_mat + a2 * ref_mat + a3 * np.ones([length, length])
+        x = np.linalg.solve(mat, ref_sig)
+        y = np.convolve(reference, np.flip(x), mode="valid")
+        maxy = np.amax(y)
+        x /= maxy
+        y /= maxy
 
     @guvectorize(
         ["void(float32[:], float32[:])", "void(float64[:], float64[:])"],

--- a/tests/dsp/processors/test_dplms.py
+++ b/tests/dsp/processors/test_dplms.py
@@ -19,25 +19,25 @@ def test_dplms(compare_numba_vs_python):
 
     # ensure the DSPFatal is raised for a negative length
     with pytest.raises(DSPFatal):
-        dplms(-1, nmat, ref, 1, 1, 1, 1)
+        dplms(-1, nmat, ref, 1, 1, 1, 1, [])
 
     # ensure the DSPFatal is raised for length not equal to noise matrix shape
     with pytest.raises(DSPFatal):
-        dplms(10, nmat, ref, 1, 1, 1, 1)
+        dplms(10, nmat, ref, 1, 1, 1, 1, [])
 
     # ensure the DSPFatal is raised for negative coefficients
     with pytest.raises(DSPFatal):
-        dplms(length, nmat, ref, -1, 1, 1, 1)
+        dplms(length, nmat, ref, -1, 1, 1, 1, [])
     with pytest.raises(DSPFatal):
-        dplms(length, nmat, ref, 1, -1, 1, 1)
+        dplms(length, nmat, ref, 1, -1, 1, 1, [])
     with pytest.raises(DSPFatal):
-        dplms(length, nmat, ref, 1, 1, -1, 1)
+        dplms(length, nmat, ref, 1, 1, -1, 1, [])
     with pytest.raises(DSPFatal):
-        dplms(length, nmat, ref, 1, 1, 1, -1)
+        dplms(length, nmat, ref, 1, 1, 1, -1, [])
     with pytest.raises(DSPFatal):
-        dplms(length, nmat, ref, 1, 1, 1, 2)
+        dplms(length, nmat, ref, 1, 1, 1, 2, [])
 
-    dplms_func = dplms(length, nmat, ref, 1, 1, 1, 1)
+    dplms_func = dplms(length, nmat, ref, 1, 1, 1, 1, [])
 
     # ensure to have a valid output
     w_in = np.ones(len_wf)

--- a/tests/dsp/processors/test_dplms.py
+++ b/tests/dsp/processors/test_dplms.py
@@ -19,25 +19,25 @@ def test_dplms(compare_numba_vs_python):
 
     # ensure the DSPFatal is raised for a negative length
     with pytest.raises(DSPFatal):
-        dplms(nmat, ref, -1, 1, 1, 1, 1)
+        dplms(-1, nmat, ref, 1, 1, 1, 1)
 
     # ensure the DSPFatal is raised for length not equal to noise matrix shape
     with pytest.raises(DSPFatal):
-        dplms(nmat, ref, 10, 1, 1, 1, 1)
+        dplms(10, nmat, ref, 1, 1, 1, 1)
 
     # ensure the DSPFatal is raised for negative coefficients
     with pytest.raises(DSPFatal):
-        dplms(nmat, ref, length, -1, 1, 1, 1)
+        dplms(length, nmat, ref, -1, 1, 1, 1)
     with pytest.raises(DSPFatal):
-        dplms(nmat, ref, length, 1, -1, 1, 1)
+        dplms(length, nmat, ref, 1, -1, 1, 1)
     with pytest.raises(DSPFatal):
-        dplms(nmat, ref, length, 1, 1, -1, 1)
+        dplms(length, nmat, ref, 1, 1, -1, 1)
     with pytest.raises(DSPFatal):
-        dplms(nmat, ref, length, 1, 1, 1, -1)
+        dplms(length, nmat, ref, 1, 1, 1, -1)
     with pytest.raises(DSPFatal):
-        dplms(nmat, ref, length, 1, 1, 1, 2)
+        dplms(length, nmat, ref, 1, 1, 1, 2)
 
-    dplms_func = dplms(nmat, ref, length, 1, 1, 1, 1)
+    dplms_func = dplms(length, nmat, ref, 1, 1, 1, 1)
 
     # ensure to have a valid output
     w_in = np.ones(len_wf)


### PR DESCRIPTION
Added possibility to have filter coefficients as input of the dplms processor, to be consistent with to changes in the legend-dataflow-overrides and legend-dataflow-config repositories.

<!---

Before submitting a pull request, please make sure you've read and understood the pygama developer's guide: https://pygama.readthedocs.io/en/latest/developer.html. In particular, do not forget to:

- Conform to our coding conventions
- Update existing or add new tests
- Update existing or add new documentation
- Address any issue reported by GitHub checks

--->
