### PR TITLE
Loosen version bounds on other LEGEND packages

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,11 +32,11 @@ project_urls =
 packages = find:
 install_requires =
     colorlog
-    dspeed==1.1.*
+    dspeed>=1.1
     h5py>=3.2
     iminuit
-    legend-daq2lh5==1.0.*
-    legend-pydataobj==1.1.*
+    legend-daq2lh5>=1.0
+    legend-pydataobj>=1.1
     matplotlib
     numba!=0.53.*,!=0.54.*,!=0.57
     numpy>=1.21


### PR DESCRIPTION
This will simplify adoption of the most recent stable version of other LEGEND packages in pygama. The disadvantage of this approach is that we will need to quickly change pygama, if dependencies release non backward-compatible code.