### PR TITLE
Bugfix for issue 516

### DIFF
--- a/src/pygama/flow/data_loader.py
+++ b/src/pygama/flow/data_loader.py
@@ -605,9 +605,12 @@ class DataLoader:
 
             # Perform cuts specified for child or parent level, in that order
             for level in [child, parent]:
-                if self.cuts is None or level not in self.cuts.keys():
-                    continue
-                cut = self.cuts[level]
+                # Extract the cut condition if given, otherwise set to ""
+                cut = ""
+                if self.cuts is not None:
+                    if level in self.cuts.keys():
+                        cut = self.cuts[level]
+
                 col_tiers = self.get_tiers_for_col(cut_cols[level], merge_files=False)
 
                 # Tables in first tier of event should be the same for all tiers in one level
@@ -615,6 +618,9 @@ class DataLoader:
                 if self.table_list is not None:
                     if level in self.table_list.keys():
                         tables = self.table_list[level]
+                    else:
+                        continue
+
                 # Cut any rows of TCM not relating to requested tables
                 if level == parent:
                     f_entries.query(f"{level}_table in {tables}", inplace=True)

--- a/src/pygama/flow/data_loader.py
+++ b/src/pygama/flow/data_loader.py
@@ -620,6 +620,8 @@ class DataLoader:
                         tables = self.table_list[level]
                     else:
                         continue
+                if tables is None:
+                    continue
 
                 # Cut any rows of TCM not relating to requested tables
                 if level == parent:


### PR DESCRIPTION
- Fixed the bug that `drop_idx` in `build_entry_list` was not filled if no cuts were set by removing the `continue` condition and making the default value of cut `cut = ""` which is changed if `self.cuts is not None` and `level in self.cuts.keys()`.
- Added `continue` condition if `self.table_list is not None` but not `level in self.table_list.keys()`. Otherwise the loop over `tables` would throw an error. 