### PR TITLE
Allow `build_evt()` and `build_skm()` to just return the output table

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  TQDM_MININTERVAL: 10
+  TQDM_MININTERVAL: 100
 
 jobs:
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -58,7 +58,6 @@ intersphinx_mapping = {
     "scipy": ("https://docs.scipy.org/doc/scipy", None),
     "pandas": ("https://pandas.pydata.org/docs", None),
     "matplotlib": ("https://matplotlib.org/stable", None),
-    "iminuit": ("https://iminuit.readthedocs.io/en/stable", None),
     "h5py": ("https://docs.h5py.org/en/stable", None),
     "pint": ("https://pint.readthedocs.io/en/stable", None),
     "lgdo": ("https://legend-pydataobj.readthedocs.io/en/stable", None),

--- a/src/pygama/evt/build_evt.py
+++ b/src/pygama/evt/build_evt.py
@@ -25,7 +25,6 @@ def build_evt(
     f_dsp: str,
     f_hit: str,
     evt_config: str | dict,
-    *,
     f_evt: str | None = None,
     wo_mode: str = "write_safe",
     evt_group: str = "evt",

--- a/src/pygama/skm/build_skm.py
+++ b/src/pygama/skm/build_skm.py
@@ -24,16 +24,17 @@ def build_skm(
     f_hit: str,
     f_dsp: str,
     f_tcm: str,
-    f_skm: str,
     skm_conf: dict | str,
-    wo_mode="w",
+    *,
+    f_skm: str | None = None,
+    wo_mode: str = "w",
     skm_group: str = "skm",
     evt_group: str = "evt",
     tcm_group: str = "hardware_tcm_1",
     dsp_group: str = "dsp",
     hit_group: str = "hit",
     tcm_id_table_pattern: str = "ch{}",
-) -> None:
+) -> None | Table:
     """Builds a skimmed file from a (set) of `evt/hit/dsp` tier file(s).
 
     Parameters
@@ -46,8 +47,6 @@ def build_skm(
         path of `dsp` file.
     f_tcm
         path of `tcm` file.
-    f_skm
-        name of the `skm` output file.
     skm_conf
         name of configuration file or dictionary defining `skm` fields.
 
@@ -87,6 +86,9 @@ def build_skm(
                }
              }
            }
+    f_skm
+        name of the `skm` output file. If ``None``, return the output
+        class:`.Table` instead of writing to disk.
 
     wo_mode
         writing mode.
@@ -228,6 +230,9 @@ def build_skm(
                 if "lgdo_attrs" in tbl_cfg["operations"][op].keys():
                     obj.attrs |= tbl_cfg["operations"][op]["lgdo_attrs"]
                 table.add_field(op, obj, True)
+
+    if not f_skm:
+        return table
 
     # last thing missing is writing it out
     if wo_mode not in ["w", "write_safe", "o", "overwrite", "a", "append"]:

--- a/src/pygama/skm/build_skm.py
+++ b/src/pygama/skm/build_skm.py
@@ -25,7 +25,6 @@ def build_skm(
     f_dsp: str,
     f_tcm: str,
     skm_conf: dict | str,
-    *,
     f_skm: str | None = None,
     wo_mode: str = "w",
     skm_group: str = "skm",
@@ -237,6 +236,7 @@ def build_skm(
     # last thing missing is writing it out
     if wo_mode not in ["w", "write_safe", "o", "overwrite", "a", "append"]:
         raise ValueError(f"wo_mode {wo_mode} not valid.")
+
     log.debug("saving skm file")
     if (wo_mode in ["w", "write_safe"]) and os.path.exists(f_skm):
         raise FileExistsError(f"Write_safe mode: {f_skm} exists.")

--- a/tests/evt/test_build_evt.py
+++ b/tests/evt/test_build_evt.py
@@ -22,8 +22,8 @@ def test_basics(lgnd_test_data, tmptestdir):
         f_tcm=lgnd_test_data.get_path(tcm_path),
         f_dsp=lgnd_test_data.get_path(tcm_path.replace("tcm", "dsp")),
         f_hit=lgnd_test_data.get_path(tcm_path.replace("tcm", "hit")),
-        f_evt=outfile,
         evt_config=f"{config_dir}/basic-evt-config.json",
+        f_evt=outfile,
         wo_mode="o",
         evt_group="evt",
         hit_group="hit",
@@ -74,8 +74,8 @@ def test_lar_module(lgnd_test_data, tmptestdir):
         f_tcm=lgnd_test_data.get_path(tcm_path),
         f_dsp=lgnd_test_data.get_path(tcm_path.replace("tcm", "dsp")),
         f_hit=lgnd_test_data.get_path(tcm_path.replace("tcm", "hit")),
-        f_evt=outfile,
         evt_config=f"{config_dir}/module-test-evt-config.json",
+        f_evt=outfile,
         wo_mode="o",
         evt_group="evt",
         hit_group="hit",
@@ -103,8 +103,8 @@ def test_lar_t0_vov_module(lgnd_test_data, tmptestdir):
         f_tcm=lgnd_test_data.get_path(tcm_path),
         f_dsp=lgnd_test_data.get_path(tcm_path.replace("tcm", "dsp")),
         f_hit=lgnd_test_data.get_path(tcm_path.replace("tcm", "hit")),
-        f_evt=outfile,
         evt_config=f"{config_dir}/module-test-t0-vov-evt-config.json",
+        f_evt=outfile,
         wo_mode="o",
         evt_group="evt",
         hit_group="hit",
@@ -136,8 +136,8 @@ def test_vov(lgnd_test_data, tmptestdir):
         f_tcm=lgnd_test_data.get_path(tcm_path),
         f_dsp=lgnd_test_data.get_path(tcm_path.replace("tcm", "dsp")),
         f_hit=lgnd_test_data.get_path(tcm_path.replace("tcm", "hit")),
-        f_evt=outfile,
         evt_config=f"{config_dir}/vov-test-evt-config.json",
+        f_evt=outfile,
         wo_mode="o",
         evt_group="evt",
         hit_group="hit",
@@ -187,21 +187,21 @@ def test_graceful_crashing(lgnd_test_data, tmptestdir):
     f_config = f"{config_dir}/basic-evt-config.json"
 
     with pytest.raises(KeyError):
-        build_evt(f_dsp, f_tcm, f_hit, outfile, f_config)
+        build_evt(f_dsp, f_tcm, f_hit, f_config, outfile)
 
     with pytest.raises(KeyError):
-        build_evt(f_tcm, f_hit, f_dsp, outfile, f_config)
+        build_evt(f_tcm, f_hit, f_dsp, f_config, outfile)
 
     with pytest.raises(TypeError):
-        build_evt(f_tcm, f_dsp, f_hit, outfile, None)
+        build_evt(f_tcm, f_dsp, f_hit, None, outfile)
 
     conf = {"operations": {}}
     with pytest.raises(ValueError):
-        build_evt(f_tcm, f_dsp, f_hit, outfile, conf)
+        build_evt(f_tcm, f_dsp, f_hit, conf, outfile)
 
     conf = {"channels": {"geds_on": ["ch1084803", "ch1084804", "ch1121600"]}}
     with pytest.raises(ValueError):
-        build_evt(f_tcm, f_dsp, f_hit, outfile, conf)
+        build_evt(f_tcm, f_dsp, f_hit, conf, outfile)
 
     conf = {
         "channels": {"geds_on": ["ch1084803", "ch1084804", "ch1121600"]},
@@ -217,7 +217,7 @@ def test_graceful_crashing(lgnd_test_data, tmptestdir):
         },
     }
     with pytest.raises(ValueError):
-        build_evt(f_tcm, f_dsp, f_hit, outfile, conf)
+        build_evt(f_tcm, f_dsp, f_hit, conf, outfile)
 
 
 def test_query(lgnd_test_data, tmptestdir):
@@ -229,8 +229,8 @@ def test_query(lgnd_test_data, tmptestdir):
         f_tcm=lgnd_test_data.get_path(tcm_path),
         f_dsp=lgnd_test_data.get_path(tcm_path.replace("tcm", "dsp")),
         f_hit=lgnd_test_data.get_path(tcm_path.replace("tcm", "hit")),
-        f_evt=outfile,
         evt_config=f"{config_dir}/query-test-evt-config.json",
+        f_evt=outfile,
         wo_mode="o",
         evt_group="evt",
         hit_group="hit",
@@ -277,7 +277,7 @@ def test_vector_sort(lgnd_test_data, tmptestdir):
             },
         },
     }
-    build_evt(f_tcm, f_dsp, f_hit, outfile, conf)
+    build_evt(f_tcm, f_dsp, f_hit, conf, outfile)
 
     assert os.path.exists(outfile)
     assert len(lh5.ls(outfile, "/evt/")) == 4
@@ -300,14 +300,14 @@ def test_tcm_id_table_pattern(lgnd_test_data, tmptestdir):
     f_config = f"{config_dir}/basic-evt-config.json"
 
     with pytest.raises(ValueError):
-        build_evt(f_tcm, f_dsp, f_hit, outfile, f_config, tcm_id_table_pattern="ch{{}}")
+        build_evt(f_tcm, f_dsp, f_hit, f_config, outfile, tcm_id_table_pattern="ch{{}}")
     with pytest.raises(ValueError):
-        build_evt(f_tcm, f_dsp, f_hit, outfile, f_config, tcm_id_table_pattern="ch{}{}")
+        build_evt(f_tcm, f_dsp, f_hit, f_config, outfile, tcm_id_table_pattern="ch{}{}")
     with pytest.raises(NotImplementedError):
         build_evt(
-            f_tcm, f_dsp, f_hit, outfile, f_config, tcm_id_table_pattern="ch{tcm_id}"
+            f_tcm, f_dsp, f_hit, f_config, outfile, tcm_id_table_pattern="ch{tcm_id}"
         )
     with pytest.raises(ValueError):
         build_evt(
-            f_tcm, f_dsp, f_hit, outfile, f_config, tcm_id_table_pattern="apple{}banana"
+            f_tcm, f_dsp, f_hit, f_config, outfile, tcm_id_table_pattern="apple{}banana"
         )

--- a/tests/evt/test_build_evt.py
+++ b/tests/evt/test_build_evt.py
@@ -18,6 +18,7 @@ def test_basics(lgnd_test_data, tmptestdir):
     tcm_path = "lh5/prod-ref-l200/generated/tier/tcm/phy/p03/r001/l200-p03-r001-phy-20230322T160139Z-tier_tcm.lh5"
     if os.path.exists(outfile):
         os.remove(outfile)
+
     build_evt(
         f_tcm=lgnd_test_data.get_path(tcm_path),
         f_dsp=lgnd_test_data.get_path(tcm_path.replace("tcm", "dsp")),
@@ -30,6 +31,7 @@ def test_basics(lgnd_test_data, tmptestdir):
         dsp_group="dsp",
         tcm_group="hardware_tcm_1",
     )
+
     assert "statement" in store.read("/evt/multiplicity", outfile)[0].getattrs().keys()
     assert (
         store.read("/evt/multiplicity", outfile)[0].getattrs()["statement"]

--- a/tests/skm/configs/basic-skm-config.json
+++ b/tests/skm/configs/basic-skm-config.json
@@ -13,7 +13,7 @@
     },
     "energy": {
       "forward_field": "hit.cuspEmax_ctc_cal",
-      "missing_value": "np.nan",
+      "missing_value": 0.0,
       "tcm_idx": "evt.energy_idx"
     },
     "energy_id": {

--- a/tests/skm/test_build_skm.py
+++ b/tests/skm/test_build_skm.py
@@ -22,8 +22,8 @@ def test_basics(lgnd_test_data, tmptestdir):
         f_tcm=lgnd_test_data.get_path(tcm_path),
         f_dsp=lgnd_test_data.get_path(tcm_path.replace("tcm", "dsp")),
         f_hit=lgnd_test_data.get_path(tcm_path.replace("tcm", "hit")),
-        f_evt=outfile,
         evt_config=f"{evt_config_dir}/vov-test-evt-config.json",
+        f_evt=outfile,
         wo_mode="o",
         evt_group="evt",
         hit_group="hit",
@@ -38,8 +38,8 @@ def test_basics(lgnd_test_data, tmptestdir):
         lgnd_test_data.get_path(tcm_path.replace("tcm", "hit")),
         lgnd_test_data.get_path(tcm_path.replace("tcm", "dsp")),
         lgnd_test_data.get_path(tcm_path),
-        skm_out,
         skm_conf,
+        skm_out,
         wo_mode="o",
     )
 
@@ -103,8 +103,8 @@ def test_attribute_passing(lgnd_test_data, tmptestdir):
         lgnd_test_data.get_path(tcm_path.replace("tcm", "hit")),
         lgnd_test_data.get_path(tcm_path.replace("tcm", "dsp")),
         lgnd_test_data.get_path(tcm_path),
-        skm_out,
         skm_conf,
+        skm_out,
         wo_mode="o",
     )
 


### PR DESCRIPTION
I had to adjust the order of function arguments a little, sorry for that.

CC @ggmarshall 