### PR TITLE
added `name` attribute to distributions

### DIFF
--- a/src/pygama/math/functions/crystal_ball.py
+++ b/src/pygama/math/functions/crystal_ball.py
@@ -190,9 +190,9 @@ def nb_crystal_ball_scaled_cdf(x: np.ndarray, area: float, mu: float, sigma: flo
 class crystal_ball_gen(pygama_continuous): 
 
     def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.x_lo = -1*np.inf
         self.x_hi = np.inf
-        super().__init__(self)
 
     def _pdf(self, x: np.ndarray, mu: float, sigma: float, beta: float, m: float) -> np.ndarray:
         x.flags.writeable = True

--- a/src/pygama/math/functions/exgauss.py
+++ b/src/pygama/math/functions/exgauss.py
@@ -226,7 +226,7 @@ class exgauss_gen(pygama_continuous):
     def __init__(self, *args, **kwargs):
         self.x_lo = -1*np.inf
         self.x_hi = np.inf
-        super().__init__(self)
+        super().__init__(*args, **kwargs)
 
     def _pdf(self, x: np.ndarray, sigma: float, tau: float) -> np.ndarray:
         x.flags.writeable = True

--- a/src/pygama/math/functions/exponential.py
+++ b/src/pygama/math/functions/exponential.py
@@ -141,7 +141,7 @@ class exponential_gen(pygama_continuous):
     def __init__(self, *args, **kwargs):
         self.x_lo = 0
         self.x_hi = np.inf
-        super().__init__(self)
+        super().__init__(*args, **kwargs)
 
     def _pdf(self, x: np.ndarray, mu: float, sigma: float, lamb: float) -> np.ndarray:
         x.flags.writeable = True

--- a/src/pygama/math/functions/gauss.py
+++ b/src/pygama/math/functions/gauss.py
@@ -169,9 +169,9 @@ def nb_gauss_scaled_cdf(x: np.ndarray, area: float, mu: float, sigma: float) -> 
 class gaussian_gen(pygama_continuous):
 
     def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
         self.x_lo = -1*np.inf
         self.x_hi = np.inf
-        super().__init__(self)
 
     def _pdf(self, x: np.ndarray) -> np.ndarray:
         x.flags.writeable = True

--- a/src/pygama/math/functions/gauss_on_exgauss.py
+++ b/src/pygama/math/functions/gauss_on_exgauss.py
@@ -28,4 +28,4 @@ from pygama.math.functions.exgauss import exgauss
 (mu, sigma, frac, tau) = range(4) # the sum_dist array we will pass will be mu, sigma, frac/htail, tau
 par_array = [(exgauss, [mu, sigma, tau]), (gaussian, [mu, sigma])] 
 
-gauss_on_exgauss = sum_dists(par_array, [frac], "fracs", parameter_names = ["mu", "sigma", "htail", "tau"])
+gauss_on_exgauss = sum_dists(par_array, [frac], "fracs", parameter_names = ["mu", "sigma", "htail", "tau"], name="gauss_on_exgauss")

--- a/src/pygama/math/functions/gauss_on_exponential.py
+++ b/src/pygama/math/functions/gauss_on_exponential.py
@@ -28,4 +28,4 @@ from pygama.math.functions.exponential import exponential
 (n_sig, mu, sigma, n_bkg, lamb, mu_exp, sigma_exp)= range(7) # the sum_dist array we will pass will be n_sig, mu, sigma, lambda, n_bkg, mu_exp, sigma_exp
 par_array = [(gaussian, [mu, sigma]), (exponential, [mu_exp, sigma_exp, lamb])] 
 
-gauss_on_exponential = sum_dists(par_array, [n_sig, n_bkg], "areas", parameter_names = ["n_sig", "mu", "sigma", "n_bkg", "lambd", "mu_exp", "sigma_exp"])
+gauss_on_exponential = sum_dists(par_array, [n_sig, n_bkg], "areas", parameter_names = ["n_sig", "mu", "sigma", "n_bkg", "lambd", "mu_exp", "sigma_exp"], name="gauss_on_exponential")

--- a/src/pygama/math/functions/gauss_on_linear.py
+++ b/src/pygama/math/functions/gauss_on_linear.py
@@ -34,4 +34,4 @@ from pygama.math.functions.linear import linear
 (linear_x_lo, linear_x_hi, n_sig, mu, sigma, n_bkg, m, b) = range(8) # the sum_dist array we will pass will be x_lo, x_hi, n_sig, mu, sigma, n_bkg, m, b
 par_array = [(gaussian, [mu, sigma]), (linear, [linear_x_lo, linear_x_hi, m, b])] 
 
-gauss_on_linear = sum_dists(par_array, [n_sig, n_bkg], "areas", parameter_names = ["x_lo", "x_hi", "n_sig", "mu", "sigma", "n_bkg", "m", "b"])
+gauss_on_linear = sum_dists(par_array, [n_sig, n_bkg], "areas", parameter_names = ["x_lo", "x_hi", "n_sig", "mu", "sigma", "n_bkg", "m", "b"], name="gauss_on_linear")

--- a/src/pygama/math/functions/gauss_on_step.py
+++ b/src/pygama/math/functions/gauss_on_step.py
@@ -33,4 +33,4 @@ from pygama.math.functions.step import step
 (x_lo, x_hi, n_sig, mu, sigma, n_bkg, hstep) = range(7) # the sum_dist array we will pass will be x_lo, x_hi, n_sig, mu, sigma, n_bkg, hstep
 par_array = [(gaussian, [mu, sigma]), (step, [x_lo, x_hi, mu, sigma, hstep])] 
 
-gauss_on_step = sum_dists(par_array, [n_sig, n_bkg], "areas", parameter_names = ["x_lo", "x_hi", "n_sig", "mu", "sigma", "n_bkg", "hstep"])
+gauss_on_step = sum_dists(par_array, [n_sig, n_bkg], "areas", parameter_names = ["x_lo", "x_hi", "n_sig", "mu", "sigma", "n_bkg", "hstep"], name="gauss_on_step")

--- a/src/pygama/math/functions/gauss_on_uniform.py
+++ b/src/pygama/math/functions/gauss_on_uniform.py
@@ -25,4 +25,4 @@ from pygama.math.functions.uniform import uniform
 (x_lo, x_hi, n_sig, mu, sigma, n_bkg) = range(6) # the sum_dist array we will pass will be x_lo, x_hi, n_sig, mu, sigma, n_bkg
 par_array = [(gaussian, [mu, sigma]), (uniform, [x_lo, x_hi])] 
 
-gauss_on_uniform = sum_dists(par_array, [n_sig, n_bkg], "areas", parameter_names = ["x_lo", "x_hi", "n_sig", "mu", "sigma", "n_bkg"])
+gauss_on_uniform = sum_dists(par_array, [n_sig, n_bkg], "areas", parameter_names = ["x_lo", "x_hi", "n_sig", "mu", "sigma", "n_bkg"], name="gauss_on_uniform")

--- a/src/pygama/math/functions/hpge_peak.py
+++ b/src/pygama/math/functions/hpge_peak.py
@@ -54,7 +54,7 @@ from pygama.math.hpge_peak_fitting import hpge_peak_fwhm
 (x_lo, x_hi, n_sig, mu, sigma, frac1, tau, n_bkg, hstep) = range(9)
 par_array = [(gauss_on_exgauss, [mu, sigma, frac1, tau]), (step, [x_lo, x_hi, mu, sigma, hstep])] 
 
-hpge_peak = sum_dists(par_array, [n_sig, n_bkg], "areas", parameter_names = ["x_lo", "x_hi", "n_sig", "mu", "sigma", "htail", "tau", "n_bkg", "hstep"])
+hpge_peak = sum_dists(par_array, [n_sig, n_bkg], "areas", parameter_names = ["x_lo", "x_hi", "n_sig", "mu", "sigma", "htail", "tau", "n_bkg", "hstep"], name="hpge_peak")
 
 # This is defined here as to avoid a circular import inside `sum_dists`
 def hpge_get_fwhm(self, pars: np.ndarray, cov: np.ndarray = None) -> tuple:

--- a/src/pygama/math/functions/linear.py
+++ b/src/pygama/math/functions/linear.py
@@ -139,7 +139,7 @@ class linear_gen(pygama_continuous):
     def __init__(self, *args, **kwargs):
         self.x_lo = None
         self.x_hi = None
-        super().__init__(self)
+        super().__init__(*args, **kwargs)
 
     def _argcheck(self, x_lo, x_hi, m, b):
         return True

--- a/src/pygama/math/functions/moyal.py
+++ b/src/pygama/math/functions/moyal.py
@@ -130,7 +130,7 @@ class moyal_gen(pygama_continuous):
     def __init__(self, *args, **kwargs):
         self.x_lo = -1*np.inf
         self.x_hi = np.inf
-        super().__init__(self)
+        super().__init__(*args, **kwargs)
 
     def _pdf(self, x: np.ndarray) -> np.ndarray:
         x.flags.writeable = True

--- a/src/pygama/math/functions/poisson.py
+++ b/src/pygama/math/functions/poisson.py
@@ -131,7 +131,7 @@ class poisson_gen(rv_discrete):
     def __init__(self, *args, **kwargs):
         self.x_lo = 0
         self.x_hi = np.inf
-        super().__init__()
+        super().__init__(*args, **kwargs)
 
     def _pmf(self, x: np.array, mu: int, lamb: float) -> np.array:
         x.flags.writeable = True
@@ -153,4 +153,4 @@ class poisson_gen(rv_discrete):
     def required_args(self) -> tuple[str, str]:
         return "mu", "lamb"
 
-poisson = poisson_gen(name='poisson')
+poisson = poisson_gen(a=0, name='poisson')

--- a/src/pygama/math/functions/step.py
+++ b/src/pygama/math/functions/step.py
@@ -245,7 +245,7 @@ class step_gen(pygama_continuous):
     def __init__(self, *args, **kwargs):
         self.x_lo = None
         self.x_hi = None
-        super().__init__(self)
+        super().__init__(*args, **kwargs)
 
     def _pdf(self, x: np.ndarray, x_lo: float, x_hi: float, mu: float, sigma: float, hstep: float) -> np.ndarray:
         x.flags.writeable = True

--- a/src/pygama/math/functions/sum_dists.py
+++ b/src/pygama/math/functions/sum_dists.py
@@ -194,7 +194,7 @@ class sum_dists(rv_continuous):
         return cond
 
 
-    def __init__(self, dists_and_pars_array, area_frac_idxs, flag, parameter_names=None, components=False, support_required=False):
+    def __init__(self, dists_and_pars_array, area_frac_idxs, flag, parameter_names=None, components=False, support_required=False, **kwds):
         """
         Parameters
         ----------
@@ -295,7 +295,7 @@ class sum_dists(rv_continuous):
         shapes = ','.join(str(x) for x in shapes)
 
 
-        super().__init__(self, shapes=shapes)
+        super().__init__(self, shapes=shapes, **kwds)
 
     def _pdf(self, x, *params):
         """

--- a/src/pygama/math/functions/triple_gauss_on_double_step.py
+++ b/src/pygama/math/functions/triple_gauss_on_double_step.py
@@ -51,4 +51,4 @@ double_gauss_on_double_step = sum_dists(par_array, [], None, parameter_names = [
 (x_lo, x_hi, area1, mu1, sigma1, area2, mu2, sigma2, area3, mu3, sigma3, area4, hstep1, area5, hstep2) = range(15)
 
 par_array = [(gaussian, [mu3, sigma3]), (double_gauss_on_double_step, [x_lo, x_hi, area1, mu1, sigma1, area4, hstep1, area2, mu2, sigma2, area5, hstep2])] 
-triple_gauss_on_double_step = sum_dists(par_array, [area3], "one_area", parameter_names=["x_lo", "x_hi", "n_sig1", "mu1", "sigma1", "n_sig2", "mu2", "sigma2",  "n_sig3", "mu3", "sigma3", "n_bkg1", "hstep1", "n_bkg2", "hstep2"])
+triple_gauss_on_double_step = sum_dists(par_array, [area3], "one_area", parameter_names=["x_lo", "x_hi", "n_sig1", "mu1", "sigma1", "n_sig2", "mu2", "sigma2",  "n_sig3", "mu3", "sigma3", "n_bkg1", "hstep1", "n_bkg2", "hstep2"], name="triple_gauss_on_double_step")

--- a/src/pygama/math/functions/uniform.py
+++ b/src/pygama/math/functions/uniform.py
@@ -141,7 +141,7 @@ class uniform_gen(pygama_continuous):
     def __init__(self, *args, **kwargs):
         self.x_lo = None
         self.x_hi = None
-        super().__init__(self)
+        super().__init__(*args, **kwargs)
 
     def _pdf(self, x: np.ndarray, a, b) -> np.ndarray:
         return nb_uniform_pdf(x, a[0], b[0])

--- a/tests/math/functions/test_crystal_ball.py
+++ b/tests/math/functions/test_crystal_ball.py
@@ -73,3 +73,7 @@ def test_required_args():
     assert names[1] == "sigma"
     assert names[2] == "beta"
     assert names[3] == "m"
+
+
+def test_name():
+    assert crystal_ball.name == "crystal_ball"

--- a/tests/math/functions/test_exgauss.py
+++ b/tests/math/functions/test_exgauss.py
@@ -71,3 +71,7 @@ def test_required_args():
     assert names[0] == "mu"
     assert names[1] == "sigma"
     assert names[2] == "tau"
+
+
+def test_name():
+    assert exgauss.name == "exgauss"

--- a/tests/math/functions/test_exponential.py
+++ b/tests/math/functions/test_exponential.py
@@ -65,3 +65,7 @@ def test_required_args():
     assert names[0] == "mu"
     assert names[1] == "sigma"
     assert names[2] == "lambda"
+
+
+def test_name():
+    assert exponential.name == "exponential"

--- a/tests/math/functions/test_gauss.py
+++ b/tests/math/functions/test_gauss.py
@@ -59,3 +59,7 @@ def test_required_args():
     names = gaussian.required_args()
     assert names[0] == "mu"
     assert names[1] == "sigma"
+
+
+def test_name():
+    assert gaussian.name == "gaussian"

--- a/tests/math/functions/test_gauss_on_exgauss.py
+++ b/tests/math/functions/test_gauss_on_exgauss.py
@@ -68,3 +68,7 @@ def test_required_args():
     assert names[1] == "sigma"
     assert names[2] == "htail"
     assert names[3] == "tau"
+
+
+def test_name():
+    assert gauss_on_exgauss.name == "gauss_on_exgauss"

--- a/tests/math/functions/test_gauss_on_exponential.py
+++ b/tests/math/functions/test_gauss_on_exponential.py
@@ -75,3 +75,7 @@ def test_required_args():
     assert names[4] == "lambd"
     assert names[5] == "mu_exp"
     assert names[6] == "sigma_exp"
+
+
+def test_name():
+    assert gauss_on_exponential.name == "gauss_on_exponential"

--- a/tests/math/functions/test_gauss_on_linear.py
+++ b/tests/math/functions/test_gauss_on_linear.py
@@ -86,3 +86,7 @@ def test_required_args():
     assert names[5] == "n_bkg"
     assert names[6] == "m"
     assert names[7] == "b"
+
+
+def test_name():
+    assert gauss_on_linear.name == "gauss_on_linear"

--- a/tests/math/functions/test_gauss_on_step.py
+++ b/tests/math/functions/test_gauss_on_step.py
@@ -130,3 +130,7 @@ def test_required_args():
     assert names[4] == "sigma"
     assert names[5] == "n_bkg"
     assert names[6] == "hstep"
+
+
+def test_name():
+    assert gauss_on_step.name == "gauss_on_step"

--- a/tests/math/functions/test_gauss_on_uniform.py
+++ b/tests/math/functions/test_gauss_on_uniform.py
@@ -62,3 +62,7 @@ def test_required_args():
     assert names[3] == "mu"
     assert names[4] == "sigma"
     assert names[5] == "n_bkg"
+
+
+def test_name():
+    assert gauss_on_uniform.name == "gauss_on_uniform"

--- a/tests/math/functions/test_hpge_peak.py
+++ b/tests/math/functions/test_hpge_peak.py
@@ -128,3 +128,7 @@ def test_required_args():
     assert names[6] == "tau"
     assert names[7] == "n_bkg"
     assert names[8] == "hstep"
+
+
+def test_name():
+    assert hpge_peak.name == "hpge_peak"

--- a/tests/math/functions/test_linear.py
+++ b/tests/math/functions/test_linear.py
@@ -62,3 +62,7 @@ def test_required_args():
     assert names[1] == "x_hi"
     assert names[2] == "m"
     assert names[3] == "b"
+
+
+def test_name():
+    assert linear.name == "linear"

--- a/tests/math/functions/test_moyal.py
+++ b/tests/math/functions/test_moyal.py
@@ -59,3 +59,7 @@ def test_required_args():
     names = moyal.required_args()
     assert names[0] == "mu"
     assert names[1] == "sigma"
+
+
+def test_name():
+    assert moyal.name == "moyal"

--- a/tests/math/functions/test_poisson.py
+++ b/tests/math/functions/test_poisson.py
@@ -49,3 +49,7 @@ def test_required_args():
     names = poisson.required_args()
     assert names[0] == "mu"
     assert names[1] == "lamb"
+
+
+def test_name():
+    assert poisson.name == "poisson"

--- a/tests/math/functions/test_step.py
+++ b/tests/math/functions/test_step.py
@@ -123,3 +123,7 @@ def test_required_args():
     assert names[2] == "mu"
     assert names[3] == "sigma"
     assert names[4] == "hstep"
+
+
+def test_name():
+    assert step.name == "step"

--- a/tests/math/functions/test_triple_gauss_on_double_step.py
+++ b/tests/math/functions/test_triple_gauss_on_double_step.py
@@ -180,3 +180,7 @@ def test_required_args():
     assert names[12] == "hstep1"
     assert names[13] == "n_bkg2"
     assert names[14] == "hstep2"
+
+
+def test_name():
+    assert triple_gauss_on_double_step.name == "triple_gauss_on_double_step"

--- a/tests/math/functions/test_uniform.py
+++ b/tests/math/functions/test_uniform.py
@@ -57,3 +57,7 @@ def test_required_args():
     names = uniform.required_args()
     assert names[0] == "a"
     assert names[1] == "b"
+
+
+def test_name():
+    assert uniform.name == "uniform"


### PR DESCRIPTION
This PR adds support for a `name` attribute in both `pygama_continuous` distributions as well as in `sum_dist` distributions. It also adds unit tests for these names.