### PR TITLE
Updated pargen.utils.load_data to use LH5Iterator and field_mask to be more memory efficient

### DIFF
--- a/src/pygama/pargen/utils.py
+++ b/src/pygama/pargen/utils.py
@@ -83,7 +83,9 @@ def load_data(
             )
 
             if return_selection_mask:
-                file_df[0]["run_timestamp"] = np.full(len(file_df[0]), tstamp, dtype=object)
+                file_df[0]["run_timestamp"] = np.full(
+                    len(file_df[0]), tstamp, dtype=object
+                )
                 df.append(file_df[0])
                 masks.append(file_df[1])
             else:
@@ -116,9 +118,11 @@ def load_data(
         )
         df_fields = params & (fields | set(cal_dict))
         if df_fields != params:
-            log.debug(f"load_data(): params not found in data files or cal_dict: {params-df_fields}")
+            log.debug(
+                f"load_data(): params not found in data files or cal_dict: {params-df_fields}"
+            )
         df = pd.DataFrame(columns=list(df_fields))
-        
+
         for table, entry, n_rows in lh5_it:
             # Evaluate all provided expressions and add to table
             for outname, info in cal_dict.items():

--- a/src/pygama/pargen/utils.py
+++ b/src/pygama/pargen/utils.py
@@ -103,8 +103,8 @@ def load_data(
         # Get set of keys in calibration expressions that show up in file
         cal_keys = {
             name
-            for expr in cal_dict.values()
-            for name in compile(expr, "0vbb is real!", "eval").co_names
+            for info in cal_dict.values()
+            for name in compile(info["expression"], "0vbb is real!", "eval").co_names
         } & file_keys
 
         # Get set of fields to read from files
@@ -118,7 +118,7 @@ def load_data(
             # Evaluate all provided expressions and add to table
             for outname, info in cal_dict.items():
                 table[outname] = table.eval(
-                    info["expression"], local_dict=info.get("parameters", None)
+                    info["expression"], info.get("parameters", None)
                 )
 
             # Copy params in table into dataframe


### PR DESCRIPTION
`load_data` was using too much memory (at least in P08 which is a larger dataset), and crashing my attempts to process it on NERSC. Switch it to use the fieldmask when reading from the input files and the LH5Iterator to limit the number of entries in memory at once. Also improved commenting/docstring.

Note this should not be merged until this is also merged: https://github.com/legend-exp/legend-pydataobj/pull/100