### PR TITLE
Added numba defaults for math, fixed some bugs in extended pdfs

### DIFF
--- a/src/pygama/math/functions/crystal_ball.py
+++ b/src/pygama/math/functions/crystal_ball.py
@@ -9,12 +9,12 @@ import numpy as np
 from math import erf
 
 from pygama.math.functions.pygama_continuous import pygama_continuous 
+from ..utils import numba_math_defaults_kwargs as nb_kwargs
+from ..utils import numba_math_defaults as nb_defaults
 
-kwd = {"parallel": False, "fastmath": True}
-kwd_parallel = {"parallel": True, "fastmath": True}
 
 
-@nb.njit(**kwd_parallel)
+@nb.njit(**nb_kwargs)
 def nb_crystal_ball_pdf(x: np.ndarray, mu: float, sigma: float, beta: float, m: float) -> np.ndarray:
     r"""
     PDF of a power-law tail plus gaussian. Its range of support is :math:`x\in\mathbb{R}, \beta>0, m>1`. It computes:
@@ -73,7 +73,7 @@ def nb_crystal_ball_pdf(x: np.ndarray, mu: float, sigma: float, beta: float, m: 
     return y
 
 
-@nb.njit(**kwd_parallel)
+@nb.njit(**nb_kwargs)
 def nb_crystal_ball_cdf(x: np.ndarray, mu: float, sigma: float, beta: float, m: float) -> np.ndarray:
     r"""
     CDF for power-law tail plus gaussian. Its range of support is :math:`x\in\mathbb{R}, \beta>0, m>1`. It computes: 
