### PR TITLE
Correctly set attributes for `sum_dists` to allow for pickling

### DIFF
--- a/src/pygama/math/functions/sum_dists.py
+++ b/src/pygama/math/functions/sum_dists.py
@@ -136,17 +136,6 @@ def get_parameter_names(dists: np.array, par_idxs: np.array, par_size: int) -> n
         overall_par_idxs.extend(par_idxs[i])
     return param_names
 
-def copy_signature(signature_to_copy, obj_to_copy_to):
-    """
-    Copy the signature provided in signature_to_copy into the signature for "obj_to_copy_to". 
-    This is necessary so that we can override the signature for the various methods attached to 
-    different objects.
-    """
-    def wrapper(*args, **kwargs):
-        return obj_to_copy_to(*args, **kwargs)
-    wrapper.__signature__ = signature_to_copy
-    return wrapper
-
 class sum_dists(rv_continuous):
     r"""
     Initialize an rv_continuous method so that we gain access to scipy computable methods. 


### PR DESCRIPTION
Previously, the `__getattribute__` method was over-loaded in `sum_dists` to allow Iminuit to introspect parameter names; however, this implementation incorrectly rewrapped the object which prevented pickling a `sum_dist` object. By correctly setting the attributes for `sum_dists` methods using `setattr` during the initialization, each class method now has a `_parameters` attribute that Iminuit can use to get parameter names -- it also allows for pickling.