### PR TITLE
Properly substitute variables in `FileDB` and `DataLoader` configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -20,7 +20,6 @@ build:
         --private
         --module-first
         --force
-        --maxdepth 10
         --output-dir docs/source/api
         src/pygama
         src/pygama/_version.py

--- a/src/pygama/flow/data_loader.py
+++ b/src/pygama/flow/data_loader.py
@@ -15,7 +15,7 @@ import numpy as np
 import pandas as pd
 from tqdm import tqdm
 
-from pygama.lgdo import Array, LH5Store, Struct, Table
+from pygama.lgdo import Array, LH5Store, Struct, Table, lgdo_utils
 from pygama.lgdo.vectorofvectors import build_cl, explode_arrays, explode_cl
 
 from . import utils
@@ -193,7 +193,9 @@ class DataLoader:
         # look for info in configuration if FileDB is not set
         if self.filedb is None:
             # expand $_ variables
-            value = string.Template(config["filedb"]).substitute({"_": config_dir})
+            value = lgdo_utils.expand_vars(
+                config["filedb"], substitute={"_": config_dir}
+            )
             self.filedb = FileDB(value)
 
         if not os.path.isdir(self.filedb.data_dir):

--- a/src/pygama/flow/file_db.py
+++ b/src/pygama/flow/file_db.py
@@ -193,9 +193,7 @@ class FileDB:
 
         tier_dirs = self.config["tier_dirs"]
         for k, val in tier_dirs.items():
-            tier_dirs[k] = lgdo.lgdo_utils.expand_vars(
-                val, substitute=subst_vars
-            )
+            tier_dirs[k] = lgdo.lgdo_utils.expand_vars(val, substitute=subst_vars)
         self.tier_dirs = tier_dirs
 
     def scan_files(self, dirs: list[str] = None) -> None:

--- a/src/pygama/flow/file_db.py
+++ b/src/pygama/flow/file_db.py
@@ -182,26 +182,21 @@ class FileDB:
 
         # expand/substitute variables in data_dir and tier_dirs
         # $_ expands to the location of the config file
-        config_dir = None
+        subst_vars = {}
         if config_path is not None:
-            config_dir = os.path.dirname(str(config_path))
+            subst_vars["_"] = os.path.dirname(str(config_path))
 
         data_dir = lgdo.lgdo_utils.expand_path(
-            self.config["data_dir"], substitute={"_", config_dir}
+            self.config["data_dir"], substitute=subst_vars
         )
+        self.data_dir = data_dir
 
         tier_dirs = self.config["tier_dirs"]
         for k, val in tier_dirs.items():
             tier_dirs[k] = lgdo.lgdo_utils.expand_vars(
-                val, substitute={"_", config_dir}
+                val, substitute=subst_vars
             )
         self.tier_dirs = tier_dirs
-
-        # relative paths are also interpreted relative to the configuration file
-        if not data_dir.startswith("/"):
-            data_dir = os.path.join(config_dir, data_dir.lstrip("/"))
-            data_dir = os.path.abspath(data_dir)
-        self.data_dir = data_dir
 
     def scan_files(self, dirs: list[str] = None) -> None:
         """Scan the directory containing files from the lowest tier and fill the dataframe.

--- a/src/pygama/flow/file_db.py
+++ b/src/pygama/flow/file_db.py
@@ -182,7 +182,9 @@ class FileDB:
 
         # expand/substitute variables in data_dir and tier_dirs
         # $_ expands to the location of the config file
-        config_dir = os.path.dirname(str(config_path))
+        config_dir = None
+        if config_path is not None:
+            config_dir = os.path.dirname(str(config_path))
 
         data_dir = lgdo.lgdo_utils.expand_path(
             self.config["data_dir"], substitute={"_", config_dir}

--- a/src/pygama/lgdo/lgdo_utils.py
+++ b/src/pygama/lgdo/lgdo_utils.py
@@ -124,6 +124,11 @@ def parse_datatype(datatype: str) -> tuple[str, tuple[int, ...], str | list[str]
 def expand_vars(expr: str, substitute: dict[str, str] = None) -> str:
     """Expand (environment) variables.
 
+    Note
+    ----
+    Malformed variable names and references to non-existing variables are left
+    unchanged.
+
     Parameters
     ----------
     expr
