### PR TITLE
Disable ReadTheDocs build of PDF version of the docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,7 +5,8 @@ sphinx:
 
 formats:
   - epub
-  - pdf
+  # FIXME: latex failure
+  # - pdf
 
 build:
   os: "ubuntu-22.04"


### PR DESCRIPTION
https://readthedocs.org/projects/pygama/builds/24552659/

There seems to be something wrong with this formula:

https://github.com/legend-exp/pygama/blob/ddd441440eb9c222437c440d1788dee6d46c883d/src/pygama/math/functions/step.py#L102

CC @SamuelBorden 