### PR TITLE
add ability to override aoe parameters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "matplotlib",
     "numba !=0.53.*,!=0.54.*,!=0.57",
     "numpy >=1.21",
+    "numexpr",
     "pandas >=1.4.4",
     "tables",
     "pint",

--- a/src/pygama/pargen/AoE_cal.py
+++ b/src/pygama/pargen/AoE_cal.py
@@ -1923,7 +1923,7 @@ class CalAoE:
         sf_nsamples: int = 11,
         sf_cut_range: tuple = (-5, 5),
         timecorr_mode: str = "full",
-        override_dict=None,
+        override_dict: dict | None = None,
     ):
         """
         Main function to run a full A/E calibration with all steps i.e. time correction, drift time correction,
@@ -1950,6 +1950,26 @@ class CalAoE:
             Range of A/E cut values to use for the survival fraction sweep.
         timecorr_mode
             Mode to use for the time correction; see :meth:`time_correction` for details.
+        override_dict
+            Optional dictionary of pre-computed calibration entries that bypass one or more
+            fit steps. Each key should map to a sub-dict with ``"expression"`` (a string
+            expression) and ``"parameters"`` (a dict of named constants used by the expression).
+            Supported keys and the fit step they replace:
+
+            - ``"AoE_Timecorr"`` – skips :meth:`time_correction`; the expression is evaluated
+              with columns from *df* plus the stored parameters to populate ``df["AoE_Timecorr"]``.
+            - ``"AoE_DTcorr"`` – skips :meth:`drift_time_correction` (only relevant when
+              ``self.dt_corr`` is ``True``); populates ``df["AoE_DTcorr"]``. Silently ignored
+              if ``self.dt_corr`` is ``False``.
+            - ``"AoE_Corrected"``, ``"_AoE_Classifier_intermediate"``, and ``"AoE_Classifier"``
+              – together skip :meth:`energy_correction`. All three keys must be present to
+              take the override path; if only one of ``"AoE_Corrected"`` or ``"AoE_Classifier"``
+              is given (regardless of whether ``"_AoE_Classifier_intermediate"`` is present) a
+              warning is logged and normal energy correction runs instead.
+            - ``"AoE_Low_Cut"`` – skips :meth:`get_aoe_cut_fit`; the expression should evaluate
+              to a boolean array. The numeric cut threshold is read from ``parameters["a"]``
+              (or the sole parameter value if ``"a"`` is absent) and stored as
+              ``self.low_cut_val``.
 
         """
         if peaks_of_interest is None:

--- a/src/pygama/pargen/AoE_cal.py
+++ b/src/pygama/pargen/AoE_cal.py
@@ -192,7 +192,7 @@ def aoe_peak_bounds(func, guess, **kwargs):
     """
     Build parameter bounds for an A/E peak fit.
 
-    parameters
+    Parameters
     ----------
     func
         PDF to bound; one of ``aoe_peak``, ``aoe_peak_with_high_tail``,
@@ -264,7 +264,7 @@ def aoe_peak_fixed(func, **_kwargs):
     """
     Return the fixed parameters and free-parameter mask for an A/E peak fit.
 
-    parameters
+    Parameters
     ----------
     func
         PDF to query; one of ``aoe_peak``, ``aoe_peak_with_high_tail``,
@@ -356,7 +356,7 @@ def unbinned_aoe_fit(
     Fitting function for A/E, first fits just a Gaussian before using the full pdf to fit
     if fails will return NaN values
 
-    parameters
+    Parameters
     ----------
     aoe
         A/E values.
@@ -611,7 +611,7 @@ def fit_time_means(tstamps, means, sigmas):
     """
     Fit the time dependence of the means of the A/E distribution
 
-    parameters
+    Parameters
     ----------
     tstamps
         Timestamps of the data.
@@ -676,7 +676,7 @@ def average_consecutive(tstamps, means):
     """
     Fit the time dependence of the means of the A/E distribution by average consecutive entries
 
-    parameters
+    Parameters
     ----------
     tstamps
         Timestamps of the data.
@@ -701,7 +701,7 @@ def interpolate_consecutive(tstamps, means, times, aoe_param, output_name):
     """
     Fit the time dependence of the means of the A/E distribution by average consecutive entries
 
-    parameters
+    Parameters
     ----------
     tstamps
         Timestamps of the data.
@@ -769,7 +769,7 @@ class CalAoE:
         debug_mode: bool = False,
     ):
         """
-        parameters
+        Parameters
         ----------
 
         cal_dicts
@@ -841,7 +841,7 @@ class CalAoE:
         fallback when a timestamp is absent.  Otherwise *update_dict* is
         merged directly.
 
-        parameters
+        Parameters
         ----------
         update_dict
             Dictionary of new calibration entries to merge.
@@ -871,7 +871,7 @@ class CalAoE:
         just perform a shift of the A/E parameter to 1 using the centroid otherwise for multiple
         runs the shift will be determined on the mode given in.
 
-        parameters
+        Parameters
         ----------
 
         df
@@ -1159,7 +1159,7 @@ class CalAoE:
         fitting the A/E peaks in each of these regions. A simple linear correction is then applied
         to align these regions.
 
-        parameters
+        Parameters
         ----------
 
         data
@@ -1302,7 +1302,7 @@ class CalAoE:
         Does this by fitting the compton continuum in slices and then applies fits
         to the centroid and variance.
 
-        parameters
+        Parameters
         ----------
 
         data
@@ -1590,7 +1590,7 @@ class CalAoE:
         Fits the resulting distribution and
         interpolates to get cut value at desired DEP survival fraction (typically 90%)
 
-        parameters
+        Parameters
         ----------
 
         data
@@ -1705,7 +1705,7 @@ class CalAoE:
         Calculate survival fractions for the A/E cut for a list of peaks by sweeping through values
         of the A/E cut to show how this varies
 
-        parameters
+        Parameters
         ----------
 
         data
@@ -1824,7 +1824,7 @@ class CalAoE:
         Calculate survival fractions for the A/E cut for a list of peaks for the final
         A/E cut value
 
-        parameters
+        Parameters
         ----------
 
         data
@@ -1929,7 +1929,7 @@ class CalAoE:
         Main function to run a full A/E calibration with all steps i.e. time correction, drift time correction,
         energy correction, A/E cut determination and survival fraction calculation
 
-        parameters
+        Parameters
         ----------
 
         df
@@ -1956,17 +1956,17 @@ class CalAoE:
             expression) and ``"parameters"`` (a dict of named constants used by the expression).
             Supported keys and the fit step they replace:
 
-            - ``"AoE_Timecorr"`` – skips :meth:`time_correction`; the expression is evaluated
+            - ``"AoE_Timecorr"`` - skips :meth:`time_correction`; the expression is evaluated
               with columns from *df* plus the stored parameters to populate ``df["AoE_Timecorr"]``.