@@ -167,7 +172,6 @@ def expand_path(
     path or list of paths
         Unique absolute path, or list of all absolute paths
     """
-
     if base_path is not None and base_path != "":
         base_path = os.path.expanduser(os.path.expandvars(base_path))
         path = os.path.join(base_path, path)

--- a/src/pygama/lgdo/lgdo_utils.py
+++ b/src/pygama/lgdo/lgdo_utils.py
@@ -121,6 +121,26 @@ def parse_datatype(datatype: str) -> tuple[str, tuple[int, ...], str | list[str]
         return datatype, None, element_description.split(",")
 
 
+def expand_vars(expr: str, substitute: dict[str, str] = None) -> str:
+    """Expand (environment) variables.
+
+    Parameters
+    ----------
+    expr
+        string expression, which may include (environment) variables prefixed by
+        ``$``.
+    substitute
+        use this dictionary to substitute variables. Environment variables take
+        precedence.
+    """
+    if substitute is None:
+        substitute = {}
+
+    # expand env variables first
+    # then try using provided mapping
+    return string.Template(os.path.expandvars(expr)).safe_substitute(substitute)
+
+
 def expand_path(
     path: str, substitute: dict[str, str] = None, list: bool = False
 ) -> str | list:
@@ -143,14 +163,7 @@ def expand_path(
         Unique absolute path, or list of all absolute paths
     """
 
-    if substitute is None:
-        substitute = {}
-
-    # expand env variables first
-    _path = os.path.expandvars(path)
-
-    # then try using provided mapping
-    _path = string.Template(_path).safe_substitute(substitute)
+    _path = expand_vars(path, substitute)
 
     # then expand wildcards
     paths = glob.glob(os.path.expanduser(_path))

--- a/src/pygama/lgdo/lh5_store.py
+++ b/src/pygama/lgdo/lh5_store.py
@@ -1456,7 +1456,7 @@ class LH5Iterator:
 
         # List of files, with wildcards and env vars expanded
         if isinstance(lh5_files, str):
-            lh5_files = expand_path(lh5_files, True)
+            lh5_files = expand_path(lh5_files, list=True)
         elif not isinstance(lh5_files, list):
             raise ValueError("lh5_files must be a string or list of strings")
 
@@ -1465,7 +1465,7 @@ class LH5Iterator:
                 "entry_list and entry_mask arguments are mutually exclusive"
             )
 
-        self.lh5_files = [f for f_wc in lh5_files for f in expand_path(f_wc, True)]
+        self.lh5_files = [f for f_wc in lh5_files for f in expand_path(f_wc, list=True)]
 
         # Map to last row in each file
         self.file_map = np.array(

--- a/src/pygama/lgdo/lh5_store.py
+++ b/src/pygama/lgdo/lh5_store.py
@@ -1462,7 +1462,7 @@ class LH5Iterator(Iterator):
         # List of files, with wildcards and env vars expanded
         if isinstance(lh5_files, str):
             lh5_files = [lh5_files]
-            if isinstance(groups, list=True):
+            if isinstance(groups, list):
                 lh5_files *= len(groups)
         elif not isinstance(lh5_files, list):
             raise ValueError("lh5_files must be a string or list of strings")

--- a/tests/lgdo/test_lgdo_utils.py
+++ b/tests/lgdo/test_lgdo_utils.py
@@ -68,4 +68,19 @@ def test_expand_path(lgnd_test_data):
         lgdo_utils.expand_path(f"{base_dir}/*.lh5")
 
     # Check if it finds a list of files correctly
-    assert sorted(lgdo_utils.expand_path(f"{base_dir}/*.lh5", True)) == sorted(files)
+    assert sorted(lgdo_utils.expand_path(f"{base_dir}/*.lh5", list=True)) == sorted(
+        files
+    )
+
+    # Check env variable expansion
+    os.environ["PYGAMATESTBASEDIR"] = base_dir
+    assert lgdo_utils.expand_path("$PYGAMATESTBASEDIR/*20220716T104550Z*") == files[0]
+
+    # Check user variable expansion
+    assert (
+        lgdo_utils.expand_path(
+            "$PYGAMATESTBASEDIR2/*20220716T104550Z*",
+            substitute={"PYGAMATESTBASEDIR2": base_dir},
+        )
+        == files[0]
+    )

--- a/tests/lgdo/test_lgdo_utils.py
+++ b/tests/lgdo/test_lgdo_utils.py
@@ -46,6 +46,21 @@ def test_parse_datatype():
         assert pd_dt_tuple == dt_tuple
 
 
+def test_expand_vars():
+    # Check env variable expansion
+    os.environ["PYGAMATESTBASEDIR"] = "a_random_string"
+    assert lgdo_utils.expand_vars("$PYGAMATESTBASEDIR/blah") == "a_random_string/blah"
+
+    # Check user variable expansion
+    assert (
+        lgdo_utils.expand_vars(
+            "$PYGAMATESTBASEDIR2/blah",
+            substitute={"PYGAMATESTBASEDIR2": "a_random_string"},
+        )
+        == "a_random_string/blah"
+    )
+
+
 def test_expand_path(lgnd_test_data):
     files = [
         lgnd_test_data.get_path(
@@ -70,17 +85,4 @@ def test_expand_path(lgnd_test_data):
     # Check if it finds a list of files correctly
     assert sorted(lgdo_utils.expand_path(f"{base_dir}/*.lh5", list=True)) == sorted(
         files
-    )
-
-    # Check env variable expansion
-    os.environ["PYGAMATESTBASEDIR"] = base_dir
-    assert lgdo_utils.expand_path("$PYGAMATESTBASEDIR/*20220716T104550Z*") == files[0]
-
-    # Check user variable expansion
-    assert (
-        lgdo_utils.expand_path(
-            "$PYGAMATESTBASEDIR2/*20220716T104550Z*",
-            substitute={"PYGAMATESTBASEDIR2": base_dir},
-        )
-        == files[0]
     )


### PR DESCRIPTION
Environment variables are now properly substituted everywhere. `$_` expands to the location of the configuration file.