### PR TITLE
Pre-compute `col_tiers` in `DataLoader.build_entry_list()` for speedup

### DIFF
--- a/src/pygama/flow/data_loader.py
+++ b/src/pygama/flow/data_loader.py
@@ -505,6 +505,8 @@ class DataLoader:
 
         # Find out which columns are needed for any cuts
         cut_cols = {}
+        # ... and pre-load which tiers need to be loaded to make the cuts
+        col_tiers_dict = {}
 
         for level in [child, parent]:
             cut_cols[level] = []
@@ -527,6 +529,7 @@ class DataLoader:
                             and save_output_columns
                         ):
                             for_output.append(term)
+            col_tiers_dict[level] = self.get_tiers_for_col(cut_cols[level], merge_files=False)
 
         if save_output_columns:
             entry_cols += for_output
@@ -611,7 +614,7 @@ class DataLoader:
                     if level in self.cuts.keys():
                         cut = self.cuts[level]
 
-                col_tiers = self.get_tiers_for_col(cut_cols[level], merge_files=False)
+                col_tiers = col_tiers_dict[level]
 
                 # Tables in first tier of event should be the same for all tiers in one level
                 tables = self.filedb.df.loc[file, f"{self.tiers[level][0]}_tables"]

--- a/src/pygama/flow/data_loader.py
+++ b/src/pygama/flow/data_loader.py
@@ -529,7 +529,9 @@ class DataLoader:
                             and save_output_columns
                         ):
                             for_output.append(term)
-            col_tiers_dict[level] = self.get_tiers_for_col(cut_cols[level], merge_files=False)
+            col_tiers_dict[level] = self.get_tiers_for_col(
+                cut_cols[level], merge_files=False
+            )
 
         if save_output_columns:
             entry_cols += for_output


### PR DESCRIPTION
not doing this in the inner loop gives a big speedup.
Partially addresses https://github.com/legend-exp/pygama/issues/521