### PR TITLE
Support chunked loading with `DataLoader.next()`

### DIFF
--- a/src/pygama/flow/data_loader.py
+++ b/src/pygama/flow/data_loader.py
@@ -1359,3 +1359,14 @@ class DataLoader:
                                         col_tiers[file]["columns"][c] = tier
 
         return col_tiers
+
+    def __repr__(self) -> str:
+        return (
+            "DataLoader("
+            f"cuts={self.cuts}, "
+            f"merge_files={self.merge_files}, "
+            f'output_format="{self.output_format}", '
+            f"output_columns={self.output_columns}, "
+            f"aoesa_to_vov={self.aoesa_to_vov}"
+            ")"
+        )

--- a/src/pygama/flow/data_loader.py
+++ b/src/pygama/flow/data_loader.py
@@ -333,15 +333,20 @@ class DataLoader:
         fmt
             ``lgdo.Table`` or ``pd.DataFrame``.
         merge_files
-            If ``True``, information from multiple files will be merged into
+            if ``True``, information from multiple files will be merged into
             one table.
         columns
-            The columns that should be copied into the output.
+            the columns that should be copied into the output.
         aoesa_to_vov
+            output :class:`.ArrayOfEqualSizedArrays` as :class:`.VectorOfVectors`.
 
         Example
         -------
-        >>> dl.set_output(fmt="pd.DataFrame", merge_files=False, columns=["daqenergy", "trapEmax", "channel"])
+        >>> dl.set_output(
+        ...   fmt="pd.DataFrame",
+        ...   merge_files=False,
+        ...   columns=["daqenergy", "trapEmax", "channel"]
+        ... )
         """
         if fmt not in ["lgdo.Table", "pd.DataFrame", None]:
             raise ValueError(f"'{fmt}' output format not supported")
@@ -356,8 +361,9 @@ class DataLoader:
             self.aoesa_to_vov = aoesa_to_vov
 
     def reset(self):
-        """Resets all fields to their default values, as if this is a newly
-        created data loader.
+        """Resets all fields to their default values.
+
+        As if this is a newly created data loader.
         """
         self.file_list = None
         self.table_list = None

--- a/src/pygama/flow/file_db.py
+++ b/src/pygama/flow/file_db.py
@@ -574,3 +574,30 @@ class FileDB:
             "<< DataFrame >>\n" + self.df.__repr__()
         )
         return string
+
+    def get_table_name(self, tier: str, tb: str) -> str:
+        """Get the table name for a tier given its table identifier.
+
+        Parameters
+        ----------
+        tier
+            specify the tier whose table format will be used.
+        tb
+            the table identifier that will be passed to the table format.
+
+        Returns
+        -------
+        table_name
+            the name of the table in `tier` with table identifier `tb`
+        """
+        template = self.table_format[tier]
+        fm = string.Formatter()
+        parse_arr = np.array(list(fm.parse(template)))
+        names = list(parse_arr[:, 1])
+        if len(names) > 0:
+            keyword = names[0]
+            args = {keyword: tb}
+            table_name = template.format(**args)
+        else:
+            table_name = template
+        return table_name

--- a/src/pygama/flow/file_db.py
+++ b/src/pygama/flow/file_db.py
@@ -482,6 +482,7 @@ class FileDB:
             columns.append([v.decode("utf-8") for v in ov])
         self.columns = columns
 