-            - ``"AoE_DTcorr"`` – skips :meth:`drift_time_correction` (only relevant when
+            - ``"AoE_DTcorr"`` - skips :meth:`drift_time_correction` (only relevant when
               ``self.dt_corr`` is ``True``); populates ``df["AoE_DTcorr"]``. Silently ignored
               if ``self.dt_corr`` is ``False``.
             - ``"AoE_Corrected"``, ``"_AoE_Classifier_intermediate"``, and ``"AoE_Classifier"``
-              – together skip :meth:`energy_correction`. All three keys must be present to
+              - together skip :meth:`energy_correction`. All three keys must be present to
               take the override path; if only one of ``"AoE_Corrected"`` or ``"AoE_Classifier"``
               is given (regardless of whether ``"_AoE_Classifier_intermediate"`` is present) a
               warning is logged and normal energy correction runs instead.
-            - ``"AoE_Low_Cut"`` – skips :meth:`get_aoe_cut_fit`; the expression should evaluate
+            - ``"AoE_Low_Cut"`` - skips :meth:`get_aoe_cut_fit`; the expression should evaluate
               to a boolean array. The numeric cut threshold is read from ``parameters["a"]``
               (or the sole parameter value if ``"a"`` is absent) and stored as
               ``self.low_cut_val``.

--- a/src/pygama/pargen/AoE_cal.py
+++ b/src/pygama/pargen/AoE_cal.py
@@ -1961,11 +1961,12 @@ class CalAoE:
             - ``"AoE_DTcorr"`` - skips :meth:`drift_time_correction` (only relevant when
               ``self.dt_corr`` is ``True``); populates ``df["AoE_DTcorr"]``. Silently ignored
               if ``self.dt_corr`` is ``False``.
-            - ``"AoE_Corrected"``, ``"_AoE_Classifier_intermediate"``, and ``"AoE_Classifier"``
-              - together skip :meth:`energy_correction`. All three keys must be present to
-              take the override path; if only one of ``"AoE_Corrected"`` or ``"AoE_Classifier"``
-              is given (regardless of whether ``"_AoE_Classifier_intermediate"`` is present) a
-              warning is logged and normal energy correction runs instead.
+            - ``"AoE_Corrected"`` and ``"AoE_Classifier"`` -- together skip
+              :meth:`energy_correction`. Both keys must be present to take the override path;
+              if only one is given a warning is logged and normal energy correction runs instead.
+              ``"_AoE_Classifier_intermediate"`` is optional: if present it is evaluated and
+              stored before ``"AoE_Classifier"`` is evaluated (useful when the
+              ``"AoE_Classifier"`` expression references it).
             - ``"AoE_Low_Cut"`` - skips :meth:`get_aoe_cut_fit`; the expression should evaluate
               to a boolean array. The numeric cut threshold is read from ``parameters["a"]``
               (or the sole parameter value if ``"a"`` is absent) and stored as
@@ -2023,24 +2024,25 @@ class CalAoE:
             )
         else:
             self.update_cal_dicts({"AoE_Corrected": override_dict["AoE_Corrected"]})
-            self.update_cal_dicts(
-                {
-                    "_AoE_Classifier_intermediate": override_dict[
-                        "_AoE_Classifier_intermediate"
-                    ]
-                }
-            )
             self.update_cal_dicts({"AoE_Classifier": override_dict["AoE_Classifier"]})
             df["AoE_Corrected"] = ne.evaluate(
                 override_dict["AoE_Corrected"]["expression"],
                 local_dict={col: df[col].to_numpy() for col in df.columns}
                 | override_dict["AoE_Corrected"]["parameters"],
             )
-            df["_AoE_Classifier_intermediate"] = ne.evaluate(
-                override_dict["_AoE_Classifier_intermediate"]["expression"],
-                local_dict={col: df[col].to_numpy() for col in df.columns}
-                | override_dict["_AoE_Classifier_intermediate"]["parameters"],
-            )
+            if "_AoE_Classifier_intermediate" in override_dict:
+                self.update_cal_dicts(
+                    {
+                        "_AoE_Classifier_intermediate": override_dict[
+                            "_AoE_Classifier_intermediate"
+                        ]
+                    }
+                )
+                df["_AoE_Classifier_intermediate"] = ne.evaluate(
+                    override_dict["_AoE_Classifier_intermediate"]["expression"],
+                    local_dict={col: df[col].to_numpy() for col in df.columns}
+                    | override_dict["_AoE_Classifier_intermediate"]["parameters"],
+                )
             df["AoE_Classifier"] = ne.evaluate(
                 override_dict["AoE_Classifier"]["expression"],
                 local_dict={col: df[col].to_numpy() for col in df.columns}

--- a/src/pygama/pargen/AoE_cal.py
+++ b/src/pygama/pargen/AoE_cal.py
@@ -1967,7 +1967,7 @@ class CalAoE:
                 override_dict["AoE_Timecorr"]["expression"],
                 local_dict={col: df[col].to_numpy() for col in df.columns}
                 | override_dict["AoE_Timecorr"]["parameters"],
-            ).view_as("np")
+            )
 
         if self.dt_corr is True:
             aoe_param = "AoE_DTcorr"
@@ -1979,7 +1979,7 @@ class CalAoE:
                     override_dict["AoE_DTcorr"]["expression"],
                     local_dict={col: df[col].to_numpy() for col in df.columns}
                     | override_dict["AoE_DTcorr"]["parameters"],
-                ).view_as("np")
+                )
         else:
             aoe_param = "AoE_Timecorr"
 
@@ -2007,17 +2007,17 @@ class CalAoE:
                 override_dict["AoE_Corrected"]["expression"],
                 local_dict={col: df[col].to_numpy() for col in df.columns}
                 | override_dict["AoE_Corrected"]["parameters"],