@@ -135,7 +135,7 @@ def nb_crystal_ball_cdf(x: np.ndarray, mu: float, sigma: float, beta: float, m: 
     return y
 
 
-@nb.njit(**kwd)
+@nb.njit(**nb_defaults(parallel=False))
 def nb_crystal_ball_scaled_pdf(x: np.ndarray, area: float, mu: float, sigma: float, beta: float, m: float) -> np.ndarray:
     r"""
     Scaled PDF of a power-law tail plus gaussian. 
@@ -161,7 +161,7 @@ def nb_crystal_ball_scaled_pdf(x: np.ndarray, area: float, mu: float, sigma: flo
     return area * nb_crystal_ball_pdf(x, mu, sigma, beta, m)
 
 
-@nb.njit(**kwd)
+@nb.njit(**nb_defaults(parallel=False))
 def nb_crystal_ball_scaled_cdf(x: np.ndarray, area: float, mu: float, sigma: float, beta: float, m: float) -> np.ndarray:
     r"""
     Scaled CDF for power-law tail plus gaussian. Used for extended binned fits. 
@@ -213,7 +213,7 @@ class crystal_ball_gen(pygama_continuous):
 
 
     def pdf_ext(self, x: np.ndarray, x_lo: float, x_hi: float, area: float, mu: float, sigma: float, beta: float, m: float) -> np.ndarray:
-        return np.diff(nb_crystal_ball_scaled_cdf(np.array([x_lo, x_hi]), area, mu, sigma, beta, m)), nb_crystal_ball_scaled_pdf(x, area, mu, sigma, beta, m)
+        return np.diff(nb_crystal_ball_scaled_cdf(np.array([x_lo, x_hi]), area, mu, sigma, beta, m))[0], nb_crystal_ball_scaled_pdf(x, area, mu, sigma, beta, m)
     def cdf_ext(self, x: np.ndarray, area: float, mu: float, sigma: float, beta: float, m: float) -> np.ndarray:
         return nb_crystal_ball_scaled_cdf(x, area, mu, sigma, beta, m)
 

--- a/src/pygama/math/functions/crystal_ball.py
+++ b/src/pygama/math/functions/crystal_ball.py
@@ -9,8 +9,8 @@ import numpy as np
 from math import erf
 
 from pygama.math.functions.pygama_continuous import pygama_continuous 
-from ..utils import numba_math_defaults_kwargs as nb_kwargs
-from ..utils import numba_math_defaults as nb_defaults
+from pygama.utils import numba_math_defaults_kwargs as nb_kwargs
+from pygama.utils import numba_math_defaults as nb_defaults
 
 
 

--- a/src/pygama/math/functions/exgauss.py
+++ b/src/pygama/math/functions/exgauss.py
@@ -13,8 +13,8 @@ from pygama.math.functions.pygama_continuous import pygama_continuous
 from pygama.math.functions.error_function import nb_erf, nb_erfc
 from pygama.math.functions.gauss import nb_gauss_cdf, nb_gauss_pdf
 
-from ..utils import numba_math_defaults_kwargs as nb_kwargs
-from ..utils import numba_math_defaults as nb_defaults
+from pygama.utils import numba_math_defaults_kwargs as nb_kwargs
+from pygama.utils import numba_math_defaults as nb_defaults
 
 limit = np.log(sys.float_info.max)/10
 

--- a/src/pygama/math/functions/exgauss.py
+++ b/src/pygama/math/functions/exgauss.py
@@ -13,12 +13,14 @@ from pygama.math.functions.pygama_continuous import pygama_continuous
 from pygama.math.functions.error_function import nb_erf, nb_erfc
 from pygama.math.functions.gauss import nb_gauss_cdf, nb_gauss_pdf
 
+from ..utils import numba_math_defaults_kwargs as nb_kwargs
+from ..utils import numba_math_defaults as nb_defaults
+
 limit = np.log(sys.float_info.max)/10
-kwd = {"parallel": False, "fastmath": True}
-kwd_2 = {"parallel": True, "fastmath": True}
 
 
-@nb.njit(**kwd)
+
+@nb.njit(**nb_defaults(parallel=False))
 def nb_gauss_tail_exact(x: float, mu: float, sigma: float, tau: float, tmp: float) -> float:
     r"""
     Exact form of a normalized exponentially modified Gaussian PDF. 
@@ -63,7 +65,7 @@ def nb_gauss_tail_exact(x: float, mu: float, sigma: float, tau: float, tmp: floa
     return tail_f
 
 
-@nb.njit(**kwd)
+@nb.njit(**nb_defaults(parallel=False))
 def nb_gauss_tail_approx(x: np.ndarray, mu: float, sigma: float, tau: float) -> np.ndarray:
     r"""
     Approximate form of a normalized exponentially modified Gaussian PDF
@@ -92,7 +94,7 @@ def nb_gauss_tail_approx(x: np.ndarray, mu: float, sigma: float, tau: float) -> 
     return tail_f
 
 
-@nb.njit(**kwd_2)
+@nb.njit(**nb_kwargs)
 def nb_exgauss_pdf(x: np.ndarray, mu: float, sigma: float, tau: float) -> np.ndarray:
     r"""
     Normalized PDF of an exponentially modified Gaussian distribution. Its range of support is :math:`x\in(-\infty,\infty)`, :math:`\tau\in(-\infty,\infty)`
@@ -131,7 +133,7 @@ def nb_exgauss_pdf(x: np.ndarray, mu: float, sigma: float, tau: float) -> np.nda
     return tail_f
 
 
-@nb.njit(**kwd_2)
+@nb.njit(**nb_kwargs)
 def nb_exgauss_cdf(x: np.ndarray, mu: float, sigma: float, tau: float) -> np.ndarray:
     r"""
     The CDF for a normalized exponentially modified Gaussian.  Its range of support is :math:`x\in(-\infty,\infty)`, :math:`\tau\in(-\infty,\infty)`
@@ -170,7 +172,7 @@ def nb_exgauss_cdf(x: np.ndarray, mu: float, sigma: float, tau: float) -> np.nda
     return cdf
 
 
-@nb.njit(**kwd_2)
+@nb.njit(**nb_defaults(parallel=False))
 def nb_exgauss_scaled_pdf(x: np.ndarray, area: float, mu: float, sigma: float, tau: float) -> np.ndarray:
     r"""
     Scaled PDF of an exponentially modified Gaussian distribution
@@ -195,7 +197,7 @@ def nb_exgauss_scaled_pdf(x: np.ndarray, area: float, mu: float, sigma: float, t
     return area * nb_exgauss_pdf(x, mu, sigma, tau)
 
 
-@nb.njit(**kwd)
+@nb.njit(**nb_defaults(parallel=False))
 def nb_exgauss_scaled_cdf(x: np.ndarray, area: float, mu: float, sigma: float, tau: float) -> np.ndarray:
     r"""
     Scaled CDF of an exponentially modified Gaussian distribution
@@ -244,7 +246,7 @@ class exgauss_gen(pygama_continuous):
         return self._cdf_norm(x, x_lo, x_hi, mu, sigma, tau)
 
     def pdf_ext(self, x: np.ndarray, x_lo: float, x_hi: float, area: float, mu: float, sigma: float, tau: float) -> np.ndarray:
-        return np.diff(nb_exgauss_scaled_cdf(np.array([x_lo, x_hi]), area, mu, sigma, tau)), nb_exgauss_scaled_pdf(x, area, mu, sigma, tau)
+        return np.diff(nb_exgauss_scaled_cdf(np.array([x_lo, x_hi]), area, mu, sigma, tau))[0], nb_exgauss_scaled_pdf(x, area, mu, sigma, tau)
     def cdf_ext(self, x: np.ndarray, area: float, mu: float, sigma: float, tau: float) -> np.ndarray:
         return nb_exgauss_scaled_cdf(x, area, mu, sigma, tau)
 

--- a/src/pygama/math/functions/exponential.py
+++ b/src/pygama/math/functions/exponential.py
@@ -8,8 +8,8 @@ import numba as nb
 import numpy as np
 
 from pygama.math.functions.pygama_continuous import pygama_continuous
-from ..utils import numba_math_defaults_kwargs as nb_kwargs
-from ..utils import numba_math_defaults as nb_defaults
+from pygama.utils import numba_math_defaults_kwargs as nb_kwargs
+from pygama.utils import numba_math_defaults as nb_defaults
 
 
 

--- a/src/pygama/math/functions/exponential.py
+++ b/src/pygama/math/functions/exponential.py
@@ -8,12 +8,12 @@ import numba as nb
 import numpy as np
 
 from pygama.math.functions.pygama_continuous import pygama_continuous
+from ..utils import numba_math_defaults_kwargs as nb_kwargs
+from ..utils import numba_math_defaults as nb_defaults
 
-kwd = {"parallel": False, "fastmath": True}
-kwd_parallel = {"parallel": True, "fastmath": True}
 
 
-@nb.njit(**kwd_parallel)
+@nb.njit(**nb_kwargs)
 def nb_exponential_pdf(x: np.ndarray, mu: float, sigma: float, lamb: float) -> np.ndarray:
     r"""
     Normalised exponential probability density distribution, w/ args: mu, sigma, lamb. Its range of support is :math:`x\in[0,\infty), \lambda>0`. 
@@ -50,7 +50,7 @@ def nb_exponential_pdf(x: np.ndarray, mu: float, sigma: float, lamb: float) -> n
     return y
 
 
-@nb.njit(**kwd_parallel)
+@nb.njit(**nb_kwargs)
 def nb_exponential_cdf(x: np.ndarray, mu: float, sigma: float, lamb: float) -> np.ndarray:
     r"""
     Normalised exponential cumulative distribution, w/ args:  mu, sigma, lamb. Its range of support is :math:`x\in[0,\infty), \lambda>0`. 
@@ -87,7 +87,7 @@ def nb_exponential_cdf(x: np.ndarray, mu: float, sigma: float, lamb: float) -> n
     return y
 
 
-@nb.njit(**kwd)
+@nb.njit(**nb_defaults(parallel=False))
 def nb_exponential_scaled_pdf(x: np.ndarray, area: float, mu: float, sigma: float, lamb: float) -> np.ndarray:
     r"""
     Scaled exponential probability distribution, w/ args: area, mu, sigma, lambd.
@@ -111,7 +111,7 @@ def nb_exponential_scaled_pdf(x: np.ndarray, area: float, mu: float, sigma: floa
     return area * nb_exponential_pdf(x, mu, sigma, lamb)
 
 
-@nb.njit(**kwd)
+@nb.njit(**nb_defaults(parallel=False))
 def nb_exponential_scaled_cdf(x: np.ndarray, area: float, mu: float, sigma: float, lamb: float) -> np.ndarray:
     r"""
     Exponential cdf scaled by the area, used for extended binned fits 
@@ -162,7 +162,7 @@ class exponential_gen(pygama_continuous):
         return self._cdf_norm(x, x_lo, x_hi, mu, sigma, lamb)
 
     def pdf_ext(self, x: np.ndarray, x_lo: float, x_hi: float, area: float, mu: float, sigma: float, lamb: float) -> np.ndarray:
-        return np.diff(nb_exponential_scaled_cdf(np.array([x_lo, x_hi]), area, mu, sigma, lamb)), nb_exponential_scaled_pdf(x, area, mu, sigma, lamb)
+        return np.diff(nb_exponential_scaled_cdf(np.array([x_lo, x_hi]), area, mu, sigma, lamb))[0], nb_exponential_scaled_pdf(x, area, mu, sigma, lamb)
     def cdf_ext(self, x: np.ndarray, area: float, mu: float, sigma: float, lamb: float) -> np.ndarray:
         return nb_exponential_scaled_cdf(x, area, mu, sigma, lamb)
     

--- a/src/pygama/math/functions/gauss.py
+++ b/src/pygama/math/functions/gauss.py
@@ -9,11 +9,10 @@ import numpy as np
 
 from pygama.math.functions.error_function import nb_erf
 from pygama.math.functions.pygama_continuous import pygama_continuous 
+from ..utils import numba_math_defaults as nb_defaults
 
-kwd = {"parallel": False, "fastmath": True}
 
-
-@nb.njit(**kwd)
+@nb.njit(**nb_defaults(parallel=False))
 def nb_gauss(x: np.ndarray, mu: float, sigma: float) -> np.ndarray:
     """
     Gaussian, unnormalised for use in building PDFs
@@ -39,7 +38,7 @@ def nb_gauss(x: np.ndarray, mu: float, sigma: float) -> np.ndarray:
     return np.exp(-0.5 * z ** 2)
 
 
-@nb.njit(**kwd)
+@nb.njit(**nb_defaults(parallel=False))
 def nb_gauss_amp(x: np.ndarray, mu: float, sigma: float, a: float) -> np.ndarray:
     """
     Gaussian with height as a parameter for FWHM etc.
@@ -67,7 +66,7 @@ def nb_gauss_amp(x: np.ndarray, mu: float, sigma: float, a: float) -> np.ndarray
     return a * np.exp(-0.5 * z ** 2)
 
 
-@nb.njit(**kwd)
+@nb.njit(**nb_defaults(parallel=False))
 def nb_gauss_pdf(x: np.ndarray, mu: float, sigma: float) -> np.ndarray:
     r"""
     Normalised Gaussian PDF, w/ args: mu, sigma. The support is :math:`(-\infty, \infty)`
@@ -95,7 +94,7 @@ def nb_gauss_pdf(x: np.ndarray, mu: float, sigma: float) -> np.ndarray:
     return np.exp(-0.5 * z ** 2) * invnorm
 
 
-@nb.njit(**kwd)
+@nb.njit(**nb_defaults(parallel=False))
 def nb_gauss_cdf(x: np.ndarray, mu: float, sigma: float) -> np.ndarray:
     r"""
     Gaussian CDF, w/ args: mu, sigma. The support is :math:`(-\infty, \infty)`
@@ -123,7 +122,7 @@ def nb_gauss_cdf(x: np.ndarray, mu: float, sigma: float) -> np.ndarray:
     return 1/2 * (1 + nb_erf(invs*(x - mu)/(np.sqrt(2))))
 
 
-@nb.njit(**kwd)
+@nb.njit(**nb_defaults(parallel=False))
 def nb_gauss_scaled_pdf(x: np.ndarray, area: float, mu: float, sigma: float) -> np.ndarray:
     """
     Gaussian with height as a parameter for fwhm etc.
@@ -145,7 +144,7 @@ def nb_gauss_scaled_pdf(x: np.ndarray, area: float, mu: float, sigma: float) -> 
     return area * nb_gauss_pdf(x, mu, sigma)
 
 
-@nb.njit(**kwd)
+@nb.njit(**nb_defaults(parallel=False))
 def nb_gauss_scaled_cdf(x: np.ndarray, area: float, mu: float, sigma: float) -> np.ndarray:
     """
     Gaussian CDF scaled by the number of signal counts for extended binned fits 
@@ -191,7 +190,7 @@ class gaussian_gen(pygama_continuous):
         return self._cdf_norm(x, x_lo, x_hi, mu, sigma)
 
     def pdf_ext(self, x: np.ndarray, x_lo: float, x_hi: float, area: float, mu: float, sigma: float) -> np.ndarray:
-        return np.diff(nb_gauss_scaled_cdf(np.array([x_lo, x_hi]), area, mu, sigma)), nb_gauss_scaled_pdf(x, area, mu, sigma)
+        return np.diff(nb_gauss_scaled_cdf(np.array([x_lo, x_hi]), area, mu, sigma))[0], nb_gauss_scaled_pdf(x, area, mu, sigma)
     def cdf_ext(self, x: np.ndarray, area: float, mu: float, sigma: float) -> np.ndarray:
         return nb_gauss_scaled_cdf(x, area, mu, sigma)
 

--- a/src/pygama/math/functions/gauss.py
+++ b/src/pygama/math/functions/gauss.py
@@ -9,7 +9,7 @@ import numpy as np
 
 from pygama.math.functions.error_function import nb_erf
 from pygama.math.functions.pygama_continuous import pygama_continuous 
-from ..utils import numba_math_defaults as nb_defaults
+from pygama.utils import numba_math_defaults as nb_defaults
 
 
 @nb.njit(**nb_defaults(parallel=False))

--- a/src/pygama/math/functions/linear.py
+++ b/src/pygama/math/functions/linear.py
@@ -6,8 +6,8 @@ import numpy as np
 from numba import prange
 
 from pygama.math.functions.pygama_continuous import pygama_continuous 
-from ..utils import numba_math_defaults_kwargs as nb_kwargs
-from ..utils import numba_math_defaults as nb_defaults
+from pygama.utils import numba_math_defaults_kwargs as nb_kwargs
+from pygama.utils import numba_math_defaults as nb_defaults
 
 
 @nb.njit(**nb_kwargs)

--- a/src/pygama/math/functions/linear.py
+++ b/src/pygama/math/functions/linear.py
@@ -6,13 +6,11 @@ import numpy as np
 from numba import prange
 
 from pygama.math.functions.pygama_continuous import pygama_continuous 
+from ..utils import numba_math_defaults_kwargs as nb_kwargs
+from ..utils import numba_math_defaults as nb_defaults
 
 
-kwd = {"parallel": False, "fastmath": True}
-kwd_parallel = {"parallel": True, "fastmath": True}
-
-
-@nb.njit(**kwd_parallel)
+@nb.njit(**nb_kwargs)
 def nb_linear_pdf(x: np.ndarray, x_lo: float, x_hi: float, m: float, b: float) -> np.ndarray:
     r"""
     Normalised linear probability density function, w/ args: m, b. Its range of support is :math:`x\in(x_{lower},x_{upper})`. 
@@ -48,7 +46,7 @@ def nb_linear_pdf(x: np.ndarray, x_lo: float, x_hi: float, m: float, b: float) -
     return result
 
 
-@nb.njit(**kwd_parallel)
+@nb.njit(**nb_kwargs)
 def nb_linear_cdf(x: np.ndarray, x_lo: float, x_hi: float, m: float, b: float) -> np.ndarray:
     r"""
     Normalised linear cumulative density function, w/ args: m, b. Its range of support is :math:`x\in(x_{lower},x_{upper})`. 
@@ -84,7 +82,7 @@ def nb_linear_cdf(x: np.ndarray, x_lo: float, x_hi: float, m: float, b: float) -
     return result
 
 
-@nb.njit(**kwd)
+@nb.njit(**nb_defaults(parallel=False))
 def nb_linear_scaled_pdf(x: np.ndarray, x_lo: float, x_hi: float, area: float, m: float, b: float) -> np.ndarray:
     r"""
     Scaled linear probability distribution, w/ args: m, b.
@@ -110,7 +108,7 @@ def nb_linear_scaled_pdf(x: np.ndarray, x_lo: float, x_hi: float, area: float, m
     return area * nb_linear_pdf(x, x_lo, x_hi, m, b)
 
 
-@nb.njit(**kwd)
+@nb.njit(**nb_defaults(parallel=False))
 def nb_linear_scaled_cdf(x: np.ndarray, x_lo: float, x_hi: float, area: float, m: float, b: float) -> np.ndarray:
     r"""
     Linear cdf scaled by the area for extended binned fits 

--- a/src/pygama/math/functions/moyal.py
+++ b/src/pygama/math/functions/moyal.py
@@ -10,8 +10,8 @@ from numba import prange
 from math import erfc
 
 from pygama.math.functions.pygama_continuous import pygama_continuous
-from ..utils import numba_math_defaults_kwargs as nb_kwargs
-from ..utils import numba_math_defaults as nb_defaults
+from pygama.utils import numba_math_defaults_kwargs as nb_kwargs
+from pygama.utils import numba_math_defaults as nb_defaults
 
 
 

--- a/src/pygama/math/functions/moyal.py
+++ b/src/pygama/math/functions/moyal.py
@@ -9,13 +9,13 @@ import numpy as np
 from numba import prange
 from math import erfc
 
-from pygama.math.functions.pygama_continuous import pygama_continuous 
+from pygama.math.functions.pygama_continuous import pygama_continuous
+from ..utils import numba_math_defaults_kwargs as nb_kwargs
+from ..utils import numba_math_defaults as nb_defaults
 
-kwd = {"parallel": False, "fastmath": True}
-kwd_parallel = {"parallel": True, "fastmath": True}
 
 
-@nb.njit(**kwd_parallel)
+@nb.njit(**nb_kwargs)
 def nb_moyal_pdf(x: np.ndarray, mu: float, sigma: float) -> np.ndarray:
     r"""
     Normalised Moyal probability distribution function, w/ args: mu, sigma. Its support is :math:`x\in\mathbb{R}`
@@ -47,7 +47,7 @@ def nb_moyal_pdf(x: np.ndarray, mu: float, sigma: float) -> np.ndarray:
     return y
 
 
-@nb.njit(**kwd_parallel)
+@nb.njit(**nb_kwargs)
 def nb_moyal_cdf(x: np.ndarray, mu: float, sigma: float) -> np.ndarray:
     r"""
     Normalised Moyal cumulative distribution, w/ args: mu, sigma.
@@ -80,7 +80,7 @@ def nb_moyal_cdf(x: np.ndarray, mu: float, sigma: float) -> np.ndarray:
     return y
 
 
-@nb.njit(**kwd)
+@nb.njit(**nb_defaults(parallel=False))
 def nb_moyal_scaled_pdf(x: np.ndarray, area: float, mu: float, sigma: float) -> np.ndarray:
     r"""
     Scaled Moyal probability density function, w/ args: mu, sigma, area.
@@ -102,7 +102,7 @@ def nb_moyal_scaled_pdf(x: np.ndarray, area: float, mu: float, sigma: float) -> 
     return area * nb_moyal_pdf(x, mu, sigma)
 
 
-@nb.njit(**kwd)
+@nb.njit(**nb_defaults(parallel=False))
 def nb_moyal_scaled_cdf(x: np.ndarray, area: float, mu: float, sigma: float) -> np.ndarray:
     r"""
     Moyal cdf scaled by the area, used for extended binned fits 
@@ -150,7 +150,7 @@ class moyal_gen(pygama_continuous):
         return self._cdf_norm(x, x_lo, x_hi, mu, sigma)
 
     def pdf_ext(self, x: np.ndarray, x_lo: float, x_hi: float, area: float, mu: float, sigma: float) -> np.ndarray:
-        return np.diff(nb_moyal_scaled_cdf(np.array([x_lo, x_hi]), area, mu, sigma)), nb_moyal_scaled_pdf(x, area, mu, sigma)
+        return np.diff(nb_moyal_scaled_cdf(np.array([x_lo, x_hi]), area, mu, sigma))[0], nb_moyal_scaled_pdf(x, area, mu, sigma)
     def cdf_ext(self, x: np.ndarray, area: float, mu: float, sigma: float) -> np.ndarray:
         return nb_moyal_scaled_cdf(x, area, mu, sigma)
 

--- a/src/pygama/math/functions/poisson.py
+++ b/src/pygama/math/functions/poisson.py
@@ -8,8 +8,8 @@ import numpy as np
 from numba import prange
 
 from scipy.stats import rv_discrete
-from ..utils import numba_math_defaults_kwargs as nb_kwargs
-from ..utils import numba_math_defaults as nb_defaults
+from pygama.utils import numba_math_defaults_kwargs as nb_kwargs
+from pygama.utils import numba_math_defaults as nb_defaults
 
 
 @nb.njit(**nb_defaults(parallel=False))

--- a/src/pygama/math/functions/poisson.py
+++ b/src/pygama/math/functions/poisson.py
@@ -8,18 +8,18 @@ import numpy as np
 from numba import prange
 
 from scipy.stats import rv_discrete
+from ..utils import numba_math_defaults_kwargs as nb_kwargs
+from ..utils import numba_math_defaults as nb_defaults
 
-kwd = {"parallel": False, "fastmath": True}
-kwd_parallel = {"parallel": True, "fastmath": True}
 
-@nb.njit(**kwd)
+@nb.njit(**nb_defaults(parallel=False))
 def factorial(nn):
     res = 1
     for ii in nb.prange(2, nn + 1):
         res *= ii
     return res
 
-@nb.njit(**kwd_parallel)
+@nb.njit(**nb_kwargs)
 def nb_poisson_pmf(x: np.ndarray, mu: int, lamb: float) -> np.ndarray:
     r"""
     Normalised Poisson distribution, w/ args: mu, lamb.
@@ -50,7 +50,7 @@ def nb_poisson_pmf(x: np.ndarray, mu: int, lamb: float) -> np.ndarray:
     return y
 
 
-@nb.njit(**kwd_parallel)
+@nb.njit(**nb_kwargs)
 def nb_poisson_cdf(x: np.ndarray, mu: int, lamb: float) -> np.ndarray:
     r"""
     Normalised Poisson cumulative distribution, w/ args: mu, lamb.
@@ -82,7 +82,7 @@ def nb_poisson_cdf(x: np.ndarray, mu: int, lamb: float) -> np.ndarray:
 
 
 
-@nb.njit(**kwd)
+@nb.njit(**nb_defaults(parallel=False))
 def nb_poisson_scaled_pmf(x: np.ndarray, area: float, mu: int, lamb: float) -> np.ndarray:
     r"""
     Scaled Poisson probability distribution, w/ args: lamb, mu.
@@ -104,7 +104,7 @@ def nb_poisson_scaled_pmf(x: np.ndarray, area: float, mu: int, lamb: float) -> n
     return area * nb_poisson_pmf(x, mu, lamb)
 
 
-@nb.njit(**kwd)
+@nb.njit(**nb_defaults(parallel=False))
 def nb_poisson_scaled_cdf(x: np.ndarray, area: float, mu: int, lamb: float) -> np.ndarray:
     r"""
     Poisson cdf scaled by the number of signal counts for extended binned fits 
@@ -146,7 +146,7 @@ class poisson_gen(rv_discrete):
         return nb_poisson_cdf(x, mu, lamb)
 
     def pmf_ext(self, x: np.array, x_lo: float, x_hi: float, area: float, mu: int, lamb: float) -> np.array:
-        return np.diff(nb_poisson_scaled_cdf(np.array([x_lo, x_hi]), area, mu, lamb)), nb_poisson_scaled_pmf(x, area, mu, lamb)
+        return np.diff(nb_poisson_scaled_cdf(np.array([x_lo, x_hi]), area, mu, lamb))[0], nb_poisson_scaled_pmf(x, area, mu, lamb)
     def cdf_ext(self, x: np.array, area: float, mu: int, lamb: float) -> np.array:
         return nb_poisson_scaled_cdf(x, area, mu, lamb)
 

--- a/src/pygama/math/functions/polynomial.py
+++ b/src/pygama/math/functions/polynomial.py
@@ -1,6 +1,6 @@
 import numba as nb
 import numpy as np
-from ..utils import numba_math_defaults as nb_defaults
+from pygama.utils import numba_math_defaults as nb_defaults
 
 
 @nb.njit(**nb_defaults(parallel=False))

--- a/src/pygama/math/functions/polynomial.py
+++ b/src/pygama/math/functions/polynomial.py
@@ -1,9 +1,9 @@
 import numba as nb
 import numpy as np
+from ..utils import numba_math_defaults as nb_defaults
 
-kwd = {"parallel": False, "fastmath": True}
 
-@nb.njit(**kwd)
+@nb.njit(**nb_defaults(parallel=False))
 def nb_poly(x: np.ndarray, pars: np.ndarray) -> np.ndarray:
     r"""
     A polynomial function with pars following the polyfit convention. It computes:

--- a/src/pygama/math/functions/step.py
+++ b/src/pygama/math/functions/step.py
@@ -11,11 +11,9 @@ from math import erf
 
 from pygama.math.functions.gauss import nb_gauss
 from pygama.math.functions.pygama_continuous import pygama_continuous
-from ..utils import numba_math_defaults_kwargs as nb_kwargs
-from ..utils import numba_math_defaults as nb_defaults
+from pygama.utils import numba_math_defaults_kwargs as nb_kwargs
+from pygama.utils import numba_math_defaults as nb_defaults
 
-kwd = {"parallel": False, "fastmath": True}
-kwd_parallel = {"parallel": True, "fastmath": True}
 
 @nb.njit(**nb_defaults(parallel=False))
 def nb_step_int(x: float, mu: float, sigma: float, hstep: float) -> np.ndarray:

--- a/src/pygama/math/functions/step.py
+++ b/src/pygama/math/functions/step.py
@@ -10,12 +10,14 @@ import numpy as np
 from math import erf
 
 from pygama.math.functions.gauss import nb_gauss
-from pygama.math.functions.pygama_continuous import pygama_continuous 
+from pygama.math.functions.pygama_continuous import pygama_continuous
+from ..utils import numba_math_defaults_kwargs as nb_kwargs
+from ..utils import numba_math_defaults as nb_defaults
 
 kwd = {"parallel": False, "fastmath": True}
 kwd_parallel = {"parallel": True, "fastmath": True}
 
-@nb.njit(**kwd)
+@nb.njit(**nb_defaults(parallel=False))
 def nb_step_int(x: float, mu: float, sigma: float, hstep: float) -> np.ndarray:
     r"""
     Integral of step function w/args mu, sigma, hstep. It computes: 
@@ -54,7 +56,7 @@ def nb_step_int(x: float, mu: float, sigma: float, hstep: float) -> np.ndarray:
     return y
 
 
-@nb.njit(**kwd)
+@nb.njit(**nb_defaults(parallel=False))
 def nb_unnorm_step_pdf(x: float,  mu: float, sigma: float, hstep: float) -> float:
     r"""
     Unnormalised step function for use in pdfs. It computes: 
@@ -89,7 +91,7 @@ def nb_unnorm_step_pdf(x: float,  mu: float, sigma: float, hstep: float) -> floa
         return step_f
 
 
-@nb.njit(**kwd_parallel)
+@nb.njit(**nb_kwargs)
 def nb_step_pdf(x: np.ndarray, x_lo: float, x_hi: float, mu: float, sigma: float, hstep: float) -> np.ndarray:
     r"""
     Normalised step function w/args mu, sigma, hstep, x_lo, x_hi. Its range of support is :math:`x\in` (x_lo, x_hi). It computes: 
@@ -134,7 +136,7 @@ def nb_step_pdf(x: np.ndarray, x_lo: float, x_hi: float, mu: float, sigma: float
 
     return z
 
-@nb.njit(**kwd_parallel)
+@nb.njit(**nb_kwargs)
 def nb_step_cdf(x: np.ndarray, x_lo: float, x_hi: float, mu: float, sigma: float, hstep: float) -> np.ndarray:
     r"""
     Normalized CDF for step function w/args mu, sigma, hstep, x_lo, x_hi. Its range of support is :math:`x\in` (x_lo, x_hi). It computes: 
@@ -181,7 +183,7 @@ def nb_step_cdf(x: np.ndarray, x_lo: float, x_hi: float, mu: float, sigma: float
     return cdf
 
 
-@nb.njit(**kwd)
+@nb.njit(**nb_defaults(parallel=False))
 def nb_step_scaled_pdf(x: np.ndarray, x_lo: float, x_hi: float, area: float, mu: float, sigma: float, hstep: float) -> np.ndarray:
     r"""
     Scaled step function pdf w/args x_lo, x_hi, area, mu, sigma, hstep.
@@ -209,7 +211,7 @@ def nb_step_scaled_pdf(x: np.ndarray, x_lo: float, x_hi: float, area: float, mu:
     return area * nb_step_pdf(x, x_lo, x_hi, mu, sigma, hstep)
 
 
-@nb.njit(**kwd)
+@nb.njit(**nb_defaults(parallel=False))
 def nb_step_scaled_cdf(x: np.ndarray, x_lo: float, x_hi: float, area: float, mu: float, sigma: float, hstep: float) -> np.ndarray:
     r"""
     Scaled step function CDF w/args  x_lo, x_hi, area, mu, sigma, hstep. Used for extended binned fits.
@@ -266,7 +268,7 @@ class step_gen(pygama_continuous):
         return nb_step_cdf(x, x_lo, x_hi, mu, sigma, hstep)
 
     def pdf_ext(self, x: np.ndarray, x_lo: float, x_hi: float, area: float, mu: float, sigma: float, hstep: float) -> np.ndarray:
-        return np.diff(nb_step_scaled_cdf(np.array([x_lo, x_hi]), x_lo, x_hi, area, mu, sigma, hstep)), nb_step_scaled_pdf(x, x_lo, x_hi, area, mu, sigma, hstep)
+        return np.diff(nb_step_scaled_cdf(np.array([x_lo, x_hi]), x_lo, x_hi, area, mu, sigma, hstep))[0], nb_step_scaled_pdf(x, x_lo, x_hi, area, mu, sigma, hstep)
     def cdf_ext(self, x: np.ndarray, x_lo: float, x_hi: float, area: float, mu: float, sigma: float, hstep: float) -> np.ndarray:
         return nb_step_scaled_cdf(x, x_lo, x_hi, area, mu, sigma, hstep)
 

--- a/src/pygama/math/functions/uniform.py
+++ b/src/pygama/math/functions/uniform.py
@@ -10,8 +10,8 @@ import numpy as np
 from numba import prange
 
 from pygama.math.functions.pygama_continuous import pygama_continuous
-from ..utils import numba_math_defaults_kwargs as nb_kwargs
-from ..utils import numba_math_defaults as nb_defaults
+from pygama.utils import numba_math_defaults_kwargs as nb_kwargs
+from pygama.utils import numba_math_defaults as nb_defaults
 
 
 @nb.njit(**nb_kwargs)

--- a/src/pygama/math/functions/uniform.py
+++ b/src/pygama/math/functions/uniform.py
@@ -9,14 +9,12 @@ import numba as nb
 import numpy as np
 from numba import prange
 
-from pygama.math.functions.pygama_continuous import pygama_continuous 
+from pygama.math.functions.pygama_continuous import pygama_continuous
+from ..utils import numba_math_defaults_kwargs as nb_kwargs
+from ..utils import numba_math_defaults as nb_defaults
 
 
-kwd = {"parallel": False, "fastmath": True}
-kwd_parallel = {"parallel": True, "fastmath": True}
-
-
-@nb.njit(**kwd_parallel)
+@nb.njit(**nb_kwargs)
 def nb_uniform_pdf(x: np.ndarray, a: float, b: float) -> np.ndarray:
     r"""
     Normalised uniform probability density function, w/ args: a, b. Its range of support is :math:`x\in[a,b]`. The pdf is computed as:
@@ -49,7 +47,7 @@ def nb_uniform_pdf(x: np.ndarray, a: float, b: float) -> np.ndarray:
     return p
 
 
-@nb.njit(**kwd_parallel)
+@nb.njit(**nb_kwargs)
 def nb_uniform_cdf(x: np.ndarray, a: float, b: float) -> np.ndarray:
     r"""
     Normalised uniform cumulative distribution, w/ args: a, b. Its range of support is :math:`x\in[a,b]`. The cdf is computed as:
@@ -86,7 +84,7 @@ def nb_uniform_cdf(x: np.ndarray, a: float, b: float) -> np.ndarray:
     return p
 
 
-@nb.njit(**kwd)
+@nb.njit(**nb_defaults(parallel=False))
 def nb_uniform_scaled_pdf(x: np.ndarray, area: float, a: float, b: float) -> np.ndarray:
     r"""
     Scaled uniform probability distribution, w/ args: a, b.
@@ -109,7 +107,7 @@ def nb_uniform_scaled_pdf(x: np.ndarray, area: float, a: float, b: float) -> np.
     return area * nb_uniform_pdf(x, a, b)
 
 
-@nb.njit(**kwd)
+@nb.njit(**nb_defaults(parallel=False))
 def nb_uniform_scaled_cdf(x: np.ndarray, area: float, a: float, b: float) -> np.ndarray:
     r"""
     Uniform cdf scaled by the area, used for extended binned fits 

--- a/src/pygama/math/utils.py
+++ b/src/pygama/math/utils.py
@@ -3,7 +3,9 @@ pygama utility functions.
 """
 import logging
 import sys
-from typing import Optional, Union, Callable
+import os
+from typing import Optional, Union, Callable, Any, Iterator
+from collections.abc import MutableMapping
 
 import numpy as np
 
@@ -103,3 +105,75 @@ def print_fit_results(pars: np.ndarray, cov: np.ndarray, func: Optional[Callable
         log.info(f"{par_names[i]} = {mean} +/- {sigma}")
     if pad:
         log.info("")
+
+
+def getenv_bool(name: str, default: bool = False) -> bool:
+    """Get environment value as a boolean, returning True for 1, t and true
+    (caps-insensitive), and False for any other value and default if undefined.
+    """
+    val = os.getenv(name)
+    if not val:
+        return default
+    elif val.lower() in ("1", "t", "true"):
+        return True
+    else:
+        return False
+
+class NumbaMathDefaults(MutableMapping):
+    """Bare-bones class to store some Numba default options. Defaults values
+    are set from environment variables
+
+    Examples
+    --------
+    Set all default option values for a processor at once by expanding the
+    provided dictionary:
+
+    >>> from numba import guvectorize
+    >>> from pygama.math.utils import numba_defaults_kwargs as nb_kwargs
+    >>> @guvectorize([], "", **nb_kwargs, nopython=True) # def proc(...): ...
+
+    Customize one argument but still set defaults for the others:
+
+    >>> from pygama.math.utils import numba_defaults as nb_defaults
+    >>> @guvectorize([], "", **nb_defaults(cache=False) # def proc(...): ...
+
+    Override global options at runtime:
+
+    >>> from pygama.math.utils import numba_defaults
+    >>> # must set options before explicitly importing pygama.math.distributions!
+    >>> numba_defaults.cache = False
+    """
+
+    def __init__(self) -> None:
+        self.parallel: bool = getenv_bool("MATH_PARALLEL", default=True)
+        self.fastmath: bool = getenv_bool("MATH_FAST", default=True)
+
+    def __getitem__(self, item: str) -> Any:
+        return self.__dict__[item]
+
+    def __setitem__(self, item: str, val: Any) -> None:
+        self.__dict__[item] = val
+
+    def __delitem__(self, item: str) -> None:
+        del self.__dict__[item]
+
+    def __iter__(self) -> Iterator:
+        return self.__dict__.__iter__()
+
+    def __len__(self) -> int:
+        return len(self.__dict__)
+
+    def __call__(self, **kwargs) -> dict:
+        mapping = self.__dict__.copy()
+        mapping.update(**kwargs)
+        return mapping
+
+    def __str__(self) -> str:
+        return str(self.__dict__)
+
+    def __repr__(self) -> str:
+        return str(self.__dict__)
+
+
+numba_math_defaults = NumbaMathDefaults()
+numba_math_defaults_kwargs = numba_math_defaults

--- a/src/pygama/math/utils.py
+++ b/src/pygama/math/utils.py
@@ -3,9 +3,7 @@ pygama utility functions.
 """
 import logging
 import sys
-import os
-from typing import Optional, Union, Callable, Any, Iterator
-from collections.abc import MutableMapping
+from typing import Optional, Union, Callable
 
 import numpy as np
 
@@ -105,75 +103,3 @@ def print_fit_results(pars: np.ndarray, cov: np.ndarray, func: Optional[Callable
         log.info(f"{par_names[i]} = {mean} +/- {sigma}")
     if pad:
         log.info("")
-
-
-def getenv_bool(name: str, default: bool = False) -> bool:
-    """Get environment value as a boolean, returning True for 1, t and true
-    (caps-insensitive), and False for any other value and default if undefined.
-    """
-    val = os.getenv(name)
-    if not val:
-        return default
-    elif val.lower() in ("1", "t", "true"):
-        return True
-    else:
-        return False
-
-class NumbaMathDefaults(MutableMapping):
-    """Bare-bones class to store some Numba default options. Defaults values
-    are set from environment variables
-
-    Examples
-    --------
-    Set all default option values for a processor at once by expanding the
-    provided dictionary:
-
-    >>> from numba import guvectorize
-    >>> from pygama.math.utils import numba_defaults_kwargs as nb_kwargs
-    >>> @guvectorize([], "", **nb_kwargs, nopython=True) # def proc(...): ...
-
-    Customize one argument but still set defaults for the others:
-
-    >>> from pygama.math.utils import numba_defaults as nb_defaults
-    >>> @guvectorize([], "", **nb_defaults(cache=False) # def proc(...): ...
-
-    Override global options at runtime:
-
-    >>> from pygama.math.utils import numba_defaults
-    >>> # must set options before explicitly importing pygama.math.distributions!
-    >>> numba_defaults.cache = False
-    """
-
-    def __init__(self) -> None:
-        self.parallel: bool = getenv_bool("MATH_PARALLEL", default=True)
-        self.fastmath: bool = getenv_bool("MATH_FAST", default=True)
-
-    def __getitem__(self, item: str) -> Any:
-        return self.__dict__[item]
-
-    def __setitem__(self, item: str, val: Any) -> None:
-        self.__dict__[item] = val
-
-    def __delitem__(self, item: str) -> None:
-        del self.__dict__[item]
-
-    def __iter__(self) -> Iterator:
-        return self.__dict__.__iter__()
-
-    def __len__(self) -> int:
-        return len(self.__dict__)
-
-    def __call__(self, **kwargs) -> dict:
-        mapping = self.__dict__.copy()
-        mapping.update(**kwargs)
-        return mapping
-
-    def __str__(self) -> str:
-        return str(self.__dict__)
-
-    def __repr__(self) -> str:
-        return str(self.__dict__)
-
-
-numba_math_defaults = NumbaMathDefaults()
-numba_math_defaults_kwargs = numba_math_defaults

--- a/src/pygama/utils.py
+++ b/src/pygama/utils.py
@@ -43,7 +43,7 @@ class NumbaPygamaDefaults(MutableMapping):
 
     def __init__(self) -> None:
         self.parallel: bool = getenv_bool("PYGAMA_PARALLEL", default=True)
-        self.fastmath: bool = getenv_bool("PYGAMA_FAST", default=True)
+        self.fastmath: bool = getenv_bool("PYGAMA_FASTMATH", default=True)
 
     def __getitem__(self, item: str) -> Any:
         return self.__dict__[item]

--- a/src/pygama/utils.py
+++ b/src/pygama/utils.py
@@ -1,0 +1,76 @@
+import os
+from collections.abc import MutableMapping
+from typing import Any, Iterator
+
+
+def getenv_bool(name: str, default: bool = False) -> bool:
+    """Get environment value as a boolean, returning True for 1, t and true
+    (caps-insensitive), and False for any other value and default if undefined.
+    """
+    val = os.getenv(name)
+    if not val:
+        return default
+    elif val.lower() in ("1", "t", "true"):
+        return True
+    else:
+        return False
+
+
+class NumbaPygamaDefaults(MutableMapping):
+    """Bare-bones class to store some Numba default options. Defaults values
+    are set from environment variables. Useful for the pygama.math distributions
+
+    Examples
+    --------
+    Set all default option values for a numba wrapped function at once by expanding the
+    provided dictionary:
+
+    >>> from numba import njit
+    >>> from pygama.utils import numba_math_defaults_kwargs as nb_kwargs
+    >>> @njit([], "", **nb_kwargs, nopython=True) # def dist(...): ...
+
+    Customize one argument but still set defaults for the others:
+
+    >>> from pygama.utils import numba_math_defaults as nb_defaults
+    >>> @njit([], "", **nb_defaults(cache=False) # def dist(...): ...
+
+    Override global options at runtime:
+
+    >>> from pygama.utils import numba_math_defaults
+    >>> # must set options before explicitly importing pygama.math.distributions!
+    >>> numba_math_defaults.cache = False
+    """
+
+    def __init__(self) -> None:
+        self.parallel: bool = getenv_bool("PYGAMA_PARALLEL", default=True)
+        self.fastmath: bool = getenv_bool("PYGAMA_FAST", default=True)
+
+    def __getitem__(self, item: str) -> Any:
+        return self.__dict__[item]
+
+    def __setitem__(self, item: str, val: Any) -> None:
+        self.__dict__[item] = val
+
+    def __delitem__(self, item: str) -> None:
+        del self.__dict__[item]
+
+    def __iter__(self) -> Iterator:
+        return self.__dict__.__iter__()
+
+    def __len__(self) -> int:
+        return len(self.__dict__)
+
+    def __call__(self, **kwargs) -> dict:
+        mapping = self.__dict__.copy()
+        mapping.update(**kwargs)
+        return mapping
+
+    def __str__(self) -> str:
+        return str(self.__dict__)
+
+    def __repr__(self) -> str:
+        return str(self.__dict__)
+
+
+numba_math_defaults = NumbaPygamaDefaults()
+numba_math_defaults_kwargs = numba_math_defaults

--- a/tests/math/test_iminuit_integration.py
+++ b/tests/math/test_iminuit_integration.py
@@ -43,7 +43,7 @@ def test_unbinned_nll():
 def test_extended_unbinned_nll():
     c = cost.ExtendedUnbinnedNLL(xmix, exgauss.pdf_ext)
 
-    m = Minuit(c, x_lo=-7, x_hi=7, tau=1, mu=0, sigma=3, area=100)
+    m = Minuit(c, x_lo=-7, x_hi=7, area=100, mu=0, sigma=3, tau=1)
     m.fixed["x_lo", "x_hi"] = True
     m.limits["tau", "mu", "sigma"] = (0.01, 5)
     m.limits["area"] = (0, 2000)
@@ -63,7 +63,7 @@ def test_extended_unbinned_nll():
 def test_binned_nll():
     c = cost.BinnedNLL(n, xe, exgauss.cdf_norm)
 
-    m = Minuit(c, x_lo=-20, x_hi=20, tau=1, mu=0, sigma=3)
+    m = Minuit(c, x_lo=-20, x_hi=20, mu=0, sigma=3, tau=1)
     m.fixed["x_lo", "x_hi"] = True
     m.limits["tau"] = (0.1, 3)
     m.limits["mu"] = (0, 2)
@@ -82,7 +82,7 @@ def test_binned_nll():
 def test_extended_binned_nll():
     c = cost.ExtendedBinnedNLL(n, xe, exgauss.cdf_ext)
 
-    m = Minuit(c, area=100, tau=1, mu=0, sigma=3)
+    m = Minuit(c, area=100, mu=0, sigma=3, tau=1)
     m.limits["tau", "mu", "sigma"] = (0.01, 5)
     m.limits["area"] = (0, 2000)
 

--- a/tests/math/test_math_utils.py
+++ b/tests/math/test_math_utils.py
@@ -31,3 +31,11 @@ def test_print_fit_results(caplog):
         "p2 = 1.0 +/- 1.0",
         "",
     ] == [rec.message for rec in caplog.records]
+
+
+def test_math_numba_defaults():
+    assert pgu.numba_math_defaults_kwargs.fastmath
+    assert pgu.numba_math_defaults_kwargs.parallel
+
+    pgu.numba_math_defaults.fastmath = False
+    assert ~pgu.numba_math_defaults.fastmath

--- a/tests/math/test_math_utils.py
+++ b/tests/math/test_math_utils.py
@@ -31,11 +31,3 @@ def test_print_fit_results(caplog):
         "p2 = 1.0 +/- 1.0",
         "",
     ] == [rec.message for rec in caplog.records]
-
-
-def test_math_numba_defaults():
-    assert pgu.numba_math_defaults_kwargs.fastmath
-    assert pgu.numba_math_defaults_kwargs.parallel
-
-    pgu.numba_math_defaults.fastmath = False
-    assert ~pgu.numba_math_defaults.fastmath

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,9 @@
+import pygama.utils as pgu
+
+
+def test_math_numba_defaults():
+    assert pgu.numba_math_defaults_kwargs.fastmath
+    assert pgu.numba_math_defaults_kwargs.parallel
+
+    pgu.numba_math_defaults.fastmath = False
+    assert ~pgu.numba_math_defaults.fastmath


### PR DESCRIPTION
This pull request adds numba defaults for the math distributions, like in `dspeed`, as requested by @ggmarshall for more user flexibility. 