### PR TITLE
Fix merging of FileDBs

### DIFF
--- a/src/pygama/flow/file_db.py
+++ b/src/pygama/flow/file_db.py
@@ -506,7 +506,7 @@ class FileDB:
 
         if not paths:
             raise FileNotFoundError(path)
-            
+
         # Need order of fileDBs to be consistent
         paths = sorted(paths)
 
@@ -553,7 +553,7 @@ class FileDB:
                             # current dataframe has a column not in our list
                             # add the new column at the end and save its index
                             _columns += [cols]
-                            new_idx = len(_columns) - 1    
+                            new_idx = len(_columns) - 1
                         elif idx < _columns.index(cols):
                             # column is in our list, but out of order
                             # find and save index of column in our list


### PR DESCRIPTION
Merging of FileDBs introduced in #481 did not work as intended. Re-indexing only occurred for the first FileDB that had different columns. The re-indexing was also not properly implemented, leading to mismatches between {tier}_tables and {tier}_col_idxs. This PR fixes these issues.

Merge assumes the first FileDB in the list has less columns than the later FileDB's (such as from a calibration run). Sorts the list of FileDB's before merging to aid in this purpose.


<!---

Before submitting a pull request, please make sure you've read and understood the pygama developer's guide: https://pygama.readthedocs.io/en/latest/developer.html. In particular, do not forget to:

- Conform to our coding conventions
- Update existing or add new tests
- Update existing or add new documentation
- Address any issue reported by GitHub checks

--->
