### PR TITLE
Fix pandas future deprecations

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,6 +42,7 @@ install_requires =
     numpy>=1.21
     pandas>=1.4.4
     pint
+    pyarrow
     scikit-learn
     scipy>=1.0.1
     tables

--- a/src/pygama/flow/file_db.py
+++ b/src/pygama/flow/file_db.py
@@ -272,7 +272,10 @@ class FileDB:
 
         # convert cols to numeric dtypes where possible
         for col in self.df.columns:
-            self.df[col] = pd.to_numeric(self.df[col], errors="ignore")
+            try:
+                self.df[col] = pd.to_numeric(self.df[col])
+            except ValueError:
+                continue
 
         # sort rows according to timestamps
         utils.inplace_sort(self.df, self.sortby)
@@ -669,7 +672,10 @@ class FileDB:
 
         # convert cols to numeric dtypes where possible
         for col in self.df.columns:
-            self.df[col] = pd.to_numeric(self.df[col], errors="ignore")
+            try:
+                self.df[col] = pd.to_numeric(self.df[col])
+            except ValueError:
+                continue
 
     def get_table_name(self, tier: str, tb: str) -> str:
         """Get the table name for a tier given its table identifier.


### PR DESCRIPTION
1.  Pandas will depend on pyarrow
2. Pandas to_numeric function deprecates error parameter --> filedb uses it with the ignore value (just returns the input value. --> catching now ValueErrors and continue
