### PR TITLE
More ecal

### DIFF
--- a/src/pygama/math/binned_fitting.py
+++ b/src/pygama/math/binned_fitting.py
@@ -313,14 +313,21 @@ def gauss_mode_width_max(
         raise ValueError(msg)
 
     amp_guess = hist[i_0]
-    i_0 -= int(np.floor(n_bins / 2))
+    center_i = i_0
+    i_0 = center_i - int(np.floor(n_bins / 2))
     i_n = i_0 + n_bins
-    i_0 = max(i_0, 0)
-    i_n = min(i_n, len(hist))
-    if i_n >= len(hist):
-        msg = f"Fit range exceeds histogram bounds: i_n={i_n}, hist length: {len(hist)}"
+    # Recompute (i_0, i_n) together to keep the window size consistent
+    if i_0 < 0:
+        i_0 = 0
+        i_n = n_bins
+    if i_n > len(hist):
+        i_n = len(hist)
+        i_0 = len(hist) - n_bins
+    if i_0 < 0:
+        msg = f"n_bins={n_bins} exceeds histogram size {len(hist)}"
         raise ValueError(msg)
-    width_guess = bin_centers[i_n] - bin_centers[i_0]
+    # Use bins (not bin_centers) so that i_n == len(hist) is a valid index
+    width_guess = bins[i_n] - bins[i_0]
     vv = None if var is None else var[i_0:i_n]
     guess = (mode_guess, width_guess, amp_guess)
     pars, _errors, cov = fit_binned(

--- a/src/pygama/math/binned_fitting.py
+++ b/src/pygama/math/binned_fitting.py
@@ -311,12 +311,12 @@ def gauss_mode_width_max(
             f"[0, {len(hist) - 1}] for mode_guess={mode_guess}"
         )
         raise ValueError(msg)
-    if i_0 < int(np.floor(n_bins / 2)):
-        msg = f"Fit range exceeds histogram bounds: i_0={i_0}"
-        raise ValueError(msg)
+
     amp_guess = hist[i_0]
     i_0 -= int(np.floor(n_bins / 2))
     i_n = i_0 + n_bins
+    i_0 = max(i_0, 0)
+    i_n = min(i_n, len(hist))
     if i_n >= len(hist):
         msg = f"Fit range exceeds histogram bounds: i_n={i_n}, hist length: {len(hist)}"
         raise ValueError(msg)

--- a/src/pygama/pargen/energy_cal.py
+++ b/src/pygama/pargen/energy_cal.py
@@ -447,12 +447,13 @@ class HPGeCalibration:
     def hpge_cal_energy_peak_tops(
         self,
         e_uncal,
-        n_sigmas=1.2,  # noqa: ARG002
+        n_sigmas=20,
         peaks_kev=None,
         default_n_bins=50,
         n_events=None,
         allowed_p_val=0.01,
         update_cal_pars=True,
+        fit_width_bound_kev=15,
     ):
         """
         Perform energy calibration for HPGe detector using peak fitting.
@@ -533,7 +534,21 @@ class HPGeCalibration:
             pt_pars, _ = hpge_fit_energy_peak_tops(hist, bins, var, [loc], n_to_fit=5)
             # Drop failed fits
             if pt_pars[0] is not None:
-                range_uncal = (float(pt_pars[0][1]) * 20, float(pt_pars[0][1]) * 20)
+                range_uncal = (
+                    float(pt_pars[0][1]) * n_sigmas,
+                    float(pt_pars[0][1]) * n_sigmas,
+                )
+                if fit_width_bound_kev is not None:
+                    range_uncal = (
+                        min(
+                            fit_width_bound_kev / self.pars[1],
+                            range_uncal[0],
+                        ),
+                        min(
+                            fit_width_bound_kev / self.pars[1],
+                            range_uncal[1],
+                        ),
+                    )
                 n_bins = default_n_bins
             else:
                 range_uncal = None
@@ -2930,6 +2945,7 @@ def hpge_fit_energy_scale(mus, mu_vars, energies_kev, deg=0, fixed=None):
             .coef
         )
         c = cost.LeastSquares(energies_kev, mus, np.sqrt(mu_vars), poly_wrapper)
+        c.loss = "soft_l1"
         if fixed is not None:
             for idx, val in fixed.items():
                 if val is True or val is None:
@@ -3019,6 +3035,7 @@ def hpge_fit_energy_cal_func(
         c = cost.LeastSquares(
             mus[mask], energies_kev[mask], e_weights[mask], poly_wrapper
         )
+        c.loss = "soft_l1"
         m = Minuit(c, *poly_pars)
         if fixed is not None:
             for idx in list(fixed):

--- a/src/pygama/pargen/energy_cal.py
+++ b/src/pygama/pargen/energy_cal.py
@@ -94,7 +94,7 @@ class HPGeCalibration:
             self.fixed = {0: 0}
         else:
             self.pars = np.zeros(self.deg + 1, dtype=float)
-            if isinstance(guess_kev, float) or len(guess_kev)==1:
+            if isinstance(guess_kev, float) or len(guess_kev) == 1:
                 self.pars[1] = guess_kev
             else:
                 self.pars = guess_kev

--- a/src/pygama/pargen/energy_cal.py
+++ b/src/pygama/pargen/energy_cal.py
@@ -94,10 +94,19 @@ class HPGeCalibration:
             self.fixed = {0: 0}
         else:
             self.pars = np.zeros(self.deg + 1, dtype=float)
-            if isinstance(guess_kev, float) or len(guess_kev) == 1:
-                self.pars[1] = guess_kev
+            if np.isscalar(guess_kev):
+                # treat guess_kev as an initial linear scaling factor
+                self.pars[1] = float(guess_kev)
             else:
-                self.pars = guess_kev
+                guess_arr = np.asarray(guess_kev, dtype=float)
+                if guess_arr.shape[0] != self.deg + 1:
+                    log.error(
+                        "hpge_E_cal warning: guess_kev length %s does not match deg+1 = %s",
+                        guess_arr.shape[0],
+                        self.deg + 1,
+                    )
+                else:
+                    self.pars = guess_arr.copy()
             self.fixed = fixed
         self.results = {}
 

--- a/src/pygama/pargen/energy_cal.py
+++ b/src/pygama/pargen/energy_cal.py
@@ -100,13 +100,9 @@ class HPGeCalibration:
             else:
                 guess_arr = np.asarray(guess_kev, dtype=float)
                 if guess_arr.shape[0] != self.deg + 1:
-                    log.error(
-                        "hpge_E_cal warning: guess_kev length %s does not match deg+1 = %s",
-                        guess_arr.shape[0],
-                        self.deg + 1,
-                    )
-                else:
-                    self.pars = guess_arr.copy()
+                    msg = f"guess_kev length {guess_arr.shape[0]} does not match deg+1 = {self.deg + 1}"
+                    raise ValueError(msg)
+                self.pars = guess_arr.copy()
             self.fixed = fixed
         self.results = {}
 

--- a/src/pygama/pargen/energy_cal.py
+++ b/src/pygama/pargen/energy_cal.py
@@ -94,7 +94,7 @@ class HPGeCalibration:
             self.fixed = {0: 0}
         else:
             self.pars = np.zeros(self.deg + 1, dtype=float)
-            if isinstance(guess_kev, float) or len(guess_kev)=1:
+            if isinstance(guess_kev, float) or len(guess_kev)==1:
                 self.pars[1] = guess_kev
             else:
                 self.pars = guess_kev

--- a/src/pygama/pargen/energy_cal.py
+++ b/src/pygama/pargen/energy_cal.py
@@ -94,7 +94,10 @@ class HPGeCalibration:
             self.fixed = {0: 0}
         else:
             self.pars = np.zeros(self.deg + 1, dtype=float)
-            self.pars[1] = guess_kev
+            if isinstance(guess_kev, float) or len(guess_kev)=1:
+                self.pars[1] = guess_kev
+            else:
+                self.pars = guess_kev
             self.fixed = fixed
         self.results = {}
 

--- a/tests/math/test_binned_fitting.py
+++ b/tests/math/test_binned_fitting.py
@@ -73,14 +73,19 @@ def test_gauss_mode_width_max_edge_cases():
     # histogram over range [-5, 5] with 100 bins, bin width = 0.1
     hist, bins, _var = get_hist(np.random.normal(size=10000), bins=100, range=(-5, 5))  # noqa: NPY002
 
-    # mode_guess near the lower edge: find_bin returns a small index
-    # so i_0 < floor(n_bins/2) triggers ValueError
-    with pytest.raises(ValueError, match="Fit range exceeds histogram bounds"):
-        pgbf.gauss_mode_width_max(hist, bins, mode_guess=-4.9, n_bins=5)
+    # mode_guess near the lower edge: window is shifted right so i_0 = 0, i_n = n_bins
+    fit, cov = pgbf.gauss_mode_width_max(hist, bins, mode_guess=-4.9, n_bins=5)
+    assert fit is not None
+    assert cov is not None
 
-    # mode_guess near the upper edge: i_n = i_0 + n_bins >= len(hist)
-    with pytest.raises(ValueError, match="Fit range exceeds histogram bounds"):
-        pgbf.gauss_mode_width_max(hist, bins, mode_guess=4.9, n_bins=5)
+    # mode_guess near the upper edge: window is shifted left so i_n = len(hist)
+    fit, cov = pgbf.gauss_mode_width_max(hist, bins, mode_guess=4.9, n_bins=5)
+    assert fit is not None
+    assert cov is not None
+
+    # n_bins larger than histogram raises ValueError
+    with pytest.raises(ValueError, match=r"n_bins=.*exceeds histogram size"):
+        pgbf.gauss_mode_width_max(hist, bins, n_bins=101)
 
 
 def test_taylor_mode_max():


### PR DESCRIPTION
Extends and adjusts parts of the HPGe energy calibration workflow, including peak-window selection, robustness of polynomial fits, and histogram peak-top fitting boundary handling.

## Changes Made

- **`HPGeCalibration` initialization**: Updated to accept either a scalar `guess_kev` (used as an initial linear scaling factor) or a full coefficient array of length `deg+1`; raises `ValueError` with a clear message if the array length does not match.
- **`hpge_cal_energy_peak_tops`**: Made the fit window configurable via `n_sigmas` and `fit_width_bound_kev` parameters; updated docstring to match the actual defaults and document the new parameter.
- **Polynomial calibration fits**: Switched to a robust loss (`soft_l1`) in iminuit least-squares fits.
- **`gauss_mode_width_max` boundary handling** (`binned_fitting.py`): Fixed the fit window clamping to recompute `(i_0, i_n)` together so the window size stays consistent when the peak is near a histogram edge. When the window would exceed the left boundary it shifts right (`i_0=0, i_n=n_bins`); when it would exceed the right boundary it shifts left (`i_n=len(hist), i_0=len(hist)-n_bins`). A `ValueError` is only raised when `n_bins` exceeds the histogram size entirely. Uses `bins[i_n] - bins[i_0]` for `width_guess` to safely handle the `i_n == len(hist)` case.

## Testing

- Updated `test_gauss_mode_width_max_edge_cases` to verify that peaks near histogram edges now produce a valid fit (shifted window) rather than raising `ValueError`.
- Added a test case asserting that `ValueError` is raised only when `n_bins` exceeds the histogram size.
- All existing `tests/math/test_binned_fitting.py` tests pass.