### PR TITLE
Update `build_hit()` to support the latest `Table.eval()`

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -60,6 +60,9 @@ intersphinx_mapping = {
     "iminuit": ("https://iminuit.readthedocs.io/en/stable", None),
     "h5py": ("https://docs.h5py.org/en/stable", None),
     "pint": ("https://pint.readthedocs.io/en/stable", None),
+    "lgdo": ("https://legend-pydataobj.readthedocs.io/en/stable", None),
+    "dspeed": ("https://dspeed.readthedocs.io/en/stable", None),
+    "daq2lh5": ("https://legend-daq2lh5.readthedocs.io/en/stable", None),
 }
 
 suppress_warnings = [

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,11 +32,11 @@ project_urls =
 packages = find:
 install_requires =
     colorlog
-    dspeed@git+https://github.com/legend-exp/dspeed@main
+    dspeed>=1.3.0a4
     h5py>=3.2
     iminuit
     legend-daq2lh5@git+https://github.com/legend-exp/legend-daq2lh5@main
-    legend-pydataobj>=1.5.0a1
+    legend-pydataobj@git+https://github.com/legend-exp/legend-pydataobj@table-eval
     matplotlib
     numba!=0.53.*,!=0.54.*,!=0.57
     numpy>=1.21

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,8 +35,8 @@ install_requires =
     dspeed>=1.3.0a4
     h5py>=3.2
     iminuit
-    legend-daq2lh5@git+https://github.com/legend-exp/legend-daq2lh5@main
-    legend-pydataobj@git+https://github.com/legend-exp/legend-pydataobj@table-eval
+    legend-daq2lh5>=1.2.0a1
+    legend-pydataobj>=1.5.0a2
     matplotlib
     numba!=0.53.*,!=0.54.*,!=0.57
     numpy>=1.21

--- a/src/pygama/hit/build_hit.py
+++ b/src/pygama/hit/build_hit.py
@@ -8,8 +8,9 @@ import logging
 import os
 from collections import OrderedDict
 
+import lgdo
 import numpy as np
-from lgdo import Array, LH5Iterator, LH5Store, ls
+from lgdo import LH5Iterator, LH5Store, ls
 
 log = logging.getLogger(__name__)
 
@@ -25,10 +26,12 @@ def build_hit(
     buffer_len: int = 3200,
 ) -> None:
     """
-    Transform a :class:`~.lgdo.Table` into a new :class:`~.lgdo.Table` by
-    evaluating strings describing column operations.
+    Transform a :class:`~lgdo.types.table.Table` into a new
+    :class:`~lgdo.types.table.Table` by evaluating strings describing column
+    operations.
 
-    Operates on columns only, not specific rows or elements.
+    Operates on columns only, not specific rows or elements. Relies on
+    :meth:`~lgdo.types.table.Table.eval`.
 
     Parameters
     ----------
@@ -47,7 +50,7 @@ def build_hit(
                 "outputs": ["calE", "AoE"],
                 "operations": {
                     "calE": {
-                        "expression": "sqrt(@a + @b * trapEmax**2)",
+                        "expression": "sqrt(a + b * trapEmax**2)",
                         "parameters": {"a": "1.23", "b": "42.69"},
                     },
                     "AoE": {"expression": "A_max/calE"},
@@ -69,7 +72,11 @@ def build_hit(
     n_max
         maximum number of rows to process
     wo_mode
-        forwarded to :meth:`~.lgdo.lh5.write`.
+        forwarded to :meth:`lgdo.lh5.store.LH5Store.write`.
+
+    See Also
+    --------
+    lgdo.types.table.Table.eval
     """
     store = LH5Store()
 
@@ -129,7 +136,18 @@ def build_hit(
         for tbl_obj, start_row, n_rows in lh5_it:
             n_rows = min(tot_n_rows - start_row, n_rows)
 
-            outtbl_obj = tbl_obj.eval(cfg["operations"])
+            # create a new table object that links all the columns in the
+            # current table (i.e. no copy)
+            outtbl_obj = lgdo.Table(col_dict=tbl_obj)
+
+            for outname, info in cfg["operations"].items():
+                outcol = outtbl_obj.eval(
+                    info["expression"], info.get("parameters", None)
+                )
+                if "lgdo_attrs" in info:
+                    outcol.attrs |= info["lgdo_attrs"]
+
+                outtbl_obj.add_column(outname, outcol)
 
             # make high level flags
             if "aggregations" in cfg:
@@ -151,7 +169,7 @@ def build_hit(
                     multiplier = 2 ** np.arange(n_flags, dtype=flag_values.dtype)
                     flag_out = np.dot(flag_values, multiplier)
 
-                    outtbl_obj.add_field(high_lvl_flag, Array(flag_out))
+                    outtbl_obj.add_field(high_lvl_flag, lgdo.Array(flag_out))
 
             # remove or add columns according to "outputs" in the configuration
             # dictionary

--- a/tests/hit/configs/basic-hit-config.json
+++ b/tests/hit/configs/basic-hit-config.json
@@ -11,7 +11,11 @@
         "b": 42.69
       },
       "lgdo_attrs": {
-        "units": "keV"
+        "units": "keV",
+        "hdf5_settings": {
+          "compression": "gzip",
+          "shuffle": true
+        }
       }
     },
     "AoE": {

--- a/tests/hit/configs/basic-hit-config.json
+++ b/tests/hit/configs/basic-hit-config.json
@@ -9,6 +9,9 @@
       "parameters": {
         "a": 1.23,
         "b": 42.69
+      },
+      "lgdo_attrs": {
+        "units": "keV"
       }
     },
     "AoE": {

--- a/tests/hit/test_build_hit.py
+++ b/tests/hit/test_build_hit.py
@@ -24,6 +24,10 @@ def test_basics(dsp_test_file, tmptestdir):
     assert os.path.exists(outfile)
     assert ls(outfile, "/geds/") == ["geds/hit"]
 
+    store = LH5Store()
+    tbl, _ = store.read("geds/hit", outfile)
+    assert tbl.calE.attrs == {"datatype": "array<1>{real}", "units": "keV"}
+
 
 def test_illegal_arguments(dsp_test_file):
     with pytest.raises(ValueError):
@@ -95,7 +99,7 @@ def test_outputs_specification(dsp_test_file, tmptestdir):
 
     store = LH5Store()
     obj, _ = store.read("/geds/hit", outfile)
-    assert list(obj.keys()) == ["calE", "AoE", "A_max"]
+    assert sorted(obj.keys()) == ["A_max", "AoE", "calE"]
 
 
 def test_aggregation_outputs(dsp_test_file, tmptestdir):


### PR DESCRIPTION
- We can now process `VectorOfVectors` too!
- Added `lgdo_attrs` key in the `build_hit` config dictionary for setting LGDO attributes like units.

See https://github.com/legend-exp/legend-pydataobj/pull/53.
