### PR TITLE
Changes ready for p03

### DIFF
--- a/src/pygama/dsp/processors/convolutions.py
+++ b/src/pygama/dsp/processors/convolutions.py
@@ -4,6 +4,7 @@ from typing import Callable
 
 import numpy as np
 from numba import guvectorize
+from scipy.signal import fftconvolve
 
 from pygama.dsp.errors import DSPFatal
 from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
@@ -71,7 +72,7 @@ def cusp_filter(length: int, sigma: float, flat: int, decay: int) -> Callable:
         cusp[ind] = float(np.sinh((length - ind) / sigma) / np.sinh(lt / sigma))
 
     den = [1, -np.exp(-1 / decay)]
-    cuspd = np.convolve(cusp, den, "same")
+    cuspd = fftconvolve(cusp, den, "same")
 
     @guvectorize(
         ["void(float32[:], float32[:])", "void(float64[:], float64[:])"],
@@ -98,7 +99,7 @@ def cusp_filter(length: int, sigma: float, flat: int, decay: int) -> Callable:
         if len(cuspd) > len(w_in):
             raise DSPFatal("The filter is longer than the input waveform")
 
-        w_out[:] = np.convolve(w_in, cuspd, "valid")
+        w_out[:] = fftconvolve(w_in, cuspd, "valid")
 
     return cusp_out
 
@@ -183,7 +184,7 @@ def zac_filter(length: int, sigma: float, flat: int, decay: int) -> Callable:
 
     # deconvolve zac filter
     den = [1, -np.exp(-1 / decay)]
-    zacd = np.convolve(zac, den, "same")
+    zacd = fftconvolve(zac, den, "same")
 
     @guvectorize(
         ["void(float32[:], float32[:])", "void(float64[:], float64[:])"],
@@ -210,7 +211,7 @@ def zac_filter(length: int, sigma: float, flat: int, decay: int) -> Callable:
         if len(zacd) > len(w_in):
             raise DSPFatal("The filter is longer than the input waveform")
 
-        w_out[:] = np.convolve(w_in, zacd, "valid")
+        w_out[:] = fftconvolve(w_in, zacd, "valid")
 
     return zac_out
 
@@ -283,6 +284,6 @@ def t0_filter(rise: int, fall: int) -> Callable:
         if len(t0_kern) > len(w_in):
             raise DSPFatal("The filter is longer than the input waveform")
 
-        w_out[:] = np.convolve(w_in, t0_kern)[: len(w_in)]
+        w_out[:] = fftconvolve(w_in, t0_kern)[: len(w_in)]
 
     return t0_filter_out

--- a/src/pygama/dsp/processors/dplms.py
+++ b/src/pygama/dsp/processors/dplms.py
@@ -4,6 +4,7 @@ from typing import Callable
 
 import numpy as np
 from numba import guvectorize
+from scipy.signal import fftconvolve
 
 from pygama.dsp.errors import DSPFatal
 from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
@@ -146,6 +147,6 @@ def dplms(
         if len(x) > len(w_in):
             raise DSPFatal("The filter is longer than the input waveform")
 
-        w_out[:] = np.convolve(w_in, np.flip(x), "valid")
+        w_out[:] = fftconvolve(w_in, np.flip(x), "valid")
 
     return dplms_out

--- a/src/pygama/pargen/AoE_cal.py
+++ b/src/pygama/pargen/AoE_cal.py
@@ -1274,7 +1274,7 @@ def cal_aoe(
                 "AoE_Low_Cut": {
                     "expression": "AoE_Classifier>a",
                     "parameters": {"a": cut},
-                }
+                },
                 "AoE_Double_Sided_Cut": {
                     "expression": "(b>AoE_Classifier)&(AoE_Classifier>a)",
                     "parameters": {"a": cut, "b": aoe_high_cut},

--- a/src/pygama/pargen/AoE_cal.py
+++ b/src/pygama/pargen/AoE_cal.py
@@ -1235,7 +1235,7 @@ def cal_aoe(
         aoe_tmp = aoe[(energy > 1000) & (energy < 1300) & (aoe > 0)]  # [:20000]
         bulk_pars, bulk_errs = unbinned_aoe_fit(aoe_tmp, display=0)
     except:
-        bulk_pars = np.full(8,np.nan)
+        bulk_pars = np.full(8, np.nan)
         log.error("1000-1300 keV mean determination failed")
 
     try:
@@ -1251,36 +1251,38 @@ def cal_aoe(
         sigma_pars = np.full(2, np.nan)
 
     try:
-        cut = get_aoe_cut_fit(energy, classifier, 1592, (40, 20), 0.9, eres_pars, display=0)
+        cut = get_aoe_cut_fit(
+            energy, classifier, 1592, (40, 20), 0.9, eres_pars, display=0
+        )
     except:
         log.error("A/E cut determination failed")
         cut = np.nan
-        
+
     cal_dict.update(
-            {
-                "AoE_Corrected": {
-                    "expression": f"(((A_max/{energy_param})/(a*{cal_energy_param} +b))-1)",
-                    "parameters": {"a": mu_pars[0], "b": mu_pars[1]},
+        {
+            "AoE_Corrected": {
+                "expression": f"(((A_max/{energy_param})/(a*{cal_energy_param} +b))-1)",
+                "parameters": {"a": mu_pars[0], "b": mu_pars[1]},
+            },
+            "AoE_Classifier": {
+                "expression": f"AoE_Corrected/(sqrt(c+(d/{cal_energy_param})**2)/(a*{cal_energy_param} +b))",
+                "parameters": {
+                    "a": mu_pars[0],
+                    "b": mu_pars[1],
+                    "c": sigma_pars[0],
+                    "d": sigma_pars[1],
                 },
-                "AoE_Classifier": {
-                    "expression": f"AoE_Corrected/(sqrt(c+(d/{cal_energy_param})**2)/(a*{cal_energy_param} +b))",
-                    "parameters": {
-                        "a": mu_pars[0],
-                        "b": mu_pars[1],
-                        "c": sigma_pars[0],
-                        "d": sigma_pars[1],
-                    },
-                },
-                "AoE_Low_Cut": {
-                    "expression": "AoE_Classifier>a",
-                    "parameters": {"a": cut},
-                },
-                "AoE_Double_Sided_Cut": {
-                    "expression": "(b>AoE_Classifier)&(AoE_Classifier>a)",
-                    "parameters": {"a": cut, "b": aoe_high_cut},
-                }
-            }
-        )
+            },
+            "AoE_Low_Cut": {
+                "expression": "AoE_Classifier>a",
+                "parameters": {"a": cut},
+            },
+            "AoE_Double_Sided_Cut": {
+                "expression": "(b>AoE_Classifier)&(AoE_Classifier>a)",
+                "parameters": {"a": cut, "b": aoe_high_cut},
+            },
+        }
+    )
 
     try:
         log.info("  Compute low side survival fractions: ")

--- a/src/pygama/pargen/cuts.py
+++ b/src/pygama/pargen/cuts.py
@@ -76,16 +76,18 @@ def generate_cuts(
             all_par_array < np.nanpercentile(all_par_array, 99)
         )
         par_array = all_par_array[idxs]
-        bin_width = (np.nanpercentile(par_array, 70)- np.nanpercentile(par_array, 50))/5
-        
-        counts, start_bins, var = pgh.get_hist(par_array, 
-                                               range=(np.nanmin(par_array), np.nanmax(par_array)),
-                                               dx=bin_width)
+        bin_width = (
+            np.nanpercentile(par_array, 70) - np.nanpercentile(par_array, 50)
+        ) / 5
+
+        counts, start_bins, var = pgh.get_hist(
+            par_array, range=(np.nanmin(par_array), np.nanmax(par_array)), dx=bin_width
+        )
         max_idx = np.argmax(counts)
         mu = start_bins[max_idx]
         try:
             fwhm = pgh.get_fwhm(counts, start_bins)[0]
-            guess_sig = fwhm/2.355
+            guess_sig = fwhm / 2.355
 
             lower_bound = mu - 10 * guess_sig
 
@@ -260,11 +262,15 @@ def cut_dict_to_hit_dict(cut_dict, final_cut_field="is_valid_cal"):
 
 def find_pulser_properties(df, energy="daqenergy"):
 
-    if np.nanmax(df[energy])>8000:
-        hist, bins, var = pgh.get_hist(df[energy], dx=1, range=(1000, np.nanmax(df[energy])))
+    if np.nanmax(df[energy]) > 8000:
+        hist, bins, var = pgh.get_hist(
+            df[energy], dx=1, range=(1000, np.nanmax(df[energy]))
+        )
         allowed_err = 200
     else:
-        hist, bins, var = pgh.get_hist(df[energy], dx=0.2, range=(500, np.nanmax(df[energy])))
+        hist, bins, var = pgh.get_hist(
+            df[energy], dx=0.2, range=(500, np.nanmax(df[energy]))
+        )
         allowed_err = 50
     if np.any(var == 0):
         var[np.where(var == 0)] = 1
@@ -277,30 +283,42 @@ def find_pulser_properties(df, energy="daqenergy"):
 
     allowed_mask = np.ones(len(peak_energies), dtype=bool)
     for i, e in enumerate(peak_energies[1:-1]):
-        i +=1
-        if peak_e_err[i]>allowed_err:
+        i += 1
+        if peak_e_err[i] > allowed_err:
             continue
-        if i==1:
-            if e - peak_e_err[i] < peak_energies[i-1]+peak_e_err[i-1] and peak_e_err[i-1]<allowed_err:
-                overlap = (peak_energies[i-1]+peak_e_err[i-1]-(peak_energies[i]-peak_e_err[i]))
-                peak_e_err[i] -= overlap*(peak_e_err[i]/(peak_e_err[i]+peak_e_err[i-1]))
-                peak_e_err[i-1] -= overlap*(peak_e_err[i-1]/(peak_e_err[i]+peak_e_err[i-1]))
-            
-        if e + peak_e_err[i] > peak_energies[i+1]-peak_e_err[i+1] and peak_e_err[i+1]<allowed_err:
-            overlap = (e+peak_e_err[i])-(peak_energies[i+1]-peak_e_err[i+1])
-            total=peak_e_err[i]+peak_e_err[i+1]
-            peak_e_err[i] -= (overlap)*(peak_e_err[i]/total)
-            peak_e_err[i+1] -= (overlap)*(peak_e_err[i+1]/total)
+        if i == 1:
+            if (
+                e - peak_e_err[i] < peak_energies[i - 1] + peak_e_err[i - 1]
+                and peak_e_err[i - 1] < allowed_err
+            ):
+                overlap = (
+                    peak_energies[i - 1]
+                    + peak_e_err[i - 1]
+                    - (peak_energies[i] - peak_e_err[i])
+                )
+                peak_e_err[i] -= overlap * (
+                    peak_e_err[i] / (peak_e_err[i] + peak_e_err[i - 1])
+                )
+                peak_e_err[i - 1] -= overlap * (
+                    peak_e_err[i - 1] / (peak_e_err[i] + peak_e_err[i - 1])
+                )
+
+        if (
+            e + peak_e_err[i] > peak_energies[i + 1] - peak_e_err[i + 1]
+            and peak_e_err[i + 1] < allowed_err
+        ):
+            overlap = (e + peak_e_err[i]) - (peak_energies[i + 1] - peak_e_err[i + 1])
+            total = peak_e_err[i] + peak_e_err[i + 1]
+            peak_e_err[i] -= (overlap) * (peak_e_err[i] / total)
+            peak_e_err[i + 1] -= (overlap) * (peak_e_err[i + 1] / total)
 
     out_pulsers = []
     for i, e in enumerate(peak_energies[allowed_mask]):
         if peak_e_err[i] > allowed_err:
             continue
-        
+
         try:
-            e_cut = (df[energy] > e - peak_e_err[i]) & (
-                df[energy] < e + peak_e_err[i]
-            )
+            e_cut = (df[energy] > e - peak_e_err[i]) & (df[energy] < e + peak_e_err[i])
             df_peak = df[e_cut]
 
             time_since_last = (
@@ -317,10 +335,10 @@ def find_pulser_properties(df, energy="daqenergy"):
             hist, bins, var = pgh.get_hist(tsl, bins=bins)
 
             maxs = pgc.get_i_local_maxima(hist, 45)
-            maxs = maxs[maxs>20]
-            
+            maxs = maxs[maxs > 20]
+
             super_max = pgc.get_i_local_maxima(hist, 500)
-            super_max = super_max[super_max>20]
+            super_max = super_max[super_max > 20]
             if len(maxs) < 2:
                 continue
             else:
@@ -328,10 +346,10 @@ def find_pulser_properties(df, energy="daqenergy"):
                 max_locs = np.array([0.0])
                 max_locs = np.append(max_locs, bcs[np.array(maxs)])
                 if (
-                    len(np.where(np.abs(np.diff(np.diff(max_locs))) <= 0.001)[0])
-                    > 1
+                    len(np.where(np.abs(np.diff(np.diff(max_locs))) <= 0.001)[0]) > 1
                     or (np.abs(np.diff(np.diff(max_locs))) <= 0.001).all()
-                or len(super_max)>0) :
+                    or len(super_max) > 0
+                ):
                     pulser_e = e
                     period = stats.mode(tsl).mode[0]
                     out_pulsers.append((pulser_e, peak_e_err[i], period, energy))

--- a/src/pygama/pargen/cuts.py
+++ b/src/pygama/pargen/cuts.py
@@ -290,7 +290,7 @@ def find_pulser_properties(df, energy="daqenergy"):
                     & (time_since_last < np.percentile(time_since_last, 99.9))
                 ]
 
-                bins = np.arange(0.1, 5, 0.0001)
+                bins = np.arange(0.1, 5, 0.001)
                 bcs = pgh.get_bin_centers(bins)
                 hist, bins, var = pgh.get_hist(tsl, bins=bins)
 

--- a/src/pygama/pargen/ecal_th.py
+++ b/src/pygama/pargen/ecal_th.py
@@ -56,8 +56,8 @@ def load_data(
     if len(pulser_props) > 0:
         final_mask = None
         for entry in pulser_props:
-            e_cut = (df.daqenergy.values < entry[0] + entry[1]) & (
-                df.daqenergy.values > entry[0] - entry[1]
+            e_cut = (df.trapTmax.values < entry[0] + entry[1]) & (
+                df.trapTmax.values > entry[0] - entry[1]
             )
             if final_mask is None:
                 final_mask = e_cut 
@@ -210,6 +210,7 @@ def energy_cal_th(
         log.debug(f"{events_pqc} events pass")
 
     glines = [
+        238.632,
         583.191,
         727.330,
         860.564,
@@ -219,6 +220,7 @@ def energy_cal_th(
         2614.50,
     ]  # gamma lines used for calibration
     range_keV = [
+        (8, 8),
         (20, 20),
         (30, 30),
         (30, 30),
@@ -228,6 +230,7 @@ def energy_cal_th(
         (60, 60),
     ]  # side bands width
     funcs = [
+        pgf.extended_gauss_step_pdf,
         pgf.extended_radford_pdf,
         pgf.extended_radford_pdf,
         pgf.extended_radford_pdf,
@@ -237,6 +240,7 @@ def energy_cal_th(
         pgf.extended_radford_pdf,
     ]
     gof_funcs = [
+        pgf.gauss_step_pdf,
         pgf.radford_pdf,
         pgf.radford_pdf,
         pgf.radford_pdf,
@@ -562,7 +566,8 @@ def energy_cal_th(
             fig1 = plt.figure()
             range_adu = 5 / pars[0]  # 10keV window around peak in adu
             for i, peak in enumerate(mus):
-                plt.subplot(math.ceil((len(mus)) / 2), 2, i + 1)
+                #plt.subplot(math.ceil((len(mus)) / 2), 2, i + 1)
+                plt.subplot(3, 3, i + 1)
                 binning = np.arange(pk_ranges[i][0], pk_ranges[i][1], 1)
                 bin_cs = (binning[1:] + binning[:-1]) / 2
                 energies = uncal_pass[energy_param][

--- a/src/pygama/pargen/ecal_th.py
+++ b/src/pygama/pargen/ecal_th.py
@@ -10,12 +10,14 @@ import math
 import os
 import pathlib
 from datetime import datetime
+from scipy.stats import binned_statistic
 
 import matplotlib as mpl
 
 mpl.use("agg")
 import matplotlib.pyplot as plt
 import numpy as np
+import pandas as pd
 import scipy.stats
 from matplotlib.backends.backend_pdf import PdfPages
 from matplotlib.colors import LogNorm
@@ -39,20 +41,16 @@ def fwhm_slope(x: np.array, m0: float, m1: float, m2: float = None) -> np.array:
     else:
         return np.sqrt(m0 + m1 * x + m2 * x**2)
 
-
 def load_data(
     files: list[str],
     lh5_path: str,
     energy_params: list[str],
     hit_dict: dict = {},
-    cut_parameters: list[str] = ["bl_mean", "bl_std", "pz_std"],
-    display=0,
-) -> dict[str, np.ndarray]:
-
+    cut_parameters: list[str] = ["bl_mean", "bl_std", "pz_std"]
+) -> pd.DataFrame:
+    
     df = lh5.load_dfs(files, ["timestamp", "trapTmax"], lh5_path)
     pulser_props = cts.find_pulser_properties(df, energy="trapTmax")
-    if display > 0:
-        plot_dict = {}
     if len(pulser_props) > 0:
         final_mask = None
         for entry in pulser_props:
@@ -66,64 +64,59 @@ def load_data(
         ids = ~(final_mask)
         log.debug(f"pulser found: {pulser_props}")
 
-        if display > 0:
-            plt.rcParams["figure.figsize"] = (12, 8)
-            plt.rcParams["font.size"] = 10
-
-            fig = plt.figure()
-            plt.hist(df["trapTmax"], bins=10000, histtype="step", label="With Pulser")
-            plt.hist(
-                df["trapTmax"][ids], bins=10000, histtype="step", label="Pulser Removed"
-            )
-            plt.xlim([0, np.nanpercentile(df["trapTmax"], 99)])
-            plt.xlabel("Energy (ADC)")
-            plt.ylabel("Counts")
-            plt.legend(loc="upper right")
-            plot_dict["pulser"] = fig
-            if display > 1:
-                plt.show()
-            else:
-                plt.close()
-
     else:
         ids = np.ones(len(df), dtype=bool)
         log.debug(f"no pulser found")
 
+    sto = lh5.LH5Store()
+    table = sto.read_object(lh5_path, files)[0]
+    
     if len(hit_dict.keys()) == 0:
-        try:
-            energy_dict = lh5.load_nda(files, energy_params, lh5_path)
-        except RuntimeError:
-            energy_params = [
-                energy_param.split("_")[0] for energy_param in energy_params
-            ]
-            energy_dict = lh5.load_nda(files, energy_params, lh5_path)
-            energy_dict["timestamp"] = df["timestamp"][ids].to_numpy()
-
+        out_df = df.copy()
+        for param in energy_params:
+            try:
+                out_df[param] = table[param].nda
+                
+            except RuntimeError:
+                param = param.split("_")[0] 
+                out_df[param] = table[param].nda
+                
     else:
-        sto = lh5.LH5Store()
-        energy_dict = {"timestamp": df["timestamp"][ids].to_numpy()}
-        table = sto.read_object(lh5_path, files)[0]
-        df = table.eval(hit_dict).get_dataframe()
+        
+        out_df = table.eval(hit_dict).get_dataframe()
+        out_df = pd.concat([df, out_df], axis=1)
+        out_df["is_not_pulser"] = ids
+        
         cut_parameters = cts.get_keys(table, cut_parameters)
 
         for param in energy_params:
-            if param in df:
-                energy_dict[param] = df[param][ids].to_numpy()
-            else:
-                dat = lh5.load_nda(files, [param], lh5_path)[param]
-                energy_dict.update({param: dat[ids]})
+            if param not in out_df:
+                out_df[param] = table[param].nda
         if cut_parameters is not None:
             for param in cut_parameters:
-                if param in df:
-                    energy_dict[param] = df[param][ids].to_numpy()
-                else:
-                    dat = lh5.load_nda(files, [param], lh5_path)[param]
-                    energy_dict.update({param: dat[ids]})
-    if display > 0:
-        return energy_dict, plot_dict
-    else:
-        return energy_dict
+                if param not in df:
+                    out_df[param] = table[param].nda
+    log.debug("Data Loaded")
+    return out_df
 
+def apply_cuts(data:pd.DataFrame, hit_dict, cut_parameters=None, final_cut_field: str = "is_valid_cal"):
+    if cut_parameters is not None:
+        cut_dict = cts.generate_cuts(data.query("is_not_pulser"), cut_parameters)
+        hit_dict.update(
+            cts.cut_dict_to_hit_dict(cut_dict, final_cut_field=final_cut_field)
+        )
+        mask = cts.get_cut_indexes(data, cut_dict)
+        
+        data["is_valid_cal"]= mask
+        
+    else:
+        data["is_valid_cal"]= np.ones(len(data), dtype=bool)
+    data["is_usable"] = data["is_valid_cal"]&data["is_not_pulser"]
+    
+    events_pqc = len(data.query("is_usable"))
+    log.debug(f"{events_pqc} events valid for calibration")
+    
+    return data, hit_dict
 
 def gen_pars_dict(pars, deg, energy_param):
     if deg == 1:
@@ -146,71 +139,9 @@ def gen_pars_dict(pars, deg, energy_param):
         log.warning(f"hit_dict not implemented for deg = {deg}")
 
     return out_dict
-
-
-def energy_cal_th(
-    files: list[str],
-    energy_params: list[str],
-    hit_dict: dict = {},
-    cut_parameters: dict[str, int] = {"bl_mean": 4, "bl_std": 4, "pz_std": 4},
-    lh5_path: str = "dsp",
-    display: int = 0,
-    guess_keV: float | None = None,
-    threshold: int = 0,
-    p_val: float = 0,
-    n_events: int = 15000,
-    final_cut_field: str = "is_valid_cal",
-    deg: int = 1,
-) -> tuple(dict, dict):
-
-    """
-    This is an example script for calibrating Th data.
-    """
-
-    if isinstance(energy_params, str):
-        energy_params = [energy_params]
-
-    ####################
-    # Start the analysis
-    ####################
-
-    log.debug(f"{len(files)} files found")
-    log.debug("Loading and applying charge trapping corr...")
-    if display > 0:
-        uncal_pass, plot_dict = load_data(
-            files,
-            lh5_path,
-            energy_params,
-            hit_dict,
-            cut_parameters=list(cut_parameters) if cut_parameters is not None else None,
-            display=display,
-        )
-    else:
-        uncal_pass = load_data(
-            files,
-            lh5_path,
-            energy_params,
-            hit_dict,
-            cut_parameters=list(cut_parameters) if cut_parameters is not None else None,
-        )
-
-    total_events = len(uncal_pass[energy_params[0]])
-    log.debug("Done")
-    if cut_parameters is not None:
-        cut_dict = cts.generate_cuts(uncal_pass, cut_parameters)
-        hit_dict.update(
-            cts.cut_dict_to_hit_dict(cut_dict, final_cut_field=final_cut_field)
-        )
-        mask = cts.get_cut_indexes(uncal_pass, cut_dict)
-        uncal_fail = {}
-        for param in uncal_pass:
-            uncal_fail[param] = uncal_pass[param][~mask]
-            uncal_pass[param] = uncal_pass[param][mask]
-        events_pqc = len(uncal_pass[energy_params[0]])
-        log.debug(f"{events_pqc} events pass")
-
+class calibrate_parameter():
     glines = [
-        238.632,
+        #238.632,
         583.191,
         727.330,
         860.564,
@@ -220,7 +151,7 @@ def energy_cal_th(
         2614.50,
     ]  # gamma lines used for calibration
     range_keV = [
-        (8, 8),
+        #(8, 8),
         (20, 20),
         (30, 30),
         (30, 30),
@@ -230,7 +161,7 @@ def energy_cal_th(
         (60, 60),
     ]  # side bands width
     funcs = [
-        pgf.extended_gauss_step_pdf,
+        #pgf.extended_gauss_step_pdf,
         pgf.extended_radford_pdf,
         pgf.extended_radford_pdf,
         pgf.extended_radford_pdf,
@@ -240,7 +171,7 @@ def energy_cal_th(
         pgf.extended_radford_pdf,
     ]
     gof_funcs = [
-        pgf.gauss_step_pdf,
+        #pgf.gauss_step_pdf,
         pgf.radford_pdf,
         pgf.radford_pdf,
         pgf.radford_pdf,
@@ -249,194 +180,34 @@ def energy_cal_th(
         pgf.radford_pdf,
         pgf.radford_pdf,
     ]
-    output_dict = {}
-    for energy_param in energy_params:
-        kev_ranges = range_keV.copy()
-        if guess_keV is None:
-            guess_keV = 2620 / np.nanpercentile(
-                uncal_pass[energy_param][uncal_pass[energy_param] > threshold], 99
-            )
-
-        log.debug(f"Find peaks and compute calibration curve for {energy_param}")
-        log.debug(f"Guess is {guess_keV:.3f}")
-
-        try:
-            pars, cov, results = cal.hpge_E_calibration(
-                uncal_pass[energy_param],
-                glines,
-                guess_keV,
-                deg=deg,
-                range_keV=range_keV,
-                funcs=funcs,
-                gof_funcs=gof_funcs,
-                n_events=n_events,
-                allowed_p_val=p_val,
-                simplex=True,
-                verbose=False,
-            )
-            pk_pars = results["pk_pars"]
-            found_peaks = results["got_peaks_locs"]
-            fitted_peaks = results["fitted_keV"]
-        except:
-            found_peaks = np.array([])
-            fitted_peaks = np.array([])
-
-        for i, peak in enumerate(glines):
-            if peak not in fitted_peaks:
-                kev_ranges[i] = (kev_ranges[i][0] - 5, kev_ranges[i][1] - 5)
-        for i, peak in enumerate(glines):
-            if peak not in fitted_peaks:
-                kev_ranges[i] = (kev_ranges[i][0] - 5, kev_ranges[i][1] - 5)
-        for i, peak in enumerate(fitted_peaks):
-            try:
-                if results["pk_fwhms"][:, 1][i] / results["pk_fwhms"][:, 0][i] > 0.05:
-                    index = np.where(glines == peak)[0][0]
-                    kev_ranges[i] = (kev_ranges[index][0] - 5, kev_ranges[index][1] - 5)
-            except:
-                pass
-
-        try:
-            pars, cov, results = cal.hpge_E_calibration(
-                uncal_pass[energy_param],
-                glines,
-                guess_keV,
-                deg=deg,
-                range_keV=kev_ranges,
-                funcs=funcs,
-                gof_funcs=gof_funcs,
-                n_events=n_events,
-                allowed_p_val=p_val,
-                simplex=True,
-                verbose=False,
-            )
-        except:
-            pars = None
-        if pars is None:
-            log.error(f"Calibration failed for {energy_param}, trying with 0 p_val")
-            try:
-                pars, cov, results = cal.hpge_E_calibration(
-                    uncal_pass[energy_param],
-                    glines,
-                    guess_keV,
-                    deg=deg,
-                    range_keV=kev_ranges,
-                    funcs=funcs,
-                    gof_funcs=gof_funcs,
-                    n_events=n_events,
-                    allowed_p_val=0,
-                    simplex=True,
-                    verbose=False,
-                )
-                if pars is None:
-                    raise ValueError
-            except:
-                log.error(f"Calibration failed completely for {energy_param} even with 0 p_val")
-                pars = np.full(deg + 1, np.nan)
-
-                hit_dict[f"{energy_param}_cal"] = gen_pars_dict(pars, deg, energy_param)
-
-                output_dict[f"{energy_param}_cal"] = {
-                    "Qbb_fwhm": np.nan,
-                    "Qbb_fwhm_err": np.nan,
-                    "2.6_fwhm": np.nan,
-                    "2.6_fwhm_err": np.nan,
-                    "eres_pars": [np.nan, np.nan],
-                    "fitted_peaks": np.nan,
-                    "fwhms": np.nan,
-                    "peak_fit_pars": np.nan,
-                }
-                continue
-
-            fitted_peaks = results["fitted_keV"]
-            fwhms = results["pk_fwhms"][:, 0]
-            dfwhms = results["pk_fwhms"][:, 1]
-
-            #####
-            # Remove the Tl SEP and DEP from calibration if found
-            fwhm_peaks = np.array([], dtype=np.float32)
-            all_peaks = np.array([], dtype=np.float32)
-            indexes = []
-            for i, peak in enumerate(fitted_peaks):
-                all_peaks = np.append(all_peaks, peak)
-                if peak == 2103.53:
-                    log.info(f"Tl SEP found at index {i}")
-                    indexes.append(i)
-                    continue
-                elif peak == 1592.53:
-                    log.info(f"Tl DEP found at index {i}")
-                    indexes.append(i)
-                    continue
-                elif np.isnan(dfwhms[i]):
-                    log.info(f"{peak} failed")
-                    indexes.append(i)
-                    continue
-                else:
-                    fwhm_peaks = np.append(fwhm_peaks, peak)
-            fit_fwhms = np.delete(fwhms, [indexes])
-            fit_dfwhms = np.delete(dfwhms, [indexes])
-            #####
-            param_guess = [2, 0.001]
-            param_bounds = (0, np.inf)
-            try:
-                fit_pars, fit_covs = curve_fit(
-                    fwhm_slope,
-                    fwhm_peaks,
-                    fit_fwhms,
-                    sigma=fit_dfwhms,
-                    p0=param_guess,
-                    bounds=param_bounds,
-                    absolute_sigma=True,
-                )
-            except RuntimeError:
-                log.error(f"FWHM fit failed for {energy_param}")
-                fit_pars = np.array([np.nan,np.nan])
-
-
-            hit_dict[f"{energy_param}_cal"] = gen_pars_dict(pars, deg, energy_param)
-            output_dict[f"{energy_param}_cal"] = {
-                "Qbb_fwhm": np.nan,
-                "Qbb_fwhm_err": np.nan,
-                "2.6_fwhm": np.nan,
-                "2.6_fwhm_err": np.nan,
-                "eres_pars": fit_pars.tolist(),
-                "fitted_peaks": np.nan,
-                "fwhms": np.nan,
-                "peak_fit_pars": np.nan,
-            }
-            continue
-        log.debug("done")
-        log.info(f"Calibration pars are {pars}")
-
-        hit_dict[f"{energy_param}_cal"] = gen_pars_dict(pars, deg, energy_param)
-
-        fitted_peaks = results["fitted_keV"]
-        fitted_funcs = []
-        fitted_gof_funcs = []
-        for i, peak in enumerate(glines):
-            if peak in fitted_peaks:
-                fitted_funcs.append(funcs[i])
-                fitted_gof_funcs.append(gof_funcs[i])
-
-        ecal_pass = pgf.poly(uncal_pass[energy_param], pars)
-        if cut_parameters is not None:
-            ecal_fail = pgf.poly(uncal_fail[energy_param], pars)
-
-        pk_pars = results["pk_pars"]
-        pk_covs = results["pk_covs"]
-
-        pk_rs_dict = {peak: pk_pars[i].tolist() for i, peak in enumerate(fitted_peaks)}
-
-        peaks_kev = results["got_peaks_keV"]
-
-        pk_ranges = results["pk_ranges"]
-        p_vals = results["pk_pvals"]
-        mus = [
-            pgf.get_mu_func(func_i, pars_i)
-            for func_i, pars_i in zip(fitted_funcs, pk_pars)
-        ]
-
-        fwhms = results["pk_fwhms"][:, 0]
-        dfwhms = results["pk_fwhms"][:, 1]
+    
+    def __init__(self, 
+                 data,
+                 energy_param,
+                plot_options:dict =None,
+                guess_keV: float | None = None,
+                threshold: int = 0,
+                p_val: float = 0,
+                n_events: int = 15000,
+                deg: int = 1,):
+        
+        self.data=data
+        self.energy_param=energy_param
+        self.guess_keV = guess_keV
+        self.threshold=threshold
+        self.p_val=p_val
+        self.n_events=n_events
+        self.deg=deg
+        self.plot_options = plot_options
+        
+        self.output_dict={}
+        self.hit_dict={}
+        self.plot_dict={}
+        
+    def fit_energy_res(self):
+        fitted_peaks = self.results["fitted_keV"]
+        fwhms = self.results["pk_fwhms"][:, 0]
+        dfwhms = self.results["pk_fwhms"][:, 1]
 
         #####
         # Remove the Tl SEP and DEP from calibration if found
@@ -461,17 +232,15 @@ def energy_cal_th(
                 fwhm_peaks = np.append(fwhm_peaks, peak)
         fit_fwhms = np.delete(fwhms, [indexes])
         fit_dfwhms = np.delete(dfwhms, [indexes])
-        fit_mus = np.delete(mus, [indexes])
         #####
-
+        param_guess = [2, 0.001]
+        param_bounds = (0, np.inf)
         for i, peak in enumerate(fwhm_peaks):
             log.info(
                 f"FWHM of {peak} keV peak is: {fit_fwhms[i]:1.2f} +- {fit_dfwhms[i]:1.2f} keV"
             )
-        param_guess = [1.5, 0.002]
-        param_bounds = (0, np.inf)
         try:
-            fit_pars, fit_covs = curve_fit(
+            self.fit_pars, self.fit_covs = curve_fit(
                 fwhm_slope,
                 fwhm_peaks,
                 fit_fwhms,
@@ -481,327 +250,214 @@ def energy_cal_th(
                 absolute_sigma=True,
             )
             rng = np.random.default_rng(1)
-            pars_b = rng.multivariate_normal(fit_pars, fit_covs, size=1000)
+            pars_b = rng.multivariate_normal(self.fit_pars, self.fit_covs, size=1000)
             fits = np.array([fwhm_slope(fwhm_peaks, *par_b) for par_b in pars_b])
             qbb_vals = np.array([fwhm_slope(2039.0, *par_b) for par_b in pars_b])
-            qbb_err = np.nanstd(qbb_vals)
-            predicted_fwhms = fwhm_slope(fwhm_peaks, *fit_pars)
-            fit_qbb = fwhm_slope(2039.0, *fit_pars)
+            self.qbb_err = np.nanstd(qbb_vals)
+            predicted_fwhms = fwhm_slope(fwhm_peaks, *self.fit_pars)
+            self.fit_qbb = fwhm_slope(2039.0, *self.fit_pars)
 
             if 2614.50 not in fwhm_peaks:
-                fit_qbb = np.nan
-                qbb_err = np.nan
-
-            log.info(f"FWHM curve fit: {fit_pars}")
-            log.info(f"FWHM fit values: {predicted_fwhms}")
-            log.info(f"FWHM energy resolution at Qbb: {fit_qbb:1.2f} +- {qbb_err:1.2f} keV")
+                self.fit_qbb = np.nan
+                self.qbb_err = np.nan
+            log.info(f"FWHM curve fit: {self.fit_pars}")
+            log.info(f"FWHM fit values:")
+            for peak in fwhm_peaks:
+                log.info(f"Predicted FWHM of {peak} keV peak is: {fwhm_slope(peak, *self.fit_pars):.2f} keV")
+            log.info(f"FWHM energy resolution at Qbb: {self.fit_qbb:1.2f} +- {self.qbb_err:1.2f} keV")
         except RuntimeError:
-            fit_pars = np.array([np.nan,np.nan])
-            fit_covs = np.array([[ np.nan, np.nan],
+            log.error(f"FWHM fit failed for {energy_param}")
+            self.fit_pars = np.array([np.nan,np.nan])
+            self.fit_covs = np.array([[ np.nan, np.nan],
                                 [np.nan,  np.nan]])
-            fit_qbb = np.nan
-            qbb_err=np.nan
+            self.fit_qbb = np.nan
+            self.qbb_err=np.nan
             log.error("FWHM fit failed to converge")
-
-        if display > 0:
-            plot_dict_param = {}
-            plt.rcParams["figure.figsize"] = (12, 8)
-            plt.rcParams["font.size"] = 12
-            selection = (ecal_pass > 2560) & (ecal_pass < 2660)
-            fig_sta = plt.figure()
-            plt.hist2d(
-                uncal_pass["timestamp"][selection],
-                ecal_pass[selection],
-                bins=[100, np.arange(2560, 2660, 1)],
-                norm=LogNorm(),
-            )
-
-            ticks, labels = plt.xticks()
-            plt.xlabel(
-                f"Time starting : {datetime.utcfromtimestamp(ticks[0]).strftime('%d/%m/%y %H:%M')}"
-            )
-            plt.ylabel("Energy(keV)")
-            plt.ylim([2600, 2630])
-
-            plt.xticks(
-                ticks,
-                [datetime.utcfromtimestamp(tick).strftime("%H:%M") for tick in ticks],
-            )
-            plot_dict_param["cal_stability"] = fig_sta
-            if display > 1:
-                plt.show()
-            else:
-                plt.close()
-
-            time_slice = 500
-            utime_array = uncal_pass["timestamp"][selection]
-            par_array = ecal_pass[selection]
-            bins = np.arange(
-                (np.amin(utime_array) // time_slice) * time_slice,
-                ((np.amax(utime_array) // time_slice) + 2) * time_slice,
-                time_slice,
-            )
-            # bin time values
-            times_average = (bins[:-1] + bins[1:]) / 2
-
-            binned = np.digitize(utime_array, bins)
-            bin_nos = np.unique(binned)
-
-            par_average = np.zeros(len(bins) - 1)
-            par_average[:] = np.nan
-            for i in bin_nos:
-                if len(par_array[np.where(binned == i)[0]]) > 50:
-                    par_average[i - 1] = np.percentile(
-                        par_array[np.where(binned == i)[0]], 50
-                    )
-
-            plot_dict_param["mean_stability"] = {
-                "energy": par_average,
-                "time": times_average,
+            
+    def gen_pars_dict(self):
+        if self.deg == 1:
+            out_dict = {
+                "expression": f"a*{self.energy_param}+b",
+                "parameters": {"a": self.pars[0], "b": self.pars[1]},
             }
-
-            plt.rcParams["figure.figsize"] = (12, 20)
-            plt.rcParams["font.size"] = 12
-
-            fig1 = plt.figure()
-            range_adu = 5 / pars[0]  # 10keV window around peak in adu
-            for i, peak in enumerate(mus):
-                #plt.subplot(math.ceil((len(mus)) / 2), 2, i + 1)
-                plt.subplot(3, 3, i + 1)
-                binning = np.arange(pk_ranges[i][0], pk_ranges[i][1], 1)
-                bin_cs = (binning[1:] + binning[:-1]) / 2
-                energies = uncal_pass[energy_param][
-                    (uncal_pass[energy_param] > pk_ranges[i][0])
-                    & (uncal_pass[energy_param] < pk_ranges[i][1])
-                ][:n_events]
-
-                counts, bs, bars = plt.hist(energies, bins=binning, histtype="step")
-                fit_vals = fitted_gof_funcs[i](bin_cs, *pk_pars[i]) * np.diff(bs)
-                plt.plot(bin_cs, fit_vals)
-                plt.step(
-                    bin_cs,
-                    [
-                        (fval - count) / count if count != 0 else (fval - count)
-                        for count, fval in zip(counts, fit_vals)
-                    ],
-                )
-                plt.plot(
-                    [bin_cs[10]],
-                    [0],
-                    label=get_peak_label(fitted_peaks[i]),
-                    linestyle="None",
-                )
-                plt.plot(
-                    [bin_cs[10]],
-                    [0],
-                    label=f"{fitted_peaks[i]:.1f} keV",
-                    linestyle="None",
-                )
-                plt.plot(
-                    [bin_cs[10]],
-                    [0],
-                    label=f"{fwhms[i]:.2f} +- {dfwhms[i]:.2f} keV",
-                    linestyle="None",
-                )
-                plt.plot(
-                    [bin_cs[10]],
-                    [0],
-                    label=f"p-value : {p_vals[i]:.2f}",
-                    linestyle="None",
-                )
-
-                plt.xlabel("Energy (keV)")
-                plt.ylabel("Counts")
-                plt.legend(loc="upper left", frameon=False)
-                plt.xlim([peak - range_adu, peak + range_adu])
-                locs, labels = plt.xticks()
-                new_locs, new_labels = get_peak_labels(locs, pars)
-                plt.xticks(ticks=new_locs, labels=new_labels)
-
-            plt.tight_layout()
-            plot_dict_param["peak_fits"] = fig1
-            if display > 1:
-                plt.show()
-            else:
-                plt.close()
-
-            plt.rcParams["figure.figsize"] = (12, 8)
-            plt.rcParams["font.size"] = 12
-
-            fig2, (ax1, ax2) = plt.subplots(
-                2, 1, sharex=True, gridspec_kw={"height_ratios": [3, 1]}
-            )
-
-            cal_bins = np.arange(0, np.nanmax(mus) * 1.1, 10)
-
-            ax1.scatter(all_peaks, mus, marker="x", c="b")
-
-            ax1.plot(pgf.poly(cal_bins, pars), cal_bins, lw=1, c="g")
-
-            ax1.grid()
-            ax1.set_xlim([200, 2700])
-            ax1.set_ylabel("Energy (ADC)")
-            ax2.plot(
-                all_peaks,
-                pgf.poly(np.array(mus), pars) - all_peaks,
-                lw=0,
-                marker="x",
-                c="b",
-            )
-            ax2.grid()
-            ax2.set_xlabel("Energy (keV)")
-            ax2.set_ylabel("Residuals (keV)")
-            plot_dict_param["cal_fit"] = fig2
-            if display > 1:
-                plt.show()
-            else:
-                plt.close()
-
-            fig3, (ax1, ax2) = plt.subplots(
-                2, 1, sharex=True, gridspec_kw={"height_ratios": [3, 1]}
-            )
-            ax1.errorbar(
-                fwhm_peaks, fit_fwhms, yerr=fit_dfwhms, marker="x", lw=0, c="b"
-            )
-
-            fwhm_slope_bins = np.arange(200, 2700, 10)
-
-            qbb_line_vx = [2039.0, 2039.0]
-            qbb_line_vy = [
-                0.9 * np.nanmin(fwhm_slope(fwhm_slope_bins, *fit_pars)),
-                fit_qbb,
-            ]
-            qbb_line_hx = [200, 2039.0]
-            qbb_line_hy = [fit_qbb, fit_qbb]
-
-            ax1.plot(
-                fwhm_slope_bins, fwhm_slope(fwhm_slope_bins, *fit_pars), lw=1, c="g"
-            )
-            ax1.plot(qbb_line_hx, qbb_line_hy, lw=1, c="r")
-            ax1.plot(qbb_line_vx, qbb_line_vy, lw=1, c="r")
-            ax1.plot(
-                np.nan,
-                np.nan,
-                "-",
-                color="none",
-                label=f"Qbb fwhm: {fit_qbb:1.2f} +- {qbb_err:1.2f} keV",
-            )
-            ax1.legend(loc="upper left", frameon=False)
-            if np.isnan(fit_pars).all():
-                [
-                        0.9 * np.nanmin(fit_fwhms),
-                        1.1 * np.nanmax(fit_fwhms),
-                    ]
-            else:
-                ax1.set_ylim(
-                    [
-                        0.9 * np.nanmin(fwhm_slope(fwhm_slope_bins, *fit_pars)),
-                        1.1 * np.nanmax(fwhm_slope(fwhm_slope_bins, *fit_pars)),
-                    ]
-                )
-            ax1.set_xlim([200, 2700])
-            ax1.grid()
-            ax1.set_ylabel("FWHM energy resolution (keV)")
-            ax2.plot(
-                fwhm_peaks,
-                (fit_fwhms - fwhm_slope(fwhm_peaks, *fit_pars)) / fit_dfwhms,
-                lw=0,
-                marker="x",
-                c="b",
-            )
-            ax2.set_xlabel("Energy (keV)")
-            ax2.set_ylabel("Normalised Residuals")
-            ax2.grid()
-            plt.tight_layout()
-            plot_dict_param["fwhm_fit"] = fig3
-            if display > 1:
-                plt.show()
-            else:
-                plt.close()
-
-            fig4 = plt.figure()
-            bins = np.linspace(0, 3000, 1000)
-            plot_dict_param["spectrum"] = {
-                "bins": bins,
-                "counts": np.histogram(ecal_pass, bins)[0],
+        elif self.deg == 0:
+            out_dict = {
+                "expression": f"a*{self.energy_param}",
+                "parameters": {"a": self.pars[0]},
             }
-            plt.hist(
-                ecal_pass,
-                bins=bins,
-                histtype="step",
-                label=f"{len(ecal_pass)} events passed quality cuts",
-            )
-            if cut_parameters is not None:
-                plt.hist(
-                    ecal_fail,
-                    bins=bins,
-                    histtype="step",
-                    label=f"{len(ecal_fail)} events failed quality cuts",
-                )
-            plt.yscale("log")
-            plt.xlabel("Energy (keV)")
-            plt.ylabel("Counts")
-            plt.legend(loc="upper right")
-            plot_dict_param["spectrum_plot"] = fig4
-            if display > 1:
-                plt.show()
-            else:
-                plt.close()
-
-            if cut_parameters is not None:
-                fig5 = plt.figure()
-                n_bins = 500
-                counts_pass, bins_pass, _ = pgh.get_hist(
-                    ecal_pass, bins=n_bins, range=(0, 3000)
-                )
-                counts_fail, bins_fail, _ = pgh.get_hist(
-                    ecal_fail, bins=n_bins, range=(0, 3000)
-                )
-                sf = (
-                    100
-                    * (counts_pass + 10 ** (-6))
-                    / (counts_pass + counts_fail + 10 ** (-6))
-                )
-
-                plt.step(pgh.get_bin_centers(bins_pass), sf, where="post")
-                plt.xlabel("Energy (keV)")
-                plt.ylabel("Survival Fraction (%)")
-                plt.ylim([50, 100])
-                plt.xlim([0, 3000])
-                plot_dict_param["survival_frac"] = fig5
-                if display > 1:
-                    plt.show()
-                else:
-                    plt.close()
-
-            plot_dict[energy_param] = plot_dict_param
-
-        if fitted_peaks[-1] == 2614.50:
-            fep_fwhm = round(fwhms[-1], 2)
-            fep_dwhm = round(dfwhms[-1], 2)
+        elif self.deg == 2:
+            out_dict = {
+                "expression": f"a*{self.energy_param}**2 +b*{self.energy_param}+c",
+                "parameters": {"a": self.pars[0], "b": self.pars[1], "c": self.pars[2]},
+            }
         else:
-            fep_fwhm = np.nan
-            fep_dwhm = np.nan
+            out_dict = {}
+            log.warning(f"hit_dict not implemented for deg = {self.deg}")
 
-        output_dict[f"{energy_param}_cal"] = {
-            "Qbb_fwhm": round(fit_qbb, 2),
-            "Qbb_fwhm_err": round(qbb_err, 2),
-            "2.6_fwhm": fep_fwhm,
-            "2.6_fwhm_err": fep_dwhm,
-            "eres_pars": fit_pars.tolist(),
-            "fitted_peaks": results["fitted_keV"].tolist(),
-            "fwhms": results["pk_fwhms"].tolist(),
-            "peak_fit_pars": pk_rs_dict,
-        }
+        return out_dict
+    
+    def calibrate_parameter(self):
+        kev_ranges = self.range_keV.copy()
+        if self.guess_keV is None:
+            self.guess_keV = 2620 / np.nanpercentile(
+                self.data.query(f"is_usable & {self.energy_param}>{self.threshold}")[self.energy_param], 99
+            )
+
+        log.debug(f"Find peaks and compute calibration curve for {self.energy_param}")
+        log.debug(f"Guess is {self.guess_keV:.3f}")
+        
+        try:
+            self.pars, self.cov, self.results = cal.hpge_E_calibration(
+                self.data.query("is_usable")[self.energy_param],
+                self.glines,
+                self.guess_keV,
+                deg=self.deg,
+                range_keV=kev_ranges,
+                funcs=self.funcs,
+                gof_funcs=self.gof_funcs,
+                n_events=self.n_events,
+                allowed_p_val=self.p_val,
+                simplex=True,
+                verbose=False,
+            )
+            pk_pars = self.results["pk_pars"]
+            found_peaks = self.results["got_peaks_locs"]
+            fitted_peaks = self.results["fitted_keV"]
+        except:
+            found_peaks = np.array([])
+            fitted_peaks = np.array([])
+
+        for i, peak in enumerate(self.glines):
+            if peak not in fitted_peaks:
+                kev_ranges[i] = (kev_ranges[i][0] - 5, kev_ranges[i][1] - 5)
+        for i, peak in enumerate(self.glines):
+            if peak not in fitted_peaks:
+                kev_ranges[i] = (kev_ranges[i][0] - 5, kev_ranges[i][1] - 5)
+        for i, peak in enumerate(fitted_peaks):
+            try:
+                if self.results["pk_fwhms"][:, 1][i] / self.results["pk_fwhms"][:, 0][i] > 0.05:
+                    index = np.where(self.glines == peak)[0][0]
+                    kev_ranges[i] = (kev_ranges[index][0] - 5, kev_ranges[index][1] - 5)
+            except:
+                pass
+
+        try:
+            self.pars, self.cov, self.results = cal.hpge_E_calibration(
+                self.data.query("is_usable")[self.energy_param],
+                self.glines,
+                self.guess_keV,
+                deg=self.deg,
+                range_keV=kev_ranges,
+                funcs=self.funcs,
+                gof_funcs=self.gof_funcs,
+                n_events=self.n_events,
+                allowed_p_val=self.p_val,
+                simplex=True,
+                verbose=False,
+            )
+        except:
+            self.pars = None
+        if self.pars is None:
+            log.error(f"Calibration failed for {self.energy_param}, trying with 0 p_val")
+            try:
+                self.pars, self.cov, self.results = cal.hpge_E_calibration(
+                    self.data.query("is_usable")[self.energy_param],
+                    self.glines,
+                    self.guess_keV,
+                    deg=self.deg,
+                    range_keV=kev_ranges,
+                    funcs=self.funcs,
+                    gof_funcs=self.gof_funcs,
+                    n_events=self.n_events,
+                    allowed_p_val=0,
+                    simplex=True,
+                    verbose=False,
+                )
+                if self.pars is None:
+                    raise ValueError
+
+                self.fit_energy_res()
+                self.data[f"{self.energy_param}_cal"] = pgf.poly(self.data[self.energy_param], self.pars)
+                self.hit_dict[f"{self.energy_param}_cal"] = self.gen_pars_dict()
+                self.output_dict[f"{self.energy_param}_cal"] = {
+                    "Qbb_fwhm": np.nan,
+                    "Qbb_fwhm_err": np.nan,
+                    "2.6_fwhm": np.nan,
+                    "2.6_fwhm_err": np.nan,
+                    "eres_pars": self.fit_pars.tolist(),
+                    "fitted_peaks": np.nan,
+                    "fwhms": np.nan,
+                    "peak_fit_pars": np.nan,
+                    "total_fep":len(self.data.query(f"{self.energy_param}_cal>2604&{self.energy_param}_cal<2624")),
+                    "total_dep":len(self.data.query(f"{self.energy_param}_cal>1587&{self.energy_param}_cal<1597")),
+                    "pass_fep":len(self.data.query(f"{self.energy_param}_cal>2604&{self.energy_param}_cal<2624&is_usable")),
+                    "pass_dep":len(self.data.query(f"{self.energy_param}_cal>1587&{self.energy_param}_cal<1597&is_usable"))
+                }
+            except:
+                log.error(f"Calibration failed completely for {self.energy_param} even with 0 p_val")
+                self.pars = np.full(self.deg + 1, np.nan)
+
+                self.hit_dict[f"{self.energy_param}_cal"] = self.gen_pars_dict()
+
+                self.output_dict[f"{self.energy_param}_cal"] = {
+                    "Qbb_fwhm": np.nan,
+                    "Qbb_fwhm_err": np.nan,
+                    "2.6_fwhm": np.nan,
+                    "2.6_fwhm_err": np.nan,
+                    "eres_pars": [np.nan, np.nan],
+                    "fitted_peaks": np.nan,
+                    "fwhms": np.nan,
+                    "peak_fit_pars": np.nan,
+                    "total_fep":np.nan,
+                    "total_dep":np.nan,
+                    "pass_fep":np.nan,
+                    "pass_dep":np.nan
+                }
+
+        else:
+            log.debug("done")
+            log.info(f"Calibration pars are {self.pars}")
+
+            self.data[f"{self.energy_param}_cal"] = pgf.poly(self.data[self.energy_param], self.pars)
+
+            pk_rs_dict = {peak: self.results["pk_pars"][i].tolist() for i, peak in enumerate(self.results["fitted_keV"])}
+
+            self.fit_energy_res()
+            self.hit_dict[f"{self.energy_param}_cal"] = self.gen_pars_dict()
+
+
+            if self.results["fitted_keV"][-1] == 2614.50:
+                fep_fwhm = round(self.results["pk_fwhms"][-1, 0], 2)
+                fep_dwhm = round(self.results["pk_fwhms"][-1, 1], 2)
+            else:
+                fep_fwhm = np.nan
+                fep_dwhm = np.nan
+
+            self.output_dict[f"{self.energy_param}_cal"] = {
+                "Qbb_fwhm": round(self.fit_qbb, 2),
+                "Qbb_fwhm_err": round(self.qbb_err, 2),
+                "2.6_fwhm": fep_fwhm,
+                "2.6_fwhm_err": fep_dwhm,
+                "eres_pars": self.fit_pars.tolist(),
+                "fitted_peaks": self.results["fitted_keV"].tolist(),
+                "fwhms": self.results["pk_fwhms"].tolist(),
+                "peak_fit_pars": pk_rs_dict,
+                "total_fep":len(self.data.query(f"{self.energy_param}_cal>2604&{self.energy_param}_cal<2624")),
+                "total_dep":len(self.data.query(f"{self.energy_param}_cal>1587&{self.energy_param}_cal<1597")),
+                "pass_fep":len(self.data.query(f"{self.energy_param}_cal>2604&{self.energy_param}_cal<2624&is_usable")),
+                "pass_dep":len(self.data.query(f"{self.energy_param}_cal>1587&{self.energy_param}_cal<1597&is_usable"))
+            }
         log.info(
-            f"Results {energy_param}: {json.dumps(output_dict[f'{energy_param}_cal'], indent=2)}"
+            f"Results {self.energy_param}: {json.dumps(self.output_dict[f'{self.energy_param}_cal'], indent=2)}"
         )
+    
+    def fill_plot_dict(self):
+        for key, item in self.plot_options.items():
+            if item["options"] is not None:
+                self.plot_dict[key]=item["function"](self, **item["options"])
+            else:
+                self.plot_dict[key]=item["function"](self)
 
-    log.info(f"Finished all calibrations")
-    if display > 0:
-        return hit_dict, output_dict, plot_dict
-    else:
-        return hit_dict, output_dict
 
 
 def get_peak_labels(
@@ -833,3 +489,414 @@ def get_peak_label(peak: float) -> str:
         return "Tl SEP"
     elif peak == 2614.5:
         return "Tl FEP"
+
+def plot_fits(ecal_class, figsize = [12,8], fontsize=12, ncols=3, n_rows=3):
+    plt.rcParams["figure.figsize"] = figsize
+    plt.rcParams["font.size"] = fontsize
+    
+    fitted_peaks = ecal_class.results["fitted_keV"]
+    pk_pars = ecal_class.results["pk_pars"]
+    pk_ranges = ecal_class.results["pk_ranges"]
+    p_vals = ecal_class.results["pk_pvals"]
+        
+    fitted_gof_funcs = []
+    for i, peak in enumerate(ecal_class.glines):
+        if peak in fitted_peaks:
+            fitted_gof_funcs.append(ecal_class.gof_funcs[i])
+    
+    mus = [
+        pgf.get_mu_func(func_i, pars_i)
+        for func_i, pars_i in zip(fitted_gof_funcs, pk_pars)
+    ]
+    fwhms = ecal_class.results["pk_fwhms"][:, 0]
+    dfwhms = ecal_class.results["pk_fwhms"][:, 1]
+    
+
+
+    fig = plt.figure()
+    range_adu = 5 / ecal_class.pars[0]  # 10keV window around peak in adu
+    for i, peak in enumerate(mus):
+        #plt.subplot(math.ceil((len(mus)) / 2), 2, i + 1)
+        plt.subplot(n_rows, ncols, i + 1)
+        binning = np.arange(pk_ranges[i][0], pk_ranges[i][1], 1)
+        bin_cs = (binning[1:] + binning[:-1]) / 2
+        energies = ecal_class.data.query(f"{ecal_class.energy_param}>{pk_ranges[i][0]}&{ecal_class.energy_param}<{pk_ranges[i][1]}&is_usable")[ecal_class.energy_param]
+        energies=energies.iloc[:ecal_class.n_events]
+        
+        counts, bs, bars = plt.hist(energies, bins=binning, histtype="step")
+        fit_vals = fitted_gof_funcs[i](bin_cs, *pk_pars[i]) * np.diff(bs)
+        plt.plot(bin_cs, fit_vals)
+        plt.step(
+            bin_cs,
+            [
+                (fval - count) / count if count != 0 else (fval - count)
+                for count, fval in zip(counts, fit_vals)
+            ],
+        )
+        plt.plot(
+            [bin_cs[10]],
+            [0],
+            label=get_peak_label(fitted_peaks[i]),
+            linestyle="None",
+        )
+        plt.plot(
+            [bin_cs[10]],
+            [0],
+            label=f"{fitted_peaks[i]:.1f} keV",
+            linestyle="None",
+        )
+        plt.plot(
+            [bin_cs[10]],
+            [0],
+            label=f"{fwhms[i]:.2f} +- {dfwhms[i]:.2f} keV",
+            linestyle="None",
+        )
+        plt.plot(
+            [bin_cs[10]],
+            [0],
+            label=f"p-value : {p_vals[i]:.2f}",
+            linestyle="None",
+        )
+
+        plt.xlabel("Energy (keV)")
+        plt.ylabel("Counts")
+        plt.legend(loc="upper left", frameon=False)
+        plt.xlim([peak - range_adu, peak + range_adu])
+        locs, labels = plt.xticks()
+        new_locs, new_labels = get_peak_labels(locs, ecal_class.pars)
+        plt.xticks(ticks=new_locs, labels=new_labels)
+
+    plt.tight_layout()
+    plt.close()
+    return fig
+
+def plot_2614_timemap(ecal_class, figsize = [12,8], fontsize=12, erange=[2580,2630], dx=1, time_dx=180):
+    plt.rcParams["figure.figsize"] = figsize
+    plt.rcParams["font.size"] = fontsize
+    
+    selection = ecal_class.data.query(f"{ecal_class.energy_param}_cal>2560&{ecal_class.energy_param}_cal<2660&is_usable")
+    
+    time_bins = np.arange(
+        (np.amin(ecal_class.data["timestamp"]) // time_dx) * time_dx,
+        ((np.amax(ecal_class.data["timestamp"]) // time_dx) + 2) * time_dx,
+        time_dx,
+    )
+    
+    fig = plt.figure()
+    plt.hist2d(
+        selection["timestamp"],
+        selection[f"{ecal_class.energy_param}_cal"],
+        bins=[time_bins, np.arange(erange[0], erange[1]+dx, dx)],
+        norm=LogNorm(),
+    )
+
+    ticks, labels = plt.xticks()
+    plt.xlabel(
+        f"Time starting : {datetime.utcfromtimestamp(ticks[0]).strftime('%d/%m/%y %H:%M')}"
+    )
+    plt.ylabel("Energy(keV)")
+    plt.ylim([erange[0], erange[1]])
+
+    plt.xticks(
+        ticks,
+        [datetime.utcfromtimestamp(tick).strftime("%H:%M") for tick in ticks],
+    )
+    plt.close()
+    return fig
+
+def plot_pulser_timemap(ecal_class, figsize = [12, 8], fontsize = 12 , dx=0.2, time_dx=180, n_spread=3):
+    plt.rcParams["figure.figsize"] = figsize
+    plt.rcParams["font.size"] = fontsize
+    
+    time_bins = np.arange(
+        (np.amin(ecal_class.data["timestamp"]) // time_dx) * time_dx,
+        ((np.amax(ecal_class.data["timestamp"]) // time_dx) + 2) * time_dx,
+        time_dx,
+    )
+    
+    selection = ecal_class.data.query(f"~is_not_pulser")
+    mean = np.nanpercentile(selection[f"{ecal_class.energy_param}_cal"],50)
+    spread = mean-np.nanpercentile(selection[f"{ecal_class.energy_param}_cal"],10)
+    fig = plt.figure()
+    plt.hist2d(
+        selection["timestamp"],
+        selection[f"{ecal_class.energy_param}_cal"],
+        bins=[time_bins, np.arange(mean-n_spread*spread, mean+n_spread*spread+dx, dx)],
+        norm=LogNorm(),
+    )
+
+    ticks, labels = plt.xticks()
+    plt.xlabel(
+        f"Time starting : {datetime.utcfromtimestamp(ticks[0]).strftime('%d/%m/%y %H:%M')}"
+    )
+    plt.ylabel("Energy(keV)")
+    plt.ylim([mean-n_spread*spread, mean+n_spread*spread])
+
+    plt.xticks(
+        ticks,
+        [datetime.utcfromtimestamp(tick).strftime("%H:%M") for tick in ticks],
+    )
+    plt.close()
+    return fig
+
+
+def bin_pulser_stability(ecal_class, 
+                   time_slice= 180):
+    
+    selection = ecal_class.data.query(f"~is_not_pulser")
+    
+    utime_array = ecal_class.data["timestamp"]
+    select_energies = selection[f"{ecal_class.energy_param}_cal"].to_numpy()
+    
+    time_bins = np.arange(
+        (np.amin(utime_array) // time_slice) * time_slice,
+        ((np.amax(utime_array) // time_slice) + 2) * time_slice,
+        time_slice,
+    )
+    # bin time values
+    times_average = (time_bins[:-1] + time_bins[1:]) / 2
+
+    nanmedian = lambda x : np.nanpercentile(x,50) if len(x)>=10 else np.nan
+    error = lambda x : np.nanvar(x)/np.sqrt(len(x)) if len(x)>=10 else np.nan
+
+    par_average,_,_ = binned_statistic(selection["timestamp"], select_energies, statistic=nanmedian,
+                                        bins=time_bins)
+    par_error,_,_ = binned_statistic(selection["timestamp"], select_energies, statistic=error,
+                                        bins=time_bins)
+        
+    return {"time": times_average, "energy":par_average, "spread": par_error}
+
+def bin_stability(ecal_class, 
+                   time_slice= 180, energy_range = [2585, 2660]):
+    
+    selection = ecal_class.data.query(f"{ecal_class.energy_param}_cal>{energy_range[0]}&{ecal_class.energy_param}_cal<{energy_range[1]}&is_usable")
+    
+    utime_array = ecal_class.data["timestamp"]
+    select_energies = selection[f"{ecal_class.energy_param}_cal"].to_numpy()
+    
+    time_bins = np.arange(
+        (np.amin(utime_array) // time_slice) * time_slice,
+        ((np.amax(utime_array) // time_slice) + 2) * time_slice,
+        time_slice,
+    )
+    # bin time values
+    times_average = (time_bins[:-1] + time_bins[1:]) / 2
+
+    nanmedian = lambda x : np.nanpercentile(x,50) if len(x)>=10 else np.nan
+    error = lambda x : np.nanvar(x)/np.sqrt(len(x)) if len(x)>=10 else np.nan
+
+    par_average,_,_ = binned_statistic(selection["timestamp"], select_energies, statistic=nanmedian,
+                                        bins=time_bins)
+    par_error,_,_ = binned_statistic(selection["timestamp"], select_energies, statistic=error,
+                                        bins=time_bins)
+        
+    return {"time": times_average, "energy":par_average, "spread": par_error}
+
+def plot_cal_fit(ecal_class, figsize = [12,8], fontsize=12,
+                 erange=[200,2700]):
+    
+    
+    pk_pars = ecal_class.results["pk_pars"]
+    fitted_peaks = ecal_class.results["fitted_keV"]
+        
+    fitted_gof_funcs = []
+    for i, peak in enumerate(ecal_class.glines):
+        if peak in fitted_peaks:
+            fitted_gof_funcs.append(ecal_class.gof_funcs[i])
+            
+    mus = [
+            pgf.get_mu_func(func_i, pars_i)
+            for func_i, pars_i in zip(fitted_gof_funcs, pk_pars)
+        ]
+
+    plt.rcParams["figure.figsize"] = figsize
+    plt.rcParams["font.size"] = fontsize
+
+    fig, (ax1, ax2) = plt.subplots(
+        2, 1, sharex=True, gridspec_kw={"height_ratios": [3, 1]}
+    )
+
+    cal_bins = np.arange(0, np.nanmax(mus) * 1.1, 10)
+
+
+    ax1.scatter(fitted_peaks, mus, marker="x", c="b")
+
+    ax1.plot(pgf.poly(cal_bins, ecal_class.pars), cal_bins, lw=1, c="g")
+
+    ax1.grid()
+    ax1.set_xlim([erange[0], erange[1]])
+    ax1.set_ylabel("Energy (ADC)")
+    ax2.plot(
+        fitted_peaks,
+        pgf.poly(np.array(mus), ecal_class.pars) - fitted_peaks,
+        lw=0,
+        marker="x",
+        c="b",
+    )
+    ax2.grid()
+    ax2.set_xlabel("Energy (keV)")
+    ax2.set_ylabel("Residuals (keV)")
+    plt.close()
+    return fig
+
+def plot_eres_fit(ecal_class, figsize = [12,8], fontsize=12,
+                 erange=[200,2700]):
+
+    plt.rcParams["figure.figsize"] = figsize
+    plt.rcParams["font.size"] = fontsize
+    
+    fwhms = ecal_class.results["pk_fwhms"][:, 0]
+    dfwhms = ecal_class.results["pk_fwhms"][:, 1]
+    fitted_peaks = ecal_class.results["fitted_keV"]
+
+    #####
+    # Remove the Tl SEP and DEP from calibration if found
+    fwhm_peaks = np.array([], dtype=np.float32)
+    indexes = []
+    for i, peak in enumerate(fitted_peaks):
+        if peak == 2103.53:
+            log.info(f"Tl SEP found at index {i}")
+            indexes.append(i)
+            continue
+        elif peak == 1592.53:
+            log.info(f"Tl DEP found at index {i}")
+            indexes.append(i)
+            continue
+        elif np.isnan(dfwhms[i]):
+            log.info(f"{peak} failed")
+            indexes.append(i)
+            continue
+        else:
+            fwhm_peaks = np.append(fwhm_peaks, peak)
+    fit_fwhms = np.delete(fwhms, [indexes])
+    fit_dfwhms = np.delete(dfwhms, [indexes])
+    
+    fig, (ax1, ax2) = plt.subplots(
+        2, 1, sharex=True, gridspec_kw={"height_ratios": [3, 1]}
+    )
+    ax1.errorbar(
+        fwhm_peaks, fit_fwhms, yerr=fit_dfwhms, marker="x", lw=0, c="b"
+    )
+
+    fwhm_slope_bins = np.arange(erange[0], erange[1], 10)
+
+    qbb_line_vx = [2039.0, 2039.0]
+    qbb_line_vy = [
+        0.9 * np.nanmin(fwhm_slope(fwhm_slope_bins, *ecal_class.fit_pars)),
+        ecal_class.fit_qbb,
+    ]
+    qbb_line_hx = [erange[0], 2039.0]
+    qbb_line_hy = [ecal_class.fit_qbb, ecal_class.fit_qbb]
+
+    ax1.plot(
+        fwhm_slope_bins, fwhm_slope(fwhm_slope_bins, *ecal_class.fit_pars), lw=1, c="g"
+    )
+    ax1.plot(qbb_line_hx, qbb_line_hy, lw=1, c="r")
+    ax1.plot(qbb_line_vx, qbb_line_vy, lw=1, c="r")
+    ax1.plot(
+        np.nan,
+        np.nan,
+        "-",
+        color="none",
+        label=f"Qbb fwhm: {ecal_class.fit_qbb:1.2f} +- {ecal_class.qbb_err:1.2f} keV",
+    )
+    ax1.legend(loc="upper left", frameon=False)
+    if np.isnan(ecal_class.fit_pars).all():
+        [
+                0.9 * np.nanmin(fit_fwhms),
+                1.1 * np.nanmax(fit_fwhms),
+            ]
+    else:
+        ax1.set_ylim(
+            [
+                0.9 * np.nanmin(fwhm_slope(fwhm_slope_bins, *ecal_class.fit_pars)),
+                1.1 * np.nanmax(fwhm_slope(fwhm_slope_bins, *ecal_class.fit_pars)),
+            ]
+        )
+    ax1.set_xlim([200, 2700])
+    ax1.grid()
+    ax1.set_ylabel("FWHM energy resolution (keV)")
+    ax2.plot(
+        fwhm_peaks,
+        (fit_fwhms - fwhm_slope(fwhm_peaks, *ecal_class.fit_pars)) / fit_dfwhms,
+        lw=0,
+        marker="x",
+        c="b",
+    )
+    ax2.set_xlabel("Energy (keV)")
+    ax2.set_ylabel("Normalised Residuals")
+    ax2.grid()
+    plt.tight_layout()
+    plt.close()
+    return fig
+
+def bin_spectrum(ecal_class, 
+                  erange=[0,3000],dx=2):
+    bins = np.arange(erange[0], erange[1]+dx, dx)
+    return {"bins": pgh.get_bin_centers(bins), "counts": np.histogram(ecal_class.data.query("is_usable")[f"{ecal_class.energy_param}_cal"], bins)[0],
+           "cut_counts": np.histogram(ecal_class.data.query("~is_valid_cal&is_not_pulser")[f"{ecal_class.energy_param}_cal"], bins)[0],
+           "pulser_counts": np.histogram(ecal_class.data.query("~is_not_pulser")[f"{ecal_class.energy_param}_cal"], bins)[0]}
+
+def bin_survival_fraction(ecal_class,
+                           erange=[0,3000],dx=6):
+    counts_pass, bins_pass, _ = pgh.get_hist(
+            ecal_class.data.query("is_usable")[f"{ecal_class.energy_param}_cal"], 
+            bins=np.arange(erange[0], erange[1]+dx,dx)
+        )
+    counts_fail, bins_fail, _ = pgh.get_hist(
+            ecal_class.data.query("~is_valid_cal&is_not_pulser")[f"{ecal_class.energy_param}_cal"], 
+            bins=np.arange(erange[0], erange[1]+dx,dx)
+        )
+    sf = (
+            100
+            * (counts_pass + 10 ** (-6))
+            / (counts_pass + counts_fail + 10 ** (-6))
+        )
+    return {"bins": pgh.get_bin_centers(bins_pass), "sf": sf}
+
+def energy_cal_th(
+    files: list[str],
+    energy_params: list[str],
+    hit_dict: dict = {},
+    cut_parameters: dict[str, int] = {"bl_mean": 4, "bl_std": 4, "pz_std": 4},
+    lh5_path: str = "dsp",
+    plot_options:dict=None,
+    guess_keV: float | None = None,
+    threshold: int = 0,
+    p_val: float = 0,
+    n_events: int = 15000,
+    final_cut_field: str = "is_valid_cal",
+    deg: int = 1,
+) -> tuple(dict, dict):
+    
+    data = load_data(
+        files,
+        lh5_path,
+        energy_params,
+        hit_dict,
+        cut_parameters=list(cut_parameters) if cut_parameters is not None else None,
+    )
+
+    data, hit_dict = apply_cuts(data, hit_dict, cut_parameters, final_cut_field)
+    
+    output_dict = {}
+    plot_dict={}
+    for energy_param in energy_params:
+        ecal = calibrate_parameter(data,
+                energy_param,
+                plot_options,
+                guess_keV,
+                threshold,
+                p_val,
+                n_events,
+                deg)
+        ecal.calibrate_parameter()
+        output_dict.update(ecal.output_dict)
+        hit_dict.update(ecal.hit_dict)
+        if ~np.isnan(ecal.pars).all():
+            ecal.fill_plot_dict()
+        plot_dict[energy_param]= ecal.plot_dict
+        
+    
+    log.info(f"Finished all calibrations")
+    return hit_dict, output_dict, plot_dict

--- a/src/pygama/pargen/energy_optimisation.py
+++ b/src/pygama/pargen/energy_optimisation.py
@@ -1687,6 +1687,8 @@ def run_optimisation(
         param_dict = optimiser.get_best_vals()
         out_param_dict.update(param_dict)
         results_dict = optimiser.optimal_results
+        if np.isnan(results_dict["y_val"]):
+            log.error(f"Energy optimisation failed for {optimiser.dims[0][0]}")
         out_results_list.append(results_dict)
 
     return out_param_dict, out_results_list

--- a/src/pygama/pargen/energy_optimisation.py
+++ b/src/pygama/pargen/energy_optimisation.py
@@ -367,7 +367,7 @@ def unbinned_energy_fit(
                     & (~np.isnan(m.errors).any())
                     & (~(np.array(m.errors[:-3]) == 0).all())
                 )
-            except: 
+            except:
                 raise RuntimeError
 
         pars = np.array(m.values)[:-1]
@@ -938,9 +938,9 @@ def event_selection(
                 df.daqenergy.values > entry[0] - entry[1]
             )
             if final_mask is None:
-                final_mask = e_cut 
+                final_mask = e_cut
             else:
-                final_mask = final_mask | e_cut 
+                final_mask = final_mask | e_cut
         ids = final_mask
         log.debug(f"pulser found: {pulser_props}")
     else:
@@ -1059,9 +1059,9 @@ def event_selection(
         final_mask = (energy > e_lower_lim) & (energy < e_upper_lim)
         final_events.append(peak_ids[final_mask][:n_events])
         log.info(f"{len(peak_ids[final_mask][:n_events])} passed selections for {peak}")
-        if len(peak_ids[final_mask]) < 0.5*n_events:
+        if len(peak_ids[final_mask]) < 0.5 * n_events:
             log.warning("Less than half number of specified events found")
-        elif len(peak_ids[final_mask]) < 0.1*n_events:
+        elif len(peak_ids[final_mask]) < 0.1 * n_events:
             log.error("Less than 10% number of specified events found")
 
     sort_index = np.argsort(np.concatenate(final_events))
@@ -1111,7 +1111,7 @@ def interpolate_energy(peak_energies, points, err_points, energy):
 
         if nan_mask[-1] == True or nan_mask[-2] == True:
             qbb_err = np.nan
-        if qbb_err/fit_qbb > 0.1:
+        if qbb_err / fit_qbb > 0.1:
             qbb_err = np.nan
 
     return fit_qbb, qbb_err, fit_pars
@@ -1374,7 +1374,7 @@ class BayesianOptimizer:
 
         return x_optimal, min_ei
 
-    def _extend_prior_with_posterior_data(self, x, y,yerr):
+    def _extend_prior_with_posterior_data(self, x, y, yerr):
         self.x_init = np.append(self.x_init, np.array([x]), axis=0)
         self.y_init = np.append(self.y_init, np.array(y), axis=0)
         self.yerr_init = np.append(self.yerr_init, np.array(yerr), axis=0)
@@ -1414,7 +1414,9 @@ class BayesianOptimizer:
     def update(self, results):
         y_val = results["y_val"]
         y_err = results["y_err"]
-        self._extend_prior_with_posterior_data(self.current_x, np.array([y_val]), np.array([y_err]))
+        self._extend_prior_with_posterior_data(
+            self.current_x, np.array([y_val]), np.array([y_err])
+        )
 
         if np.isnan(y_val) | np.isnan(y_err):
             pass
@@ -1465,15 +1467,19 @@ class BayesianOptimizer:
             ys = np.zeros_like(points)
             ys_err = np.zeros_like(points)
             for i, point in enumerate(points):
-                ys[i],ys_err[i] = self.gauss_pr.predict(
+                ys[i], ys_err[i] = self.gauss_pr.predict(
                     np.array([point]).reshape(1, -1), return_std=True
                 )
             fig = plt.figure()
 
             plt.scatter(np.array(self.x_init), np.array(self.y_init), label="Samples")
-            plt.scatter(np.array(self.x_init)[fail_idxs], np.array(self.y_init)[fail_idxs], 
-                        color="green", label="Failed samples")
-            plt.fill_between(points, ys-ys_err,ys+ys_err, alpha = 0.1)
+            plt.scatter(
+                np.array(self.x_init)[fail_idxs],
+                np.array(self.y_init)[fail_idxs],
+                color="green",
+                label="Failed samples",
+            )
+            plt.fill_between(points, ys - ys_err, ys + ys_err, alpha=0.1)
             if init_samples is not None:
                 init_ys = np.array(
                     [
@@ -1484,14 +1490,10 @@ class BayesianOptimizer:
                 plt.scatter(
                     np.array(init_samples)[:, 0],
                     np.array(self.y_init)[init_ys],
-                    color="red", label="Init Samples"
+                    color="red",
+                    label="Init Samples",
                 )
-            plt.scatter(
-                self.optimal_x[0],
-                self.y_min,
-                color="orange",
-                label="Optimal"
-            )
+            plt.scatter(self.optimal_x[0], self.y_min, color="orange", label="Optimal")
 
             plt.xlabel(
                 f"{self.dims[0].name}-{self.dims[0].parameter}({self.dims[0].unit})"
@@ -1583,14 +1585,10 @@ class BayesianOptimizer:
                 plt.scatter(
                     np.array(init_samples)[:, 0],
                     np.array(self.y_init)[init_ys],
-                    color="red", label="Init Samples"
+                    color="red",
+                    label="Init Samples",
                 )
-            plt.scatter(
-                self.optimal_x[0],
-                self.y_min,
-                color="orange",
-                 label="Optimal"
-            )
+            plt.scatter(self.optimal_x[0], self.y_min, color="orange", label="Optimal")
 
             plt.xlabel(
                 f"{self.dims[0].name}-{self.dims[0].parameter}({self.dims[0].unit})"

--- a/src/pygama/pargen/energy_optimisation.py
+++ b/src/pygama/pargen/energy_optimisation.py
@@ -933,7 +933,7 @@ def event_selection(
                 final_mask = e_cut 
             else:
                 final_mask = final_mask | e_cut 
-        ids = ~(final_mask)
+        ids = final_mask
         log.debug(f"pulser found: {pulser_props}")
     else:
         log.debug("no_pulser")

--- a/src/pygama/pargen/energy_optimisation.py
+++ b/src/pygama/pargen/energy_optimisation.py
@@ -924,8 +924,16 @@ def event_selection(
 
     pulser_props = cts.find_pulser_properties(df, energy="daqenergy")
     if len(pulser_props) > 0:
-        out_df = cts.tag_pulsers(df, pulser_props, window=0.001)
-        ids = out_df.isPulser == 1
+        final_mask = None
+        for entry in pulser_props:
+            e_cut = (df.daqenergy.values < entry[0] + entry[1]) & (
+                df.daqenergy.values > entry[0] - entry[1]
+            )
+            if final_mask is None:
+                final_mask = e_cut 
+            else:
+                final_mask = final_mask | e_cut 
+        ids = ~(final_mask)
         log.debug(f"pulser found: {pulser_props}")
     else:
         log.debug("no_pulser")

--- a/src/pygama/pargen/energy_optimisation.py
+++ b/src/pygama/pargen/energy_optimisation.py
@@ -1533,7 +1533,7 @@ class BayesianOptimizer:
             points = np.arange(self.dims[0].min_val, self.dims[0].max_val, 0.1)
             ys = np.zeros_like(points)
             for i, point in enumerate(points):
-                ys[i] = self._acquisition_function(np.array([point]).reshape(1, -1)[0])
+                ys[i] = self.acq_function(np.array([point]).reshape(1, -1)[0])
             fig = plt.figure()
             plt.plot(points, ys)
             plt.scatter(np.array(self.x_init), np.array(self.y_init))
@@ -1575,7 +1575,7 @@ class BayesianOptimizer:
 
             j = 0
             for i, _ in np.ndenumerate(out_grid):
-                out_grid[i] = self._acquisition_function(points[j])
+                out_grid[i] = self.acq_function(points[j])
                 j += 1
 
             fig = plt.figure()

--- a/src/pygama/pargen/energy_optimisation.py
+++ b/src/pygama/pargen/energy_optimisation.py
@@ -674,7 +674,7 @@ def fom_FWHM_with_dt_corr_fit(tb_in, kwarg_dict, ctc_parameter, idxs=None, displ
 
     # Make sure fit isn't based on only a few points
     if len(fwhms) < 10:
-        log.error("less than 10 fits successful")
+        log.warning("less than 10 fits successful")
         return {
             "fwhm": np.nan,
             "fwhm_err": np.nan,
@@ -723,7 +723,7 @@ def fom_FWHM_with_dt_corr_fit(tb_in, kwarg_dict, ctc_parameter, idxs=None, displ
             plt.show()
 
     except:
-        log.error("alpha fit failed")
+        log.warning("alpha fit failed")
         return {
             "fwhm": np.nan,
             "fwhm_err": np.nan,
@@ -735,7 +735,7 @@ def fom_FWHM_with_dt_corr_fit(tb_in, kwarg_dict, ctc_parameter, idxs=None, displ
         }
 
     if np.isnan(fit_vals).all():
-        log.error("alpha fit all nan")
+        log.warning("alpha fit all nan")
         return {
             "fwhm": np.nan,
             "fwhm_err": np.nan,
@@ -791,7 +791,7 @@ def fom_FWHM_with_dt_corr_fit(tb_in, kwarg_dict, ctc_parameter, idxs=None, displ
                 display=display,
             )
         if np.isnan(final_fwhm) or np.isnan(final_err):
-            log.error(f"final fit failed, alpha was {alpha}")
+            log.warning(f"final fit failed, alpha was {alpha}")
         return {
             "fwhm": final_fwhm,
             "fwhm_err": final_err,
@@ -1043,6 +1043,10 @@ def event_selection(
         final_mask = (energy > e_lower_lim) & (energy < e_upper_lim)
         final_events.append(peak_ids[final_mask][:n_events])
         log.info(f"{len(peak_ids[final_mask][:n_events])} passed selections for {peak}")
+        if len(peak_ids[final_mask]) < 0.5*n_events:
+            log.warning("Less than half number of specified events found")
+        elif len(peak_ids[final_mask]) < 0.1*n_events:
+            log.error("Less than 10% number of specified events found")
 
     sort_index = np.argsort(np.concatenate(final_events))
     idx_list = get_wf_indexes(sort_index, [len(mask) for mask in final_events])

--- a/src/pygama/pargen/energy_optimisation.py
+++ b/src/pygama/pargen/energy_optimisation.py
@@ -960,7 +960,7 @@ def event_selection(
         hist,
         bins,
         var,
-        np.array([583.191, 727.330, 860.564, 1620.5, 2103.53, 2614.553]),
+        np.array([238.632, 583.191, 727.330, 860.564, 1620.5, 2103.53, 2614.553]),
     )
     log.debug(f"detected {detected_peaks_keV} keV peaks at {detected_peaks_locs}")
 
@@ -1017,7 +1017,7 @@ def event_selection(
     cut_dict = cts.generate_cuts(tb_data, cut_parameters)
     log.debug(f"Cuts are: {cut_dict}")
     log.debug("Loaded Cuts")
-    ct_mask = cts.get_cut_indexes(tb_data, cut_dict, "raw")
+    ct_mask = cts.get_cut_indexes(tb_data, cut_dict)
 
     final_events = []
     for peak_idx in peak_idxs:
@@ -1111,6 +1111,8 @@ def interpolate_energy(peak_energies, points, err_points, energy):
 
         if nan_mask[-1] == True or nan_mask[-2] == True:
             qbb_err = np.nan
+        if qbb_err/fit_qbb > 0.1:
+            qbb_err = np.nan
 
     return fit_qbb, qbb_err, fit_pars
 
@@ -1199,6 +1201,7 @@ def single_peak_fom(data, kwarg_dict):
         data, peak_dicts[0], ctc_param, idxs=idx_list[0], display=0
     )
     out_dict["y_val"] = out_dict["fwhm"]
+    out_dict["y_err"] = out_dict["fwhm_err"]
     return out_dict
 
 
@@ -1265,11 +1268,10 @@ class BayesianOptimizer:
     np.random.seed(55)
     lambda_param = 0.01
     eta_param = 0
-    kernel = None
     # FIXME: the following throws a TypeError
     # kernel=ConstantKernel(1.0, constant_value_bounds="fixed") * RBF(1, length_scale_bounds="fixed") #+ WhiteKernel(noise_level=0.0111)
 
-    def __init__(self, acq_func, batch_size):
+    def __init__(self, acq_func, batch_size, kernel=None):
 
         self.dims = []
         self.current_iter = 0
@@ -1277,7 +1279,7 @@ class BayesianOptimizer:
         self.batch_size = batch_size
         self.iters = 0
 
-        self.gauss_pr = GaussianProcessRegressor(kernel=self.kernel)
+        self.gauss_pr = GaussianProcessRegressor(kernel=kernel)
         self.best_samples_ = pd.DataFrame(columns=["x", "y", "ei"])
         self.distances_ = []
 
@@ -1296,9 +1298,10 @@ class BayesianOptimizer:
     def get_n_dimensions(self):
         return len(self.dims)
 
-    def add_initial_values(self, x_init, y_init):
+    def add_initial_values(self, x_init, y_init, yerr_init):
         self.x_init = x_init
         self.y_init = y_init
+        self.yerr_init = yerr_init
 
     def _get_expected_improvement(self, x_new):
 
@@ -1371,9 +1374,10 @@ class BayesianOptimizer:
 
         return x_optimal, min_ei
 
-    def _extend_prior_with_posterior_data(self, x, y):
+    def _extend_prior_with_posterior_data(self, x, y,yerr):
         self.x_init = np.append(self.x_init, np.array([x]), axis=0)
         self.y_init = np.append(self.y_init, np.array(y), axis=0)
+        self.yerr_init = np.append(self.yerr_init, np.array(yerr), axis=0)
 
     def get_first_point(self):
         y_min_ind = np.nanargmin(self.y_init)
@@ -1410,7 +1414,7 @@ class BayesianOptimizer:
     def update(self, results):
         y_val = results["y_val"]
         y_err = results["y_err"]
-        self._extend_prior_with_posterior_data(self.current_x, np.array([y_val]))
+        self._extend_prior_with_posterior_data(self.current_x, np.array([y_val]), np.array([y_err]))
 
         if np.isnan(y_val) | np.isnan(y_err):
             pass
@@ -1452,6 +1456,7 @@ class BayesianOptimizer:
 
     def plot(self, init_samples=None):
         nan_idxs = np.isnan(self.y_init)
+        fail_idxs = np.isnan(self.yerr_init)
         self.gauss_pr.fit(self.x_init[~nan_idxs], np.array(self.y_init)[~nan_idxs])
         if (len(self.dims) != 2) and (len(self.dims) != 1):
             raise Exception("Acquisition Function Plotting not implemented for dim!=2")
@@ -1465,7 +1470,9 @@ class BayesianOptimizer:
                 )
             fig = plt.figure()
 
-            plt.scatter(np.array(self.x_init), np.array(self.y_init))
+            plt.scatter(np.array(self.x_init), np.array(self.y_init), label="Samples")
+            plt.scatter(np.array(self.x_init)[fail_idxs], np.array(self.y_init)[fail_idxs], 
+                        color="green", label="Failed samples")
             plt.fill_between(points, ys-ys_err,ys+ys_err, alpha = 0.1)
             if init_samples is not None:
                 init_ys = np.array(
@@ -1477,18 +1484,20 @@ class BayesianOptimizer:
                 plt.scatter(
                     np.array(init_samples)[:, 0],
                     np.array(self.y_init)[init_ys],
-                    color="red",
+                    color="red", label="Init Samples"
                 )
             plt.scatter(
                 self.optimal_x[0],
                 self.y_min,
                 color="orange",
+                label="Optimal"
             )
 
             plt.xlabel(
                 f"{self.dims[0].name}-{self.dims[0].parameter}({self.dims[0].unit})"
             )
             plt.ylabel(f"Kernel Value")
+            plt.legend()
         elif len(self.dims) == 2:
             x, y = np.mgrid[
                 self.dims[0].min_val : self.dims[0].max_val : 0.1,
@@ -1563,7 +1572,7 @@ class BayesianOptimizer:
                 ys[i] = self.acq_function(np.array([point]).reshape(1, -1)[0])
             fig = plt.figure()
             plt.plot(points, ys)
-            plt.scatter(np.array(self.x_init), np.array(self.y_init))
+            plt.scatter(np.array(self.x_init), np.array(self.y_init), label="Samples")
             if init_samples is not None:
                 init_ys = np.array(
                     [
@@ -1574,18 +1583,20 @@ class BayesianOptimizer:
                 plt.scatter(
                     np.array(init_samples)[:, 0],
                     np.array(self.y_init)[init_ys],
-                    color="red",
+                    color="red", label="Init Samples"
                 )
             plt.scatter(
                 self.optimal_x[0],
                 self.y_min,
                 color="orange",
+                 label="Optimal"
             )
 
             plt.xlabel(
                 f"{self.dims[0].name}-{self.dims[0].parameter}({self.dims[0].unit})"
             )
             plt.ylabel(f"Acquisition Function Value")
+            plt.legend()
 
         elif len(self.dims) == 2:
             x, y = np.mgrid[

--- a/src/pygama/pargen/extract_tau.py
+++ b/src/pygama/pargen/extract_tau.py
@@ -41,8 +41,16 @@ def load_data(
 
     pulser_props = cts.find_pulser_properties(df, energy="daqenergy")
     if len(pulser_props) > 0:
-        out_df = cts.tag_pulsers(df, pulser_props, window=0.001)
-        ids = ~(out_df.isPulser == 1)
+        final_mask = None
+        for entry in pulser_props:
+            e_cut = (df.daqenergy.values < entry[0] + entry[1]) & (
+                df.daqenergy.values > entry[0] - entry[1]
+            )
+            if final_mask is None:
+                final_mask = e_cut 
+            else:
+                final_mask = final_mask | e_cut 
+        ids = ~(final_mask)
         log.debug(f"pulser found: {pulser_props}")
     else:
         log.debug("no_pulser")

--- a/src/pygama/pargen/extract_tau.py
+++ b/src/pygama/pargen/extract_tau.py
@@ -47,9 +47,9 @@ def load_data(
                 df.daqenergy.values > entry[0] - entry[1]
             )
             if final_mask is None:
-                final_mask = e_cut 
+                final_mask = e_cut
             else:
-                final_mask = final_mask | e_cut 
+                final_mask = final_mask | e_cut
         ids = ~(final_mask)
         log.debug(f"pulser found: {pulser_props}")
     else:
@@ -122,7 +122,7 @@ def get_decay_constant(
         plt.rcParams["figure.figsize"] = (10, 6)
         plt.rcParams["font.size"] = 8
         fig, ax = plt.subplots()
-        bins = np.linspace(-0.01,0,100000)  # change if needed
+        bins = np.linspace(-0.01, 0, 100000)  # change if needed
         counts, bins, bars = ax.hist(slopes, bins=bins, histtype="step")
         plot_max = np.argmax(counts)
         in_min = plot_max - 20
@@ -140,7 +140,7 @@ def get_decay_constant(
             bins=200,
             histtype="step",
         )
-        axins.axvline(high_bin,color="red")
+        axins.axvline(high_bin, color="red")
         axins.set_xlim(bins[in_min], bins[in_max])
         labels = ax.get_xticklabels()
         ax.set_xticklabels(labels=labels, rotation=45)

--- a/src/pygama/pargen/extract_tau.py
+++ b/src/pygama/pargen/extract_tau.py
@@ -114,13 +114,13 @@ def get_decay_constant(
         plt.rcParams["figure.figsize"] = (10, 6)
         plt.rcParams["font.size"] = 8
         fig, ax = plt.subplots()
-        bins = 10000  # change if needed
+        bins = np.linspace(-0.01,0,100000)  # change if needed
         counts, bins, bars = ax.hist(slopes, bins=bins, histtype="step")
         plot_max = np.argmax(counts)
-        in_min = plot_max - 10
+        in_min = plot_max - 20
         if in_min < 0:
             in_min = 0
-        in_max = plot_max + 11
+        in_max = plot_max + 21
         if in_max >= len(bins):
             in_min = len(bins) - 1
         plt.xlabel("Slope")
@@ -132,6 +132,7 @@ def get_decay_constant(
             bins=200,
             histtype="step",
         )
+        axins.axvline(high_bin,color="red")
         axins.set_xlim(bins[in_min], bins[in_max])
         labels = ax.get_xticklabels()
         ax.set_xticklabels(labels=labels, rotation=45)


### PR DESCRIPTION
dsp - Changed all convolution processes from np.convolve to scipy.signal.fftconvolve gave >4x speedup in testing

A/E - Can now fail gracefully at more stages 

Cuts - Rewrote how the cuts are found to be much more robust than before, also tuned pulser finding based on p02 data

Energy Optimisation - Added fallback to Minos fitting, improved event selection by including SEP, added errors to bayesian optimiser if nan the value will still contribute to gpr fit but will not be returned as optimal

Ecal - Moved into class and redefined the plotting interface can now pass a dictionary with the function to plot and any options you want to pass. Better defined failure modes such as when FEP fails to fit.

Extract_tau - improved output plots.

In all cases the pulser was changed to remove all events in window to make sure there is no contamination. I have also done a sweep through of pargen logging and lowered unnecessary warnings to info.