-            ).view_as("np")
+            )
             df["_AoE_Classifier_intermediate"] = ne.evaluate(
                 override_dict["_AoE_Classifier_intermediate"]["expression"],
                 local_dict={col: df[col].to_numpy() for col in df.columns}
                 | override_dict["_AoE_Classifier_intermediate"]["parameters"],
-            ).view_as("np")
+            )
             df["AoE_Classifier"] = ne.evaluate(
                 override_dict["AoE_Classifier"]["expression"],
                 local_dict={col: df[col].to_numpy() for col in df.columns}
                 | override_dict["AoE_Classifier"]["parameters"],
-            ).view_as("np")
+            )
 
         if override_dict is None or ("AoE_Low_Cut" not in override_dict):
             self.get_aoe_cut_fit(
@@ -2034,7 +2034,7 @@ class CalAoE:
                 override_dict["AoE_Low_Cut"]["expression"],
                 local_dict={col: df[col].to_numpy() for col in df.columns}
                 | override_dict["AoE_Low_Cut"]["parameters"],
-            ).view_as("np")
+            )
 
         df["AoE_Double_Sided_Cut"] = df["AoE_Low_Cut"] & (
             df["AoE_Classifier"] < self.high_cut_val

--- a/src/pygama/pargen/AoE_cal.py
+++ b/src/pygama/pargen/AoE_cal.py
@@ -1983,9 +1983,17 @@ class CalAoE:
         else:
             aoe_param = "AoE_Timecorr"
 
+        if override_dict is not None and (
+            ("AoE_Corrected" in override_dict) != ("AoE_Classifier" in override_dict)
+        ):
+            log.warning(
+                "override_dict must contain both 'AoE_Corrected' and 'AoE_Classifier' to "
+                "override energy correction; ignoring partial override and running energy correction."
+            )
+
         if override_dict is None or (
             "AoE_Corrected" not in override_dict
-            and "AoE_Classifier" not in override_dict
+            or "AoE_Classifier" not in override_dict
         ):
             self.energy_correction(
                 df,

--- a/src/pygama/pargen/AoE_cal.py
+++ b/src/pygama/pargen/AoE_cal.py
@@ -12,10 +12,10 @@ from datetime import datetime
 
 import matplotlib.dates as mdates
 import matplotlib.pyplot as plt
+import numexpr as ne
 import numpy as np
 import pandas as pd
 from iminuit import Minuit, cost
-from lgdo.types import Table
 from matplotlib.colors import LogNorm
 from scipy.stats import chi2
 
@@ -84,10 +84,10 @@ def aoe_peak_guess(func, hist, bins, var, **kwargs):
     :func:`~pygama.pargen.utils.convert_to_minuit` so they can be passed
     directly to :class:`~iminuit.Minuit`.
 
-    Parameters
+    local_dict
     ----------
     func
-        PDF to guess parameters for; one of ``aoe_peak``,
+        PDF to guess local_dict for; one of ``aoe_peak``,
         ``aoe_peak_with_high_tail``, ``exgauss``, or ``gaussian``.
     hist
         Histogram counts.
@@ -192,7 +192,7 @@ def aoe_peak_bounds(func, guess, **kwargs):
     """
     Build parameter bounds for an A/E peak fit.
 
-    Parameters
+    local_dict
     ----------
     func
         PDF to bound; one of ``aoe_peak``, ``aoe_peak_with_high_tail``,
@@ -262,9 +262,9 @@ def aoe_peak_bounds(func, guess, **kwargs):
 
 def aoe_peak_fixed(func, **_kwargs):
     """
-    Return the fixed parameters and free-parameter mask for an A/E peak fit.
+    Return the fixed local_dict and free-parameter mask for an A/E peak fit.
 
-    Parameters
+    local_dict
     ----------
     func
         PDF to query; one of ``aoe_peak``, ``aoe_peak_with_high_tail``,
@@ -279,7 +279,7 @@ def aoe_peak_fixed(func, **_kwargs):
         boundaries ``x_lo`` and ``x_hi``).
     mask
         Boolean array aligned with ``func.required_args()``; ``True`` for
-        free parameters, ``False`` for fixed ones.
+        free local_dict, ``False`` for fixed ones.
     """
     if func in (aoe_peak, aoe_peak_with_high_tail):
         fixed = ["x_lo", "x_hi"]
@@ -356,7 +356,7 @@ def unbinned_aoe_fit(
     Fitting function for A/E, first fits just a Gaussian before using the full pdf to fit
     if fails will return NaN values
 
-    Parameters
+    local_dict
     ----------
     aoe
         A/E values.
@@ -611,7 +611,7 @@ def fit_time_means(tstamps, means, sigmas):
     """
     Fit the time dependence of the means of the A/E distribution
 
-    Parameters
+    local_dict
     ----------
     tstamps
         Timestamps of the data.
@@ -676,7 +676,7 @@ def average_consecutive(tstamps, means):
     """
     Fit the time dependence of the means of the A/E distribution by average consecutive entries
 
-    Parameters
+    local_dict
     ----------
     tstamps
         Timestamps of the data.
@@ -701,7 +701,7 @@ def interpolate_consecutive(tstamps, means, times, aoe_param, output_name):
     """
     Fit the time dependence of the means of the A/E distribution by average consecutive entries
 
-    Parameters
+    local_dict
     ----------
     tstamps
         Timestamps of the data.
@@ -725,14 +725,14 @@ def interpolate_consecutive(tstamps, means, times, aoe_param, output_name):
             out_dict[tstamp] = {
                 output_name: {
                     "expression": f"{aoe_param}/a",
-                    "parameters": {"a": means[i]},
+                    "local_dict": {"a": means[i]},
                 }
             }
         else:
             out_dict[tstamp] = {
                 output_name: {
                     "expression": f"{aoe_param} / ((timestamp - a ) * b + c) ",
-                    "parameters": {
+                    "local_dict": {
                         "a": times[i],
                         "b": (means[i + 1] - means[i]) / (times[i + 1] - times[i]),
                         "c": means[i],
@@ -769,11 +769,11 @@ class CalAoE:
         debug_mode: bool = False,
     ):
         """
-        Parameters
+        local_dict
         ----------
 
         cal_dicts
-            Dictionary of calibration parameters; can be empty/None for a single run, or keyed by
+            Dictionary of calibration local_dict; can be empty/None for a single run, or keyed by
             timestamp in the format ``YYYYMMDDTHHMMSSZ`` for multiple runs.
         cal_energy_param
             Calibrated energy parameter to use for A/E calibrations and for determining peak events.
@@ -788,7 +788,7 @@ class CalAoE:
         dep_correct
             Whether to correct the double escape peak into the single-site band before cut determination.
         dt_cut
-            Dictionary of the drift time cut parameters in the form::
+            Dictionary of the drift time cut local_dict in the form::
 
                 {"out_param": "dt_cut", "hard": False}
 
@@ -841,7 +841,7 @@ class CalAoE:
         fallback when a timestamp is absent.  Otherwise *update_dict* is
         merged directly.
 
-        Parameters
+        local_dict
         ----------
         update_dict
             Dictionary of new calibration entries to merge.
@@ -871,7 +871,7 @@ class CalAoE:
         just perform a shift of the A/E parameter to 1 using the centroid otherwise for multiple
         runs the shift will be determined on the mode given in.
 
-        Parameters
+        local_dict
         ----------
 
         df
@@ -963,7 +963,7 @@ class CalAoE:
                             tstamp: {
                                 output_name: {
                                     "expression": f"{aoe_param}/a",
-                                    "parameters": {"a": t_dict},
+                                    "local_dict": {"a": t_dict},
                                 }
                             }
                             for tstamp, t_dict in time_dict.items()
@@ -981,7 +981,7 @@ class CalAoE:
                             tstamp: {
                                 output_name: {
                                     "expression": f"{aoe_param}/a",
-                                    "parameters": {"a": t_dict},
+                                    "local_dict": {"a": t_dict},
                                 }
                             }
                             for tstamp, t_dict in time_dict.items()
@@ -996,7 +996,7 @@ class CalAoE:
                             tstamp: {
                                 output_name: {
                                     "expression": f"{aoe_param}/a",
-                                    "parameters": {"a": t_dict},
+                                    "local_dict": {"a": t_dict},
                                 }
                             }
                             for tstamp, t_dict in time_dict.items()
@@ -1011,7 +1011,7 @@ class CalAoE:
                             tstamp: {
                                 output_name: {
                                     "expression": f"{aoe_param}/a",
-                                    "parameters": {"a": t_dict},
+                                    "local_dict": {"a": t_dict},
                                 }
                             }
                             for tstamp, t_dict in time_dict.items()
@@ -1062,7 +1062,7 @@ class CalAoE:
                         {
                             output_name: {
                                 "expression": f"{aoe_param}/a",
-                                "parameters": {
+                                "local_dict": {
                                     "a": np.array(self.timecorr_df["mean"])[0]
                                 },
                             }
@@ -1127,7 +1127,7 @@ class CalAoE:
                     {
                         output_name: {
                             "expression": f"{aoe_param}/a",
-                            "parameters": {"a": pars["mu"]},
+                            "local_dict": {"a": pars["mu"]},
                         }
                     }
                 )
@@ -1141,7 +1141,7 @@ class CalAoE:
                 {
                     output_name: {
                         "expression": f"{aoe_param}/a",
-                        "parameters": {"a": np.nan},
+                        "local_dict": {"a": np.nan},
                     }
                 }
             )
@@ -1159,7 +1159,7 @@ class CalAoE:
         fitting the A/E peaks in each of these regions. A simple linear correction is then applied
         to align these regions.
 
-        Parameters
+        local_dict
         ----------
 
         data
@@ -1284,7 +1284,7 @@ class CalAoE:
             {
                 out_param: {
                     "expression": f"{aoe_param}*(1+a*{self.dt_param})",
-                    "parameters": {"a": self.alpha},
+                    "local_dict": {"a": self.alpha},
                 }
             }
         )
@@ -1302,7 +1302,7 @@ class CalAoE:
         Does this by fitting the compton continuum in slices and then applies fits
         to the centroid and variance.
 
-        Parameters
+        local_dict
         ----------
 
         data
@@ -1561,15 +1561,15 @@ class CalAoE:
             {
                 corrected_param: {
                     "expression": f"{aoe_param}/({self.mean_func.string_func(self.cal_energy_param)})",
-                    "parameters": mu_pars.to_dict(),
+                    "local_dict": mu_pars.to_dict(),
                 },
                 f"_{classifier_param}_intermediate": {
                     "expression": f"({aoe_param})-({self.mean_func.string_func(self.cal_energy_param)})",
-                    "parameters": mu_pars.to_dict(),
+                    "local_dict": mu_pars.to_dict(),
                 },
                 classifier_param: {
                     "expression": f"(_{classifier_param}_intermediate)/({self.sigma_func.string_func(self.cal_energy_param)})",
-                    "parameters": sig_pars.to_dict(),
+                    "local_dict": sig_pars.to_dict(),
                 },
             }
         )
@@ -1590,7 +1590,7 @@ class CalAoE:
         Fits the resulting distribution and
         interpolates to get cut value at desired DEP survival fraction (typically 90%)
 
-        Parameters
+        local_dict
         ----------
 
         data
@@ -1686,7 +1686,7 @@ class CalAoE:
             {
                 output_cut_param: {
                     "expression": f"({aoe_param}>a)",
-                    "parameters": {"a": self.low_cut_val},
+                    "local_dict": {"a": self.low_cut_val},
                 }
             }
         )
@@ -1705,7 +1705,7 @@ class CalAoE:
         Calculate survival fractions for the A/E cut for a list of peaks by sweeping through values
         of the A/E cut to show how this varies
 
-        Parameters
+        local_dict
         ----------
 
         data
@@ -1824,7 +1824,7 @@ class CalAoE:
         Calculate survival fractions for the A/E cut for a list of peaks for the final
         A/E cut value
 
-        Parameters
+        local_dict
         ----------
 
         data
@@ -1929,7 +1929,7 @@ class CalAoE:
         Main function to run a full A/E calibration with all steps i.e. time correction, drift time correction,
         energy correction, A/E cut determination and survival fraction calculation
 
-        Parameters
+        local_dict
         ----------
 
         df
@@ -1963,10 +1963,11 @@ class CalAoE:
             )
         else:
             self.update_cal_dicts({"AoE_Timecorr": override_dict["AoE_Timecorr"]})
-            df["AoE_Timecorr"] = Table(df).eval(
+            df["AoE_Timecorr"] = ne.evaluate(
                 override_dict["AoE_Timecorr"]["expression"],
-                parameters=override_dict["AoE_Timecorr"]["parameters"],
-            )
+                local_dict={col: df[col].to_numpy() for col in df.columns}
+                | override_dict["AoE_Timecorr"]["local_dict"],
+            ).view_as("np")
 
         if self.dt_corr is True:
             aoe_param = "AoE_DTcorr"
@@ -1974,10 +1975,11 @@ class CalAoE:
                 self.drift_time_correction(df, "AoE_Timecorr", out_param=aoe_param)
             else:
                 self.update_cal_dicts({"AoE_DTcorr": override_dict["AoE_DTcorr"]})
-                df["AoE_DTcorr"] = Table(df).eval(
+                df["AoE_DTcorr"] = ne.evaluate(
                     override_dict["AoE_DTcorr"]["expression"],
-                    parameters=override_dict["AoE_DTcorr"]["parameters"],
-                )
+                    local_dict={col: df[col].to_numpy() for col in df.columns}
+                    | override_dict["AoE_DTcorr"]["local_dict"],
+                ).view_as("np")
         else:
             aoe_param = "AoE_Timecorr"
 
@@ -2001,18 +2003,21 @@ class CalAoE:
                 }
             )
             self.update_cal_dicts({"AoE_Classifier": override_dict["AoE_Classifier"]})
-            df["AoE_Corrected"] = Table(df).eval(
+            df["AoE_Corrected"] = ne.evaluate(
                 override_dict["AoE_Corrected"]["expression"],
-                parameters=override_dict["AoE_Corrected"]["parameters"],
-            )
-            df["_AoE_Classifier_intermediate"] = Table(df).eval(
+                local_dict={col: df[col].to_numpy() for col in df.columns}
+                | override_dict["AoE_Corrected"]["local_dict"],
+            ).view_as("np")
+            df["_AoE_Classifier_intermediate"] = ne.evaluate(
                 override_dict["_AoE_Classifier_intermediate"]["expression"],
-                parameters=override_dict["_AoE_Classifier_intermediate"]["parameters"],
-            )
-            df["AoE_Classifier"] = Table(df).eval(
+                local_dict={col: df[col].to_numpy() for col in df.columns}
+                | override_dict["_AoE_Classifier_intermediate"]["local_dict"],
+            ).view_as("np")
+            df["AoE_Classifier"] = ne.evaluate(
                 override_dict["AoE_Classifier"]["expression"],
-                parameters=override_dict["AoE_Classifier"]["parameters"],
-            )
+                local_dict={col: df[col].to_numpy() for col in df.columns}
+                | override_dict["AoE_Classifier"]["local_dict"],
+            ).view_as("np")
 
         if override_dict is None or ("AoE_Low_Cut" not in override_dict):
             self.get_aoe_cut_fit(
@@ -2025,10 +2030,11 @@ class CalAoE:
             )
         else:
             self.update_cal_dicts({"AoE_Low_Cut": override_dict["AoE_Low_Cut"]})
-            df["AoE_Low_Cut"] = Table(df).eval(
+            df["AoE_Low_Cut"] = ne.evaluate(
                 override_dict["AoE_Low_Cut"]["expression"],
-                parameters=override_dict["AoE_Low_Cut"]["parameters"],
-            )
+                local_dict={col: df[col].to_numpy() for col in df.columns}
+                | override_dict["AoE_Low_Cut"]["local_dict"],
+            ).view_as("np")
 
         df["AoE_Double_Sided_Cut"] = df["AoE_Low_Cut"] & (
             df["AoE_Classifier"] < self.high_cut_val
@@ -2038,7 +2044,7 @@ class CalAoE:
             {
                 "AoE_High_Side_Cut": {
                     "expression": "(a>AoE_Classifier)",
-                    "parameters": {"a": self.high_cut_val},
+                    "local_dict": {"a": self.high_cut_val},
                 }
             }
         )
@@ -2047,7 +2053,7 @@ class CalAoE:
             {
                 "AoE_Double_Sided_Cut": {
                     "expression": "(AoE_High_Side_Cut) & (AoE_Low_Cut)",
-                    "parameters": {},
+                    "local_dict": {},
                 }
             }
         )
@@ -2118,7 +2124,7 @@ def plot_aoe_mean_time(
         )
 
         grouped_means = [
-            cal_dict[time_param]["parameters"]["a"]
+            cal_dict[time_param]["local_dict"]["a"]
             for tstamp, cal_dict in aoe_class.cal_dicts.items()
         ]
         ax.step(

--- a/src/pygama/pargen/AoE_cal.py
+++ b/src/pygama/pargen/AoE_cal.py
@@ -725,14 +725,14 @@ def interpolate_consecutive(tstamps, means, times, aoe_param, output_name):
             out_dict[tstamp] = {
                 output_name: {
                     "expression": f"{aoe_param}/a",
-                    "local_dict": {"a": means[i]},
+                    "parameters": {"a": means[i]},
                 }
             }
         else:
             out_dict[tstamp] = {
                 output_name: {
                     "expression": f"{aoe_param} / ((timestamp - a ) * b + c) ",
-                    "local_dict": {
+                    "parameters": {
                         "a": times[i],
                         "b": (means[i + 1] - means[i]) / (times[i + 1] - times[i]),
                         "c": means[i],
@@ -963,7 +963,7 @@ class CalAoE:
                             tstamp: {
                                 output_name: {
                                     "expression": f"{aoe_param}/a",
-                                    "local_dict": {"a": t_dict},
+                                    "parameters": {"a": t_dict},
                                 }
                             }
                             for tstamp, t_dict in time_dict.items()
@@ -981,7 +981,7 @@ class CalAoE:
                             tstamp: {
                                 output_name: {
                                     "expression": f"{aoe_param}/a",
-                                    "local_dict": {"a": t_dict},
+                                    "parameters": {"a": t_dict},
                                 }
                             }
                             for tstamp, t_dict in time_dict.items()
@@ -996,7 +996,7 @@ class CalAoE:
                             tstamp: {
                                 output_name: {
                                     "expression": f"{aoe_param}/a",
-                                    "local_dict": {"a": t_dict},
+                                    "parameters": {"a": t_dict},
                                 }
                             }
                             for tstamp, t_dict in time_dict.items()
@@ -1011,7 +1011,7 @@ class CalAoE:
                             tstamp: {
                                 output_name: {
                                     "expression": f"{aoe_param}/a",
-                                    "local_dict": {"a": t_dict},
+                                    "parameters": {"a": t_dict},
                                 }
                             }
                             for tstamp, t_dict in time_dict.items()
@@ -1062,7 +1062,7 @@ class CalAoE:
                         {
                             output_name: {
                                 "expression": f"{aoe_param}/a",
-                                "local_dict": {
+                                "parameters": {
                                     "a": np.array(self.timecorr_df["mean"])[0]
                                 },
                             }
@@ -1127,7 +1127,7 @@ class CalAoE:
                     {
                         output_name: {
                             "expression": f"{aoe_param}/a",
-                            "local_dict": {"a": pars["mu"]},
+                            "parameters": {"a": pars["mu"]},
                         }
                     }
                 )
@@ -1141,7 +1141,7 @@ class CalAoE:
                 {
                     output_name: {
                         "expression": f"{aoe_param}/a",
-                        "local_dict": {"a": np.nan},
+                        "parameters": {"a": np.nan},
                     }
                 }
             )
@@ -1284,7 +1284,7 @@ class CalAoE:
             {
                 out_param: {
                     "expression": f"{aoe_param}*(1+a*{self.dt_param})",
-                    "local_dict": {"a": self.alpha},
+                    "parameters": {"a": self.alpha},
                 }
             }
         )
@@ -1561,15 +1561,15 @@ class CalAoE:
             {
                 corrected_param: {
                     "expression": f"{aoe_param}/({self.mean_func.string_func(self.cal_energy_param)})",
-                    "local_dict": mu_pars.to_dict(),
+                    "parameters": mu_pars.to_dict(),
                 },
                 f"_{classifier_param}_intermediate": {
                     "expression": f"({aoe_param})-({self.mean_func.string_func(self.cal_energy_param)})",
-                    "local_dict": mu_pars.to_dict(),
+                    "parameters": mu_pars.to_dict(),
                 },
                 classifier_param: {
                     "expression": f"(_{classifier_param}_intermediate)/({self.sigma_func.string_func(self.cal_energy_param)})",
-                    "local_dict": sig_pars.to_dict(),
+                    "parameters": sig_pars.to_dict(),
                 },
             }
         )
@@ -1686,7 +1686,7 @@ class CalAoE:
             {
                 output_cut_param: {
                     "expression": f"({aoe_param}>a)",
-                    "local_dict": {"a": self.low_cut_val},
+                    "parameters": {"a": self.low_cut_val},
                 }
             }
         )
@@ -1966,7 +1966,7 @@ class CalAoE:
             df["AoE_Timecorr"] = ne.evaluate(
                 override_dict["AoE_Timecorr"]["expression"],
                 local_dict={col: df[col].to_numpy() for col in df.columns}
-                | override_dict["AoE_Timecorr"]["local_dict"],
+                | override_dict["AoE_Timecorr"]["parameters"],
             ).view_as("np")
 
         if self.dt_corr is True:
@@ -1978,7 +1978,7 @@ class CalAoE:
                 df["AoE_DTcorr"] = ne.evaluate(
                     override_dict["AoE_DTcorr"]["expression"],
                     local_dict={col: df[col].to_numpy() for col in df.columns}
-                    | override_dict["AoE_DTcorr"]["local_dict"],
+                    | override_dict["AoE_DTcorr"]["parameters"],
                 ).view_as("np")
         else:
             aoe_param = "AoE_Timecorr"
@@ -2006,17 +2006,17 @@ class CalAoE:
             df["AoE_Corrected"] = ne.evaluate(
                 override_dict["AoE_Corrected"]["expression"],
                 local_dict={col: df[col].to_numpy() for col in df.columns}
-                | override_dict["AoE_Corrected"]["local_dict"],
+                | override_dict["AoE_Corrected"]["parameters"],
             ).view_as("np")
             df["_AoE_Classifier_intermediate"] = ne.evaluate(
                 override_dict["_AoE_Classifier_intermediate"]["expression"],
                 local_dict={col: df[col].to_numpy() for col in df.columns}
-                | override_dict["_AoE_Classifier_intermediate"]["local_dict"],
+                | override_dict["_AoE_Classifier_intermediate"]["parameters"],
             ).view_as("np")
             df["AoE_Classifier"] = ne.evaluate(
                 override_dict["AoE_Classifier"]["expression"],
                 local_dict={col: df[col].to_numpy() for col in df.columns}
-                | override_dict["AoE_Classifier"]["local_dict"],
+                | override_dict["AoE_Classifier"]["parameters"],
             ).view_as("np")
 
         if override_dict is None or ("AoE_Low_Cut" not in override_dict):
@@ -2033,7 +2033,7 @@ class CalAoE:
             df["AoE_Low_Cut"] = ne.evaluate(
                 override_dict["AoE_Low_Cut"]["expression"],
                 local_dict={col: df[col].to_numpy() for col in df.columns}
-                | override_dict["AoE_Low_Cut"]["local_dict"],
+                | override_dict["AoE_Low_Cut"]["parameters"],
             ).view_as("np")
 
         df["AoE_Double_Sided_Cut"] = df["AoE_Low_Cut"] & (
@@ -2044,7 +2044,7 @@ class CalAoE:
             {
                 "AoE_High_Side_Cut": {
                     "expression": "(a>AoE_Classifier)",
-                    "local_dict": {"a": self.high_cut_val},
+                    "parameters": {"a": self.high_cut_val},
                 }
             }
         )
@@ -2053,7 +2053,7 @@ class CalAoE:
             {
                 "AoE_Double_Sided_Cut": {
                     "expression": "(AoE_High_Side_Cut) & (AoE_Low_Cut)",
-                    "local_dict": {},
+                    "parameters": {},
                 }
             }
         )
@@ -2124,7 +2124,7 @@ def plot_aoe_mean_time(
         )
 
         grouped_means = [
-            cal_dict[time_param]["local_dict"]["a"]
+            cal_dict[time_param]["parameters"]["a"]
             for tstamp, cal_dict in aoe_class.cal_dicts.items()
         ]
         ax.step(

--- a/src/pygama/pargen/AoE_cal.py
+++ b/src/pygama/pargen/AoE_cal.py
@@ -2036,6 +2036,16 @@ class CalAoE:
                 | override_dict["AoE_Low_Cut"]["parameters"],
             )
 
+            # Ensure the numeric low-cut threshold is stored for downstream use
+            params = override_dict["AoE_Low_Cut"].get("parameters", {})
+            low_cut_val = None
+            if "a" in params:
+                low_cut_val = params["a"]
+            elif len(params) == 1:
+                # Fall back to the single provided parameter if its name is not "a"
+                low_cut_val = next(iter(params.values()))
+            if low_cut_val is not None:
+                self.low_cut_val = low_cut_val
         df["AoE_Double_Sided_Cut"] = df["AoE_Low_Cut"] & (
             df["AoE_Classifier"] < self.high_cut_val
         )

--- a/src/pygama/pargen/AoE_cal.py
+++ b/src/pygama/pargen/AoE_cal.py
@@ -15,6 +15,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 from iminuit import Minuit, cost
+from lgdo.types import Table
 from matplotlib.colors import LogNorm
 from scipy.stats import chi2
 
@@ -1922,7 +1923,7 @@ class CalAoE:
         sf_nsamples: int = 11,
         sf_cut_range: tuple = (-5, 5),
         timecorr_mode: str = "full",
-        override_dict = None
+        override_dict=None,
     ):
         """
         Main function to run a full A/E calibration with all steps i.e. time correction, drift time correction,
@@ -1961,8 +1962,10 @@ class CalAoE:
                 df, initial_aoe_param, mode=timecorr_mode, output_name="AoE_Timecorr"
             )
         else:
-            self.update_cal_dicts(
-                {"AoE_Timecorr": override_dict["AoE_Timecorr"]}
+            self.update_cal_dicts({"AoE_Timecorr": override_dict["AoE_Timecorr"]})
+            df["AoE_Timecorr"] = Table(df).eval(
+                override_dict["AoE_Timecorr"]["expression"],
+                parameters=override_dict["AoE_Timecorr"]["parameters"],
             )
 
         if self.dt_corr is True:
@@ -1970,13 +1973,18 @@ class CalAoE:
             if override_dict is None or "AoE_DTcorr" not in override_dict:
                 self.drift_time_correction(df, "AoE_Timecorr", out_param=aoe_param)
             else:
-                self.update_cal_dicts(
-                {"AoE_DTcorr": override_dict["AoE_DTcorr"]}
-            )
+                self.update_cal_dicts({"AoE_DTcorr": override_dict["AoE_DTcorr"]})
+                df["AoE_DTcorr"] = Table(df).eval(
+                    override_dict["AoE_DTcorr"]["expression"],
+                    parameters=override_dict["AoE_DTcorr"]["parameters"],
+                )
         else:
             aoe_param = "AoE_Timecorr"
 
-        if override_dict is None or ("AoE_Corrected" not in override_dict and "AoE_Classifier" not in override_dict):
+        if override_dict is None or (
+            "AoE_Corrected" not in override_dict
+            and "AoE_Classifier" not in override_dict
+        ):
             self.energy_correction(
                 df,
                 aoe_param,
@@ -1984,14 +1992,26 @@ class CalAoE:
                 classifier_param="AoE_Classifier",
             )
         else:
+            self.update_cal_dicts({"AoE_Corrected": override_dict["AoE_Corrected"]})
             self.update_cal_dicts(
-                {"AoE_Corrected": override_dict["AoE_Corrected"]}
+                {
+                    "_AoE_Classifier_intermediate": override_dict[
+                        "_AoE_Classifier_intermediate"
+                    ]
+                }
             )
-            self.update_cal_dicts(
-                {"_AoE_Classifier_intermediate": override_dict["_AoE_Classifier_intermediate"]}
+            self.update_cal_dicts({"AoE_Classifier": override_dict["AoE_Classifier"]})
+            df["AoE_Corrected"] = Table(df).eval(
+                override_dict["AoE_Corrected"]["expression"],
+                parameters=override_dict["AoE_Corrected"]["parameters"],
             )
-            self.update_cal_dicts(
-                {"AoE_Classifier": override_dict["AoE_Classifier"]}
+            df["_AoE_Classifier_intermediate"] = Table(df).eval(
+                override_dict["_AoE_Classifier_intermediate"]["expression"],
+                parameters=override_dict["_AoE_Classifier_intermediate"]["parameters"],
+            )
+            df["AoE_Classifier"] = Table(df).eval(
+                override_dict["AoE_Classifier"]["expression"],
+                parameters=override_dict["AoE_Classifier"]["parameters"],
             )
 
         if override_dict is None or ("AoE_Low_Cut" not in override_dict):
@@ -2004,8 +2024,10 @@ class CalAoE:
                 output_cut_param="AoE_Low_Cut",
             )
         else:
-            self.update_cal_dicts(
-                {"AoE_Low_Cut": override_dict["AoE_Low_Cut"]}
+            self.update_cal_dicts({"AoE_Low_Cut": override_dict["AoE_Low_Cut"]})
+            df["AoE_Low_Cut"] = Table(df).eval(
+                override_dict["AoE_Low_Cut"]["expression"],
+                parameters=override_dict["AoE_Low_Cut"]["parameters"],
             )
 
         df["AoE_Double_Sided_Cut"] = df["AoE_Low_Cut"] & (

--- a/src/pygama/pargen/AoE_cal.py
+++ b/src/pygama/pargen/AoE_cal.py
@@ -84,10 +84,10 @@ def aoe_peak_guess(func, hist, bins, var, **kwargs):
     :func:`~pygama.pargen.utils.convert_to_minuit` so they can be passed
     directly to :class:`~iminuit.Minuit`.
 
-    local_dict
+    parameters
     ----------
     func
-        PDF to guess local_dict for; one of ``aoe_peak``,
+        PDF to guess parameters for; one of ``aoe_peak``,
         ``aoe_peak_with_high_tail``, ``exgauss``, or ``gaussian``.
     hist
         Histogram counts.
@@ -192,7 +192,7 @@ def aoe_peak_bounds(func, guess, **kwargs):
     """
     Build parameter bounds for an A/E peak fit.
 
-    local_dict
+    parameters
     ----------
     func
         PDF to bound; one of ``aoe_peak``, ``aoe_peak_with_high_tail``,
@@ -262,9 +262,9 @@ def aoe_peak_bounds(func, guess, **kwargs):
 
 def aoe_peak_fixed(func, **_kwargs):
     """
-    Return the fixed local_dict and free-parameter mask for an A/E peak fit.
+    Return the fixed parameters and free-parameter mask for an A/E peak fit.
 
-    local_dict
+    parameters
     ----------
     func
         PDF to query; one of ``aoe_peak``, ``aoe_peak_with_high_tail``,
@@ -279,7 +279,7 @@ def aoe_peak_fixed(func, **_kwargs):
         boundaries ``x_lo`` and ``x_hi``).
     mask
         Boolean array aligned with ``func.required_args()``; ``True`` for
-        free local_dict, ``False`` for fixed ones.
+        free parameters, ``False`` for fixed ones.
     """
     if func in (aoe_peak, aoe_peak_with_high_tail):
         fixed = ["x_lo", "x_hi"]
@@ -356,7 +356,7 @@ def unbinned_aoe_fit(
     Fitting function for A/E, first fits just a Gaussian before using the full pdf to fit
     if fails will return NaN values
 
-    local_dict
+    parameters
     ----------
     aoe
         A/E values.
@@ -611,7 +611,7 @@ def fit_time_means(tstamps, means, sigmas):
     """
     Fit the time dependence of the means of the A/E distribution
 
-    local_dict
+    parameters
     ----------
     tstamps
         Timestamps of the data.
@@ -676,7 +676,7 @@ def average_consecutive(tstamps, means):
     """
     Fit the time dependence of the means of the A/E distribution by average consecutive entries
 
-    local_dict
+    parameters
     ----------
     tstamps
         Timestamps of the data.
@@ -701,7 +701,7 @@ def interpolate_consecutive(tstamps, means, times, aoe_param, output_name):
     """
     Fit the time dependence of the means of the A/E distribution by average consecutive entries
 
-    local_dict
+    parameters
     ----------
     tstamps
         Timestamps of the data.
@@ -769,11 +769,11 @@ class CalAoE:
         debug_mode: bool = False,
     ):
         """
-        local_dict
+        parameters
         ----------
 
         cal_dicts
-            Dictionary of calibration local_dict; can be empty/None for a single run, or keyed by
+            Dictionary of calibration parameters; can be empty/None for a single run, or keyed by
             timestamp in the format ``YYYYMMDDTHHMMSSZ`` for multiple runs.
         cal_energy_param
             Calibrated energy parameter to use for A/E calibrations and for determining peak events.
@@ -788,7 +788,7 @@ class CalAoE:
         dep_correct
             Whether to correct the double escape peak into the single-site band before cut determination.
         dt_cut
-            Dictionary of the drift time cut local_dict in the form::
+            Dictionary of the drift time cut parameters in the form::
 
                 {"out_param": "dt_cut", "hard": False}
 
@@ -841,7 +841,7 @@ class CalAoE:
         fallback when a timestamp is absent.  Otherwise *update_dict* is
         merged directly.
 
-        local_dict
+        parameters
         ----------
         update_dict
             Dictionary of new calibration entries to merge.
@@ -871,7 +871,7 @@ class CalAoE:
         just perform a shift of the A/E parameter to 1 using the centroid otherwise for multiple
         runs the shift will be determined on the mode given in.
 
-        local_dict
+        parameters
         ----------
 
         df
@@ -1159,7 +1159,7 @@ class CalAoE:
         fitting the A/E peaks in each of these regions. A simple linear correction is then applied
         to align these regions.
 
-        local_dict
+        parameters
         ----------
 
         data
@@ -1302,7 +1302,7 @@ class CalAoE:
         Does this by fitting the compton continuum in slices and then applies fits
         to the centroid and variance.
 
-        local_dict
+        parameters
         ----------
 
         data
@@ -1590,7 +1590,7 @@ class CalAoE:
         Fits the resulting distribution and
         interpolates to get cut value at desired DEP survival fraction (typically 90%)
 
-        local_dict
+        parameters
         ----------
 
         data
@@ -1705,7 +1705,7 @@ class CalAoE:
         Calculate survival fractions for the A/E cut for a list of peaks by sweeping through values
         of the A/E cut to show how this varies
 
-        local_dict
+        parameters
         ----------
 
         data
@@ -1824,7 +1824,7 @@ class CalAoE:
         Calculate survival fractions for the A/E cut for a list of peaks for the final
         A/E cut value
 
-        local_dict
+        parameters
         ----------
 
         data
@@ -1929,7 +1929,7 @@ class CalAoE:
         Main function to run a full A/E calibration with all steps i.e. time correction, drift time correction,
         energy correction, A/E cut determination and survival fraction calculation
 
-        local_dict
+        parameters
         ----------
 
         df

--- a/src/pygama/pargen/AoE_cal.py
+++ b/src/pygama/pargen/AoE_cal.py
@@ -84,7 +84,7 @@ def aoe_peak_guess(func, hist, bins, var, **kwargs):
     :func:`~pygama.pargen.utils.convert_to_minuit` so they can be passed
     directly to :class:`~iminuit.Minuit`.
 
-    parameters
+    Parameters
     ----------
     func
         PDF to guess parameters for; one of ``aoe_peak``,

--- a/src/pygama/pargen/AoE_cal.py
+++ b/src/pygama/pargen/AoE_cal.py
@@ -1922,6 +1922,7 @@ class CalAoE:
         sf_nsamples: int = 11,
         sf_cut_range: tuple = (-5, 5),
         timecorr_mode: str = "full",
+        override_dict = None
     ):
         """
         Main function to run a full A/E calibration with all steps i.e. time correction, drift time correction,
@@ -1955,31 +1956,57 @@ class CalAoE:
         if fit_widths is None:
             fit_widths = [(40, 25), (25, 40), (0, 0), (25, 40), (50, 50)]
 
-        self.time_correction(
-            df, initial_aoe_param, mode=timecorr_mode, output_name="AoE_Timecorr"
-        )
+        if override_dict is None or "AoE_Timecorr" not in override_dict:
+            self.time_correction(
+                df, initial_aoe_param, mode=timecorr_mode, output_name="AoE_Timecorr"
+            )
+        else:
+            self.update_cal_dicts(
+                {"AoE_Timecorr": override_dict["AoE_Timecorr"]}
+            )
 
         if self.dt_corr is True:
             aoe_param = "AoE_DTcorr"
-            self.drift_time_correction(df, "AoE_Timecorr", out_param=aoe_param)
+            if override_dict is None or "AoE_DTcorr" not in override_dict:
+                self.drift_time_correction(df, "AoE_Timecorr", out_param=aoe_param)
+            else:
+                self.update_cal_dicts(
+                {"AoE_DTcorr": override_dict["AoE_DTcorr"]}
+            )
         else:
             aoe_param = "AoE_Timecorr"
 
-        self.energy_correction(
-            df,
-            aoe_param,
-            corrected_param="AoE_Corrected",
-            classifier_param="AoE_Classifier",
-        )
+        if override_dict is None or ("AoE_Corrected" not in override_dict and "AoE_Classifier" not in override_dict):
+            self.energy_correction(
+                df,
+                aoe_param,
+                corrected_param="AoE_Corrected",
+                classifier_param="AoE_Classifier",
+            )
+        else:
+            self.update_cal_dicts(
+                {"AoE_Corrected": override_dict["AoE_Corrected"]}
+            )
+            self.update_cal_dicts(
+                {"_AoE_Classifier_intermediate": override_dict["_AoE_Classifier_intermediate"]}
+            )
+            self.update_cal_dicts(
+                {"AoE_Classifier": override_dict["AoE_Classifier"]}
+            )
 
-        self.get_aoe_cut_fit(
-            df,
-            "AoE_Classifier",
-            peaks_of_interest[cut_peak_idx],
-            fit_widths[cut_peak_idx],
-            dep_acc,
-            output_cut_param="AoE_Low_Cut",
-        )
+        if override_dict is None or ("AoE_Low_Cut" not in override_dict):
+            self.get_aoe_cut_fit(
+                df,
+                "AoE_Classifier",
+                peaks_of_interest[cut_peak_idx],
+                fit_widths[cut_peak_idx],
+                dep_acc,
+                output_cut_param="AoE_Low_Cut",
+            )
+        else:
+            self.update_cal_dicts(
+                {"AoE_Low_Cut": override_dict["AoE_Low_Cut"]}
+            )
 
         df["AoE_Double_Sided_Cut"] = df["AoE_Low_Cut"] & (
             df["AoE_Classifier"] < self.high_cut_val

--- a/tests/pargen/test_aoecal.py
+++ b/tests/pargen/test_aoecal.py
@@ -85,11 +85,15 @@ def test_aoe_cal_override_dict(lgnd_test_data):
         "AoE_Classifier",
         "AoE_Low_Cut",
     ):
-        assert col in data_df2.columns, f"column '{col}' missing after override calibrate()"
+        assert col in data_df2.columns, (
+            f"column '{col}' missing after override calibrate()"
+        )
 
     # All overridden entries must land in cal_dicts.
     for key, val in override_dict.items():
-        assert key in aoe_ovr.cal_dicts, f"cal_dict key '{key}' missing after override calibrate()"
+        assert key in aoe_ovr.cal_dicts, (
+            f"cal_dict key '{key}' missing after override calibrate()"
+        )
         assert aoe_ovr.cal_dicts[key] == val, (
             f"cal_dict entry for '{key}' was not taken from override_dict"
         )
@@ -101,11 +105,15 @@ def test_aoe_cal_override_dict(lgnd_test_data):
         )
 
     # low_cut_val must be set from the override and match the stored parameter.
-    assert hasattr(aoe_ovr, "low_cut_val"), "low_cut_val not set after AoE_Low_Cut override"
-    assert np.isfinite(aoe_ovr.low_cut_val), "low_cut_val is not finite after AoE_Low_Cut override"
-    assert aoe_ovr.low_cut_val == pytest.approx(
-        aoe_ref.low_cut_val
-    ), "low_cut_val from override does not match reference"
+    assert hasattr(aoe_ovr, "low_cut_val"), (
+        "low_cut_val not set after AoE_Low_Cut override"
+    )
+    assert np.isfinite(aoe_ovr.low_cut_val), (
+        "low_cut_val is not finite after AoE_Low_Cut override"
+    )
+    assert aoe_ovr.low_cut_val == pytest.approx(aoe_ref.low_cut_val), (
+        "low_cut_val from override does not match reference"
+    )
 
 
 def test_aoe_cal_override_partial_energy_warns(lgnd_test_data, caplog):
@@ -122,7 +130,9 @@ def test_aoe_cal_override_partial_energy_warns(lgnd_test_data, caplog):
     data_df2 = _load_test_df(lgnd_test_data)
     aoe_partial = _make_aoe()
     with caplog.at_level(logging.WARNING, logger="pygama.pargen.AoE_cal"):
-        aoe_partial.calibrate(data_df2, "AoE_Uncorr", override_dict=override_dict_partial)
+        aoe_partial.calibrate(
+            data_df2, "AoE_Uncorr", override_dict=override_dict_partial
+        )
 
     assert any(
         "AoE_Corrected" in rec.message and "AoE_Classifier" in rec.message
@@ -133,5 +143,3 @@ def test_aoe_cal_override_partial_energy_warns(lgnd_test_data, caplog):
     # Normal energy correction still ran, so the cut should be valid.
     assert hasattr(aoe_partial, "low_cut_val")
     assert np.isfinite(aoe_partial.low_cut_val)
-
-

--- a/tests/pargen/test_aoecal.py
+++ b/tests/pargen/test_aoecal.py
@@ -1,37 +1,47 @@
 from __future__ import annotations
 
+import logging
+
 import numpy as np
+import pytest
 from lgdo import lh5
 
 import pygama.pargen.AoE_cal as Coe
 
 
-def test_aoe_cal(lgnd_test_data):
-    # load test data here
-    data = lgnd_test_data.get_path(
-        "lh5/prod-ref-l200/generated/tier/dsp/cal/p03/r000/l200-p03-r000-cal-20230311T235840Z-tier_dsp.lh5"
-    )
-
-    data_df = lh5.read_as("ch1104000/dsp", data, "pd")
-
-    data_df["AoE_Uncorr"] = data_df["A_max"] / data_df["cuspEmax"]
-
-    data_df["cuspEmax_cal"] = data_df["cuspEmax"] * 0.155
-
-    cal_dict = {
-        "AoE_Uncorr": {
-            "expression": "A_max/cuspEmax",
-            "parameters": {},
+def _make_aoe(cal_dict=None):
+    """Helper to build a CalAoE instance with standard test settings."""
+    if cal_dict is None:
+        cal_dict = {
+            "AoE_Uncorr": {
+                "expression": "A_max/cuspEmax",
+                "parameters": {},
+            }
         }
-    }
-
-    aoe = Coe.CalAoE(
+    return Coe.CalAoE(
         cal_dict,
         "cuspEmax_cal",
         lambda x: np.sqrt(1.5 + 0.1 * x),
         selection_string="index==index",
         debug_mode=True,
     )
+
+
+def _load_test_df(lgnd_test_data):
+    """Load the standard LH5 test data and add derived columns."""
+    data = lgnd_test_data.get_path(
+        "lh5/prod-ref-l200/generated/tier/dsp/cal/p03/r000/l200-p03-r000-cal-20230311T235840Z-tier_dsp.lh5"
+    )
+    df = lh5.read_as("ch1104000/dsp", data, "pd")
+    df["AoE_Uncorr"] = df["A_max"] / df["cuspEmax"]
+    df["cuspEmax_cal"] = df["cuspEmax"] * 0.155
+    return df
+
+
+def test_aoe_cal(lgnd_test_data):
+    data_df = _load_test_df(lgnd_test_data)
+
+    aoe = _make_aoe()
     aoe.calibrate(data_df, "AoE_Uncorr")
     assert (
         (aoe.low_cut_val < -1.0) & (aoe.low_cut_val > -3) & (~np.isnan(aoe.low_cut_val))
@@ -41,3 +51,87 @@ def test_aoe_cal(lgnd_test_data):
         & (aoe.low_side_sfs.loc[2614.5]["sf"] < 20)
         & (aoe.low_side_sfs.loc[2614.5]["sf"] > 0)
     )
+
+
+def test_aoe_cal_override_dict(lgnd_test_data):
+    """The override_dict paths produce the same columns and cal_dict entries as a normal run."""
+    # Reference run: calibrate in-place so we have the cal_dict entries afterwards.
+    data_df = _load_test_df(lgnd_test_data)
+    aoe_ref = _make_aoe()
+    aoe_ref.calibrate(data_df, "AoE_Uncorr")
+
+    # Build an override_dict from the entries stored by the reference run.
+    override_dict = {
+        key: aoe_ref.cal_dicts[key]
+        for key in [
+            "AoE_Timecorr",
+            "AoE_Corrected",
+            "_AoE_Classifier_intermediate",
+            "AoE_Classifier",
+            "AoE_Low_Cut",
+        ]
+    }
+
+    # Override run: a fresh DataFrame, skip all fits.
+    data_df2 = _load_test_df(lgnd_test_data)
+    aoe_ovr = _make_aoe()
+    aoe_ovr.calibrate(data_df2, "AoE_Uncorr", override_dict=override_dict)
+
+    # All expected columns must be present.
+    for col in (
+        "AoE_Timecorr",
+        "AoE_Corrected",
+        "_AoE_Classifier_intermediate",
+        "AoE_Classifier",
+        "AoE_Low_Cut",
+    ):
+        assert col in data_df2.columns, f"column '{col}' missing after override calibrate()"
+
+    # All overridden entries must land in cal_dicts.
+    for key, val in override_dict.items():
+        assert key in aoe_ovr.cal_dicts, f"cal_dict key '{key}' missing after override calibrate()"
+        assert aoe_ovr.cal_dicts[key] == val, (
+            f"cal_dict entry for '{key}' was not taken from override_dict"
+        )
+
+    # Numeric column values must be finite (no NaNs or Infs introduced by the override path).
+    for col in ("AoE_Timecorr", "AoE_Corrected", "AoE_Classifier"):
+        assert np.isfinite(data_df2[col].to_numpy()).all(), (
+            f"column '{col}' contains non-finite values after override calibrate()"
+        )
+
+    # low_cut_val must be set from the override and match the stored parameter.
+    assert hasattr(aoe_ovr, "low_cut_val"), "low_cut_val not set after AoE_Low_Cut override"
+    assert np.isfinite(aoe_ovr.low_cut_val), "low_cut_val is not finite after AoE_Low_Cut override"
+    assert aoe_ovr.low_cut_val == pytest.approx(
+        aoe_ref.low_cut_val
+    ), "low_cut_val from override does not match reference"
+
+
+def test_aoe_cal_override_partial_energy_warns(lgnd_test_data, caplog):
+    """A partial energy-correction override (only one key) logs a warning and falls back to normal fitting."""
+    data_df = _load_test_df(lgnd_test_data)
+
+    # First run to get AoE_Corrected entry only.
+    aoe_ref = _make_aoe()
+    aoe_ref.calibrate(data_df.copy(), "AoE_Uncorr")
+
+    # Supply only AoE_Corrected (missing AoE_Classifier) → should warn and run normal fit.
+    override_dict_partial = {"AoE_Corrected": aoe_ref.cal_dicts["AoE_Corrected"]}
+
+    data_df2 = _load_test_df(lgnd_test_data)
+    aoe_partial = _make_aoe()
+    with caplog.at_level(logging.WARNING, logger="pygama.pargen.AoE_cal"):
+        aoe_partial.calibrate(data_df2, "AoE_Uncorr", override_dict=override_dict_partial)
+
+    assert any(
+        "AoE_Corrected" in rec.message and "AoE_Classifier" in rec.message
+        for rec in caplog.records
+        if rec.levelno == logging.WARNING
+    ), "Expected a warning about partial energy-correction override"
+
+    # Normal energy correction still ran, so the cut should be valid.
+    assert hasattr(aoe_partial, "low_cut_val")
+    assert np.isfinite(aoe_partial.low_cut_val)
+
+

--- a/tests/pargen/test_aoecal.py
+++ b/tests/pargen/test_aoecal.py
@@ -32,10 +32,10 @@ def _load_test_df(lgnd_test_data):
     data = lgnd_test_data.get_path(
         "lh5/prod-ref-l200/generated/tier/dsp/cal/p03/r000/l200-p03-r000-cal-20230311T235840Z-tier_dsp.lh5"
     )
-    df = lh5.read_as("ch1104000/dsp", data, "pd")
-    df["AoE_Uncorr"] = df["A_max"] / df["cuspEmax"]
-    df["cuspEmax_cal"] = df["cuspEmax"] * 0.155
-    return df
+    dsp_df = lh5.read_as("ch1104000/dsp", data, "pd")
+    dsp_df["AoE_Uncorr"] = dsp_df["A_max"] / dsp_df["cuspEmax"]
+    dsp_df["cuspEmax_cal"] = dsp_df["cuspEmax"] * 0.155
+    return dsp_df
 
 
 def test_aoe_cal(lgnd_test_data):


### PR DESCRIPTION
Adds a mechanism to bypass parts of the A/E calibration pipeline by supplying precomputed calibration expressions/parameters via an `override_dict`.

## Changes Made

- **`override_dict` support in `CalAoE.calibrate()`**: Allows reusing externally provided calibration expressions for time correction, drift-time correction, energy correction, and cut calculation, skipping the corresponding fit steps. The parameter is typed as `dict | None` and fully documented in the docstring, including all supported keys, their expected structure (`"expression"` + `"parameters"`), and edge-case behaviour.
- **`numexpr`-based expression evaluation**: Override expressions are evaluated using `numexpr` to populate derived DataFrame columns from stored parameters.
- **Robust energy correction override gate**: Both `AoE_Corrected` and `AoE_Classifier` must be present in `override_dict` to take the energy correction override path. `_AoE_Classifier_intermediate` is optional — it is evaluated and stored only when present. A warning is logged if only one of the two primary keys is provided, and normal energy correction runs in that case.
- **`self.low_cut_val` derived from override**: When `AoE_Low_Cut` is overridden, `self.low_cut_val` is set from `parameters["a"]` (or the sole parameter value as a fallback) so that downstream survival-fraction calculations use the correct threshold.
- **Test coverage for override paths**: Added `test_aoe_cal_override_dict` (integration test using real LH5 data verifying all override paths populate expected DataFrame columns and `cal_dicts` entries, and that `low_cut_val` is correctly derived from the override) and `test_aoe_cal_override_partial_energy_warns` (verifies a warning is emitted when only one of the two required energy-correction keys is supplied and normal fitting runs as fallback).