### PR TITLE
Fixed FFTW processors for use with refactor

### DIFF
--- a/src/pygama/dsp/processing_chain.py
+++ b/src/pygama/dsp/processing_chain.py
@@ -1165,6 +1165,7 @@ class ProcessorManager:
         ):
             dim_list = outerdims.copy()
             for d in dims.split(","):
+                d = d.strip()
                 if not d:
                     continue
                 if d not in dims_dict:

--- a/src/pygama/dsp/processing_chain.py
+++ b/src/pygama/dsp/processing_chain.py
@@ -1092,7 +1092,7 @@ class ProcessorManager:
                         if not ad or this_dim.length != ad:
                             raise ProcessingChainError(
                                 f"failed to broadcast array dimensions for "
-                                f"{func.__name}. Could not find consistent value "
+                                f"{func.__name__}. Could not find consistent value "
                                 f"for dimension {fd}"
                             )
                         if not this_dim.grid:

--- a/src/pygama/dsp/processing_chain.py
+++ b/src/pygama/dsp/processing_chain.py
@@ -1084,7 +1084,13 @@ class ProcessorManager:
             # check if arr_dims can be broadcast to match fun_dims
             for i in range(max(len(fun_dims), len(arr_dims))):
                 fd = fun_dims[-i - 1] if i < len(fun_dims) else None
-                ad = arr_dims[-i - 1] if i < len(arr_dims) else self.proc_chain._block_width if i==len(arr_dims) else None
+                ad = (
+                    arr_dims[-i - 1]
+                    if i < len(arr_dims)
+                    else self.proc_chain._block_width
+                    if i == len(arr_dims)
+                    else None
+                )
 
                 if isinstance(fd, str):
                     if fd in dims_dict:

--- a/src/pygama/dsp/processing_chain.py
+++ b/src/pygama/dsp/processing_chain.py
@@ -1084,7 +1084,7 @@ class ProcessorManager:
             # check if arr_dims can be broadcast to match fun_dims
             for i in range(max(len(fun_dims), len(arr_dims))):
                 fd = fun_dims[-i - 1] if i < len(fun_dims) else None
-                ad = arr_dims[-i - 1] if i < len(arr_dims) else None
+                ad = arr_dims[-i - 1] if i < len(arr_dims) else self.proc_chain._block_width if i==len(arr_dims) else None
 
                 if isinstance(fd, str):
                     if fd in dims_dict:

--- a/src/pygama/dsp/processors/fftw.py
+++ b/src/pygama/dsp/processors/fftw.py
@@ -7,16 +7,29 @@ from numba import guvectorize
 from pyfftw import FFTW
 
 from pygama.dsp.utils import numba_defaults_kwargs as nb_kwargs
+from pygama.dsp.processing_chain import ProcChainVar
 
-
-def dft(buf_in: np.ndarray, buf_out: np.ndarray) -> Callable:
+def dft(w_in: np.ndarray | ProcChainVar, w_out: np.ndarray | ProcChainVar) -> Callable:
     """Perform discrete Fourier transforms using the FFTW library.
 
-    Note
-    ----
-    This processor is composed of a factory function that is called using the
-    `init_args` argument. The input and output waveforms are passed using
-    `args`.
+    Parameters
+    ----------
+    w_in
+        the input waveform.
+    w_out
+        the output fourier transform.
+
+    JSON Configuration Example
+    --------------------------
+
+    .. code-block :: json
+
+        "wf_dft": {
+            "function": "dft",
+            "module": "pygama.dsp.processors",
+            "args": ["wf", "wf_dft"],
+            "init_args": ["wf", "wf_dft"]
+        }
 
     Note
     ----
@@ -25,11 +38,8 @@ def dft(buf_in: np.ndarray, buf_out: np.ndarray) -> Callable:
     is a factory function that returns a Numba gufunc that performs the FFT.
     FFTW works on fixed memory buffers, so you must tell it what memory to use
     ahead of time.  When using this with
-    :class:`~.dsp.processing_chain.ProcessingChain`, to ensure the correct
-    buffers are used, call
-    :meth:`~.dsp.processing_chain.ProcessingChain.get_variable` to give it the
-    internal memory buffer directly. With :func:`~.dsp.build_dsp.build_dsp`,
-    you can just give it the name, and it will automatically happen. The
+    :class:`~.dsp.processing_chain.ProcessingChain`, the output waveform's size,
+    dtype and coordinate grid units can be set automatically.  The
     possible `dtypes` for the input/outputs are:
 
     =============================== ========= =============================== =============
@@ -43,15 +53,34 @@ def dft(buf_in: np.ndarray, buf_out: np.ndarray) -> Callable:
     ``complex256``/``clongdouble``  :math:`n` ``complex256``/``clongdouble``  :math:`n`
     =============================== ========= =============================== =============
     """
+    # if we have a ProcChainVar, set up the output and get numpy arrays
+    if isinstance(w_in, ProcChainVar) and isinstance(w_out, ProcChainVar):
+        c = w_in.dtype.kind
+        s = w_in.dtype.itemsize
+        if c=="f":
+            w_out.update_auto(
+                shape = w_in.shape[:-1] + (w_in.shape[-1]//2 + 1,),
+                dtype = np.dtype(f"c{2*s}"),
+                period = 1./w_in.period/w_in.shape[-1]
+            )
+        elif c=="c":
+            w_out.update_auto(
+                shape = w_in.shape,
+                dtype = np.dtype(f"c{s}"),
+                period = 1./w_in.period/w_in.shape[-1]
+            )
+        w_in = w_in.buffer
+        w_out = w_out.buffer
+
     try:
-        dft_fun = FFTW(buf_in, buf_out, axes=(-1,), direction="FFTW_FORWARD")
+        dft_fun = FFTW(w_in, w_out, axes=(-1,), direction="FFTW_FORWARD")
     except ValueError:
         raise ValueError(
             "incompatible array types/shapes. See function documentation for allowed values"
         )
 
-    typesig = "void(" + str(buf_in.dtype) + "[:, :], " + str(buf_out.dtype) + "[:, :])"
-    sizesig = "(m, n)->(m, n)" if buf_in.shape == buf_out.shape else "(m, n),(m, l)"
+    typesig = "void(" + str(w_in.dtype) + "[:, :], " + str(w_out.dtype) + "[:, :])"
+    sizesig = "(m, n)->(m, n)" if w_in.shape == w_out.shape else "(m, n),(m, l)"
 
     @guvectorize(
         [typesig],
@@ -67,14 +96,27 @@ def dft(buf_in: np.ndarray, buf_out: np.ndarray) -> Callable:
     return dft
 
 
-def inv_dft(buf_in: np.ndarray, buf_out: np.ndarray) -> Callable:
+def inv_dft(w_in: np.ndarray, w_out: np.ndarray) -> Callable:
     """Perform inverse discrete Fourier transforms using the FFTW library.
 
-    Note
-    ----
-    This processor is composed of a factory function that is called using the
-    `init_args` argument. The input and output waveforms are passed using
-    `args`.
+    Parameters
+    ----------
+    w_in
+        the input fourier transformed waveform.
+    w_out
+        the output time-domain waveform.
+
+    JSON Configuration Example
+    --------------------------
+
+    .. code-block :: json
+
+        "wf_invdft": {
+            "function": "inv_dft",
+            "module": "pygama.dsp.processors",
+            "args": ["wf_dft", "wf_invdft"],
+            "init_args": ["wf_dft", "wf_invdft"]
+        }
 
     Note
     ----
@@ -83,12 +125,10 @@ def inv_dft(buf_in: np.ndarray, buf_out: np.ndarray) -> Callable:
     is a factory function that returns a Numba gufunc that performs the FFT.
     FFTW works on fixed memory buffers, so you must tell it what memory to use
     ahead of time.  When using this with
-    :class:`~.dsp.processing_chain.ProcessingChain`, to ensure the correct
-    buffers are used, call
-    :meth:`~.dsp.processing_chain.ProcessingChain.get_variable` to give it the
-    internal memory buffer directly. With :func:`~.dsp.build_dsp.build_dsp`,
-    you can just give it the name, and it will automatically happen. The
-    possible `dtypes` for the input/outputs are:
+    :class:`~.dsp.processing_chain.ProcessingChain`, the output waveform's size,
+    dtype and coordinate grid units can be set automatically.  The automated
+    behavior will produce a real output by default, unless you specify a complex
+    output. Possible `dtypes` for the input/outputs are:
 
     =============================== ============= =============================== =========
     :class:`numpy.dtype`            Size          :class:`numpy.dtype`            Size
@@ -101,15 +141,32 @@ def inv_dft(buf_in: np.ndarray, buf_out: np.ndarray) -> Callable:
     ``complex256``/``clongdouble``  :math:`n`     ``complex256``/``clongdouble``  :math:`n`
     =============================== ============= =============================== =========
     """
+    # if we have a ProcChainVar, set up the output and get numpy arrays
+    if isinstance(w_in, ProcChainVar) and isinstance(w_out, ProcChainVar):
+        s = w_in.dtype.itemsize
+        if w_out.dtype=="auto":
+            w_out.update_auto(
+                shape = w_in.shape[:-1] + (2*(w_in.shape[-1]-1),),
+                dtype = np.dtype(f"f{s//2}"),
+                period = 1./w_in.period/w_in.shape[-1]
+            )
+        else:
+            w_out.update_auto(
+                shape = w_in.shape if w_out.dtype.kind=="c" else w_in.shape[:-1] + (2*(w_in.shape[-1]-1),),
+                period = 1./w_in.period/w_in.shape[-1]
+            )
+        w_in = w_in.buffer
+        w_out = w_out.buffer
+
     try:
-        idft_fun = FFTW(buf_in, buf_out, axes=(-1,), direction="FFTW_BACKWARD")
+        idft_fun = FFTW(w_in, w_out, axes=(-1,), direction="FFTW_BACKWARD")
     except ValueError:
         raise ValueError(
             "incompatible array types/shapes. See function documentation for allowed values"
         )
 
-    typesig = "void(" + str(buf_in.dtype) + "[:, :], " + str(buf_out.dtype) + "[:, :])"
-    sizesig = "(m, n)->(m, n)" if buf_in.shape == buf_out.shape else "(m, n),(m, l)"
+    typesig = "void(" + str(w_in.dtype) + "[:, :], " + str(w_out.dtype) + "[:, :])"
+    sizesig = "(m, n)->(m, n)" if w_in.shape == w_out.shape else "(m, n),(m, l)"
 
     @guvectorize(
         [typesig],
@@ -125,15 +182,28 @@ def inv_dft(buf_in: np.ndarray, buf_out: np.ndarray) -> Callable:
     return inv_dft
 
 
-def psd(buf_in: np.ndarray, buf_out: np.ndarray) -> Callable:
+def psd(w_in: np.ndarray, w_out: np.ndarray) -> Callable:
     """Perform discrete Fourier transforms using the FFTW library, and use it to get
     the power spectral density.
 
-    Note
-    ----
-    This processor is composed of a factory function that is called using the
-    `init_args` argument. The input and output waveforms are passed using
-    `args`.
+    Parameters
+    ----------
+    w_in
+        the input waveform.
+    w_out
+        the output fourier transform.
+
+    JSON Configuration Example
+    --------------------------
+
+    .. code-block :: json
+
+        "wf_psd": {
+            "function": "psd",
+            "module": "pygama.dsp.processors",
+            "args": ["wf", "wf_psd"],
+            "init_args": ["wf", "wf_psd"]
+        }
 
     Note
     ----
@@ -142,11 +212,8 @@ def psd(buf_in: np.ndarray, buf_out: np.ndarray) -> Callable:
     is a factory function that returns a Numba gufunc that performs the FFT.
     FFTW works on fixed memory buffers, so you must tell it what memory to use
     ahead of time.  When using this with
-    :class:`~.dsp.processing_chain.ProcessingChain`, to ensure the correct
-    buffers are used, call
-    :meth:`~.dsp.processing_chain.ProcessingChain.get_variable` to give it the
-    internal memory buffer directly. With :func:`~.dsp.build_dsp.build_dsp`,
-    you can just give it the name, and it will automatically happen. The
+    :class:`~.dsp.processing_chain.ProcessingChain`, the output waveform's size,
+    dtype and coordinate grid units can be set automatically.  The
     possible `dtypes` for the input/outputs are:
 
     =============================== ========= ============================ =============
@@ -160,20 +227,38 @@ def psd(buf_in: np.ndarray, buf_out: np.ndarray) -> Callable:
     ``float128``/``longdouble``     :math:`n` ``float128``/``longdouble``  :math:`n/2+1`
     =============================== ========= ============================ =============
     """
+    # if we have a ProcChainVar, set up the output and get numpy arrays
+    if isinstance(w_in, ProcChainVar) and isinstance(w_out, ProcChainVar):
+        c = w_in.dtype.kind
+        s = w_in.dtype.itemsize
+        if c=="f":
+            w_out.update_auto(
+                shape = w_in.shape[:-1] + (w_in.shape[-1]//2 + 1,),
+                dtype = np.dtype(f"f{s}"),
+                period = 1./w_in.period/w_in.shape[-1]
+            )
+        elif c=="c":
+            w_out.update_auto(
+                shape = w_in.shape,
+                dtype = np.dtype(f"f{s//2}"),
+                period = 1./w_in.period/w_in.shape[-1]
+            )
+        w_in = w_in.buffer
+        w_out = w_out.buffer
 
     # build intermediate array for the dft, which will be abs'd to get the PSD
-    buf_dft = np.ndarray(
-        buf_out.shape, np.dtype("complex" + str(buf_out.dtype.itemsize * 16))
+    w_dft = np.ndarray(
+        w_out.shape, np.dtype(f"c{w_in.dtype.itemsize*2}")
     )
     try:
-        dft_fun = FFTW(buf_in, buf_dft, axes=(-1,), direction="FFTW_FORWARD")
+        dft_fun = FFTW(w_in, w_dft, axes=(-1,), direction="FFTW_FORWARD")
     except ValueError:
         raise ValueError(
             "incompatible array types/shapes. See function documentation for allowed values"
         )
 
-    typesig = "void(" + str(buf_in.dtype) + "[:, :], " + str(buf_out.dtype) + "[:, :])"
-    sizesig = "(m, n)->(m, n)" if buf_in.shape == buf_out.shape else "(m, n),(m, l)"
+    typesig = "void(" + str(w_in.dtype) + "[:, :], " + str(w_out.dtype) + "[:, :])"
+    sizesig = "(m, n)->(m, n)" if w_in.shape == w_out.shape else "(m, n),(m, l)"
 
     @guvectorize(
         [typesig],
@@ -184,7 +269,7 @@ def psd(buf_in: np.ndarray, buf_out: np.ndarray) -> Callable:
         ),
     )
     def psd(wf_in: np.ndarray, psd_out: np.ndarray) -> None:
-        dft_fun(wf_in, buf_dft)
-        np.abs(buf_dft, psd_out)
+        dft_fun(wf_in, w_dft)
+        np.abs(w_dft, psd_out)
 
     return psd

--- a/tests/dsp/processors/test_fftw.py
+++ b/tests/dsp/processors/test_fftw.py
@@ -9,7 +9,7 @@ def test_dft(compare_numba_vs_python):
     """Testing function for the discrete fourier transform."""
 
     # set up arrays to use
-    w_in = np.ones(shape=(16, 100), dtype="float32")
+    w_in = np.zeros(shape=(16, 100), dtype="float32")
     w_dft = np.zeros(shape=(16, 51), dtype="complex64")
 
     # ensure the DSPFatal is raised for incorrect shaps/types
@@ -21,6 +21,8 @@ def test_dft(compare_numba_vs_python):
     w_expected[:, 0] = 100.
     
     dft_func = dft(w_in, w_dft)
+    w_in[:] = 1.
+
     assert np.allclose(
         compare_numba_vs_python(dft_func, w_in, w_dft),
         w_expected,
@@ -34,7 +36,7 @@ def test_inv_dft(compare_numba_vs_python):
     """Testing function for the inverse discrete fourier transform."""
 
     # set up arrays to use
-    w_in = np.ones(shape=(16, 51), dtype="complex64")
+    w_in = np.zeros(shape=(16, 51), dtype="complex64")
     w_inv_dft = np.zeros(shape=(16, 100), dtype="float32")
 
     # ensure the DSPFatal is raised for incorrect shaps/types
@@ -46,6 +48,8 @@ def test_inv_dft(compare_numba_vs_python):
     w_expected[:, 0] = 1.
     
     inv_dft_func = inv_dft(w_in, w_inv_dft)
+    w_in[:] = 1.
+
     assert np.allclose(
         compare_numba_vs_python(inv_dft_func, w_in, w_inv_dft),
         w_expected,
@@ -59,7 +63,7 @@ def test_psd(compare_numba_vs_python):
     """Testing function for the power spectral density."""
 
     # set up arrays to use
-    w_in = np.ones(shape=(16, 100), dtype="float32")
+    w_in = np.zeros(shape=(16, 100), dtype="float32")
     w_psd = np.zeros(shape=(16, 51), dtype="float32")
 
     # ensure the DSPFatal is raised for incorrect shaps/types
@@ -71,6 +75,8 @@ def test_psd(compare_numba_vs_python):
     w_expected[:, 0] = 100.
     
     psd_func = psd(w_in, w_psd)
+    w_in[:] = 1.
+
     assert np.allclose(
         compare_numba_vs_python(psd_func, w_in, w_psd),
         w_expected,

--- a/tests/dsp/processors/test_fftw.py
+++ b/tests/dsp/processors/test_fftw.py
@@ -1,0 +1,81 @@
+import numpy as np
+import pytest
+
+from pygama.dsp.errors import DSPFatal
+from pygama.dsp.processors import dft, inv_dft, psd
+
+
+def test_dft(compare_numba_vs_python):
+    """Testing function for the discrete fourier transform."""
+
+    # set up arrays to use
+    w_in = np.ones(shape=(16, 100), dtype="float32")
+    w_dft = np.zeros(shape=(16, 51), dtype="complex64")
+
+    # ensure the DSPFatal is raised for incorrect shaps/types
+    with pytest.raises(ValueError):
+        dft(w_in, np.zeros_like(w_in))
+
+    # ensure that a valid input gives the expected output
+    w_expected = np.zeros_like(w_dft)
+    w_expected[:, 0] = 100.
+    
+    dft_func = dft(w_in, w_dft)
+    assert np.allclose(
+        compare_numba_vs_python(dft_func, w_in, w_dft),
+        w_expected,
+    )
+
+    # ensure that if there is a nan in w_in, all nans are outputted
+    w_in[:, 10] = np.nan
+    assert np.all(np.isnan(compare_numba_vs_python(dft_func, w_in, w_dft)))
+
+def test_inv_dft(compare_numba_vs_python):
+    """Testing function for the inverse discrete fourier transform."""
+
+    # set up arrays to use
+    w_in = np.ones(shape=(16, 51), dtype="complex64")
+    w_inv_dft = np.zeros(shape=(16, 100), dtype="float32")
+
+    # ensure the DSPFatal is raised for incorrect shaps/types
+    with pytest.raises(ValueError):
+        inv_dft(w_in, np.zeros(shape=(16, 51), dtype="float32"))
+
+    # ensure that a valid input gives the expected output
+    w_expected = np.zeros_like(w_inv_dft)
+    w_expected[:, 0] = 1.
+    
+    inv_dft_func = inv_dft(w_in, w_inv_dft)
+    assert np.allclose(
+        compare_numba_vs_python(inv_dft_func, w_in, w_inv_dft),
+        w_expected,
+    )
+
+    # ensure that if there is a nan in w_in, all nans are outputted
+    w_in[:, 10] = np.nan
+    assert np.all(np.isnan(compare_numba_vs_python(inv_dft_func, w_in, w_inv_dft)))
+
+def test_psd(compare_numba_vs_python):
+    """Testing function for the power spectral density."""
+
+    # set up arrays to use
+    w_in = np.ones(shape=(16, 100), dtype="float32")
+    w_psd = np.zeros(shape=(16, 51), dtype="float32")
+
+    # ensure the DSPFatal is raised for incorrect shaps/types
+    with pytest.raises(ValueError):
+        psd(w_in, np.zeros_like(w_in))
+
+    # ensure that a valid input gives the expected output
+    w_expected = np.zeros_like(w_psd)
+    w_expected[:, 0] = 100.
+    
+    psd_func = psd(w_in, w_psd)
+    assert np.allclose(
+        compare_numba_vs_python(psd_func, w_in, w_psd),
+        w_expected,
+    )
+
+    # ensure that if there is a nan in w_in, all nans are outputted
+    w_in[:, 10] = np.nan
+    assert np.all(np.isnan(compare_numba_vs_python(psd_func, w_in, w_psd)))

--- a/tests/dsp/processors/test_fftw.py
+++ b/tests/dsp/processors/test_fftw.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pytest
 
-from pygama.dsp.errors import DSPFatal
 from pygama.dsp.processors import dft, inv_dft, psd
 
 
@@ -18,10 +17,10 @@ def test_dft(compare_numba_vs_python):
 
     # ensure that a valid input gives the expected output
     w_expected = np.zeros_like(w_dft)
-    w_expected[:, 0] = 100.
-    
+    w_expected[:, 0] = 100.0
+
     dft_func = dft(w_in, w_dft)
-    w_in[:] = 1.
+    w_in[:] = 1.0
 
     assert np.allclose(
         compare_numba_vs_python(dft_func, w_in, w_dft),
@@ -31,6 +30,7 @@ def test_dft(compare_numba_vs_python):
     # ensure that if there is a nan in w_in, all nans are outputted
     w_in[:, 10] = np.nan
     assert np.all(np.isnan(compare_numba_vs_python(dft_func, w_in, w_dft)))
+
 
 def test_inv_dft(compare_numba_vs_python):
     """Testing function for the inverse discrete fourier transform."""
@@ -45,10 +45,10 @@ def test_inv_dft(compare_numba_vs_python):
 
     # ensure that a valid input gives the expected output
     w_expected = np.zeros_like(w_inv_dft)
-    w_expected[:, 0] = 1.
-    
+    w_expected[:, 0] = 1.0
+
     inv_dft_func = inv_dft(w_in, w_inv_dft)
-    w_in[:] = 1.
+    w_in[:] = 1.0
 
     assert np.allclose(
         compare_numba_vs_python(inv_dft_func, w_in, w_inv_dft),
@@ -58,6 +58,7 @@ def test_inv_dft(compare_numba_vs_python):
     # ensure that if there is a nan in w_in, all nans are outputted
     w_in[:, 10] = np.nan
     assert np.all(np.isnan(compare_numba_vs_python(inv_dft_func, w_in, w_inv_dft)))
+
 
 def test_psd(compare_numba_vs_python):
     """Testing function for the power spectral density."""
@@ -72,10 +73,10 @@ def test_psd(compare_numba_vs_python):
 
     # ensure that a valid input gives the expected output
     w_expected = np.zeros_like(w_psd)
-    w_expected[:, 0] = 100.
-    
+    w_expected[:, 0] = 100.0
+
     psd_func = psd(w_in, w_psd)
-    w_in[:] = 1.
+    w_in[:] = 1.0
 
     assert np.allclose(
         compare_numba_vs_python(psd_func, w_in, w_psd),


### PR DESCRIPTION
- ProcessingChain will now work with signatures that build in the outer block-width dimension. This is useful for wrapping vectorized functions (such as fftw).
- Fixed a few minor bugs in ProcessingChain
- Fixed FFTW to work with ProcChainVar objects in addition to numpy buffers
- Updated documentation and style of FFTW to standards set by refactor
- Added tests for FFTW functions

<!---

Before submitting a pull request, please make sure you've read and understood the pygama developer's guide: https://pygama.readthedocs.io/en/latest/developer.html. In particular, do not forget to:

- Conform to our coding conventions
- Update existing or add new tests
- Update existing or add new documentation
- Address any issue reported by GitHub checks

--->