+    # TODO: rename to write() or dump() and make it accept an i/o stream
     def to_disk(self, filename: str, wo_mode="write_safe") -> None:
         """Serializes database to disk.
 

--- a/src/pygama/flow/utils.py
+++ b/src/pygama/flow/utils.py
@@ -1,3 +1,7 @@
+"""Utility functions."""
+
+from __future__ import annotations
+
 import logging
 import re
 

--- a/src/pygama/flow/utils.py
+++ b/src/pygama/flow/utils.py
@@ -1,0 +1,52 @@
+import re
+
+import numpy as np
+
+from pygama.lgdo import (
+    Array,
+    ArrayOfEqualSizedArrays,
+    Table,
+    VectorOfVectors,
+    WaveformTable,
+)
+
+
+def dict_to_table(col_dict: dict, attr_dict: dict):
+    for col in col_dict.keys():
+        if isinstance(col_dict[col], list):
+            if isinstance(col_dict[col][0], (list, np.ndarray, Array)):
+                # Convert to VectorOfVectors if there is array-like in a list
+                col_dict[col] = VectorOfVectors(
+                    listoflists=col_dict[col], attrs=attr_dict[col]
+                )
+            else:
+                # Elements are scalars, convert to Array
+                nda = np.array(col_dict[col])
+                col_dict[col] = Array(nda=nda, attrs=attr_dict[col])
+        elif isinstance(col_dict[col], dict):
+            # Dicts are Tables
+            col_dict[col] = dict_to_table(
+                col_dict=col_dict[col], attr_dict=attr_dict[col]
+            )
+        else:
+            # ndas are Arrays or AOESA
+            nda = np.array(col_dict[col])
+            if len(nda.shape) == 2:
+                dt = attr_dict[col]["datatype"]
+                g = re.match(r"\w+<(\d+),(\d+)>{\w+}", dt).groups()
+                dims = [int(e) for e in g]
+                col_dict[col] = ArrayOfEqualSizedArrays(
+                    dims=dims, nda=nda, attrs=attr_dict[col]
+                )
+            else:
+                col_dict[col] = Array(nda=nda, attrs=attr_dict[col])
+        attr_dict.pop(col)
+    if set(col_dict.keys()) == {"t0", "dt", "values"}:
+        return WaveformTable(
+            t0=col_dict["t0"],
+            dt=col_dict["dt"],
+            values=col_dict["values"],
+            attrs=attr_dict,
+        )
+    else:
+        return Table(col_dict=col_dict)

--- a/src/pygama/logging.py
+++ b/src/pygama/logging.py
@@ -3,6 +3,13 @@ import logging
 
 import colorlog
 
+DEBUG = logging.DEBUG
+INFO = logging.INFO
+WARNING = logging.WARNING
+ERROR = logging.ERROR
+FATAL = logging.FATAL
+CRITICAL = logging.CRITICAL
+
 
 def setup(level: int = logging.INFO, logger: logging.Logger = None) -> None:
     """Setup a colorful logging output.
@@ -15,6 +22,11 @@ def setup(level: int = logging.INFO, logger: logging.Logger = None) -> None:
         logging level (see :mod:`logging` module).
     logger
         if not `None`, setup this logger.
+
+    Examples
+    --------
+    >>> from pygama import logging
+    >>> logging.setup(level=logging.DEBUG)
     """
     handler = colorlog.StreamHandler()
     handler.setFormatter(

--- a/tests/flow/test_data_loader.py
+++ b/tests/flow/test_data_loader.py
@@ -20,7 +20,7 @@ def test_dl(lgnd_test_data):
     return DataLoader(f"{config_dir}/data-loader-config.json", db_config)
 
 
-def test_init(test_filedb):
+def test_init(test_dl):
     pass
 
 

--- a/tests/flow/test_data_loader.py
+++ b/tests/flow/test_data_loader.py
@@ -33,6 +33,15 @@ def test_simple_load(test_dl):
     assert list(data.keys()) == ["hit_table", "hit_idx", "file", "timestamp"]
 
 
+def test_simple_chunked_load(test_dl):
+    test_dl.set_files("all")
+    test_dl.set_output(columns=["timestamp"])
+    for data in test_dl.next(chunk_size=2):
+        assert len(data) == 2
+        assert isinstance(data, lgdo.Table)
+        assert list(data.keys()) == ["hit_table", "hit_idx", "file", "timestamp"]
+
+
 def test_load_wfs(test_dl):
     test_dl.set_files("all")
     test_dl.set_output(columns=["waveform"], fmt="lgdo.Table")


### PR DESCRIPTION
Usage:
```python
dl = DataLoader(...)
for chunk in dl.next(chunk_size=10000): # rows in entry_list
  crunch(chunk)
```
I set a default of `chunk_size=10000`, which corresponds to less than 1GB of LEGEND waveforms, but its value is of course very much application dependent and should be adjusted by the user.

I also moved some utility functions to the `flow.utils` module.