### PR TITLE
Fixed error in `DataLoader.get_iterator()` caused when no column is requested from a data tier

### DIFF
--- a/src/pygama/flow/data_loader.py
+++ b/src/pygama/flow/data_loader.py
@@ -1355,7 +1355,7 @@ class DataLoader:
                         ]
 
                     # Create iterator for this tier and friend to other tiers
-                    if len(lh5_files)>0:
+                    if len(lh5_files) > 0:
                         lh5_it = LH5Iterator(
                             lh5_files=lh5_files,
                             groups=tb_names,

--- a/src/pygama/flow/data_loader.py
+++ b/src/pygama/flow/data_loader.py
@@ -1355,15 +1355,16 @@ class DataLoader:
                         ]
 
                     # Create iterator for this tier and friend to other tiers
-                    lh5_it = LH5Iterator(
-                        lh5_files=lh5_files,
-                        groups=tb_names,
-                        base_path=self.data_dir,
-                        entry_list=idx_list,
-                        field_mask=field_mask,
-                        buffer_len=buffer_len,
-                        friend=lh5_it,
-                    )
+                    if len(lh5_files)>0:
+                        lh5_it = LH5Iterator(
+                            lh5_files=lh5_files,
+                            groups=tb_names,
+                            base_path=self.data_dir,
+                            entry_list=idx_list,
+                            field_mask=field_mask,
+                            buffer_len=buffer_len,
+                            friend=lh5_it,
+                        )
 
             return lh5_it
         else:  # not merge_files


### PR DESCRIPTION
<!---

Before submitting a pull request, please make sure you've read and understood the pygama developer's guide: https://pygama.readthedocs.io/en/latest/developer.html. In particular, do not forget to:

- Conform to our coding conventions
- Update existing or add new tests
- Update existing or add new documentation
- Address any issue reported by GitHub checks

--->
