### PR TITLE
add Bayesian-blocks adaptive rebinning to pygama.math

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         os: [ubuntu-latest, macOS-14]
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,8 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "hist",
+    "astropy",
+    "awkward",
     "colorlog",
     "dbetto",
     "dspeed >=2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,8 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "hist",
-    "astropy",
     "awkward",
+    "hepstats",
     "colorlog",
     "dbetto",
     "dspeed >=2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-    "hist",
+    "hist >=2.8.0",
     "awkward",
     "hepstats",
     "colorlog",

--- a/src/pygama/math/rebin.py
+++ b/src/pygama/math/rebin.py
@@ -1,0 +1,180 @@
+"""Bayesian-blocks adaptive rebinning for 1D histograms.
+
+Provides routines for adaptive binning based on the Bayesian-blocks
+algorithm (Scargle et al. 2013), backed by
+:func:`astropy.stats.bayesian_blocks`.
+
+Two entry points are provided:
+
+- :func:`hist_bblocks` histograms an unbinned data array
+  (:class:`numpy.ndarray` or :class:`awkward.Array`) using
+  Bayesian-blocks edges.
+- :func:`rebin_bblocks` rebins a finely-binned :class:`hist.Hist`
+  using the ``measures`` fitness.
+
+Both return a ``Variable``-axis ``Weight``-storage :class:`hist.Hist`.
+"""
+
+from __future__ import annotations
+
+import awkward as ak
+import hist as bh
+import numpy as np
+from astropy.stats import bayesian_blocks
+
+
+def hist_bblocks(
+    data: np.ndarray | ak.Array,
+    *,
+    prebin_width: float | None = None,
+    prebin_low: float | None = None,
+    prebin_high: float | None = None,
+    p0: float = 0.05,
+) -> bh.Hist:
+    """Histogram an unbinned data array using Bayesian-blocks edges.
+
+    By default uses :func:`astropy.stats.bayesian_blocks` with
+    ``fitness='events'`` directly on ``data``. The ``events`` fitness
+    is O(N²) in the number of points, which becomes prohibitive
+    for large samples; passing ``prebin_width`` first bins the data into
+    a uniform fine histogram of that width and then runs
+    :func:`rebin_bblocks` (``measures`` fitness) on it, which is
+    O(Nₙ²) in the number of fine bins.
+
+    Awkward inputs are flattened across all axes before binning.
+
+    Parameters
+    ----------
+    data
+        Array of measurement values.
+    prebin_width
+        Optional pre-binning width. If given, ``data`` is first
+        histogrammed into uniform fine bins of this width and the
+        result is rebinned with :func:`rebin_bblocks`. Choose a
+        ``prebin_width`` much finer than the smallest feature you expect
+        to resolve; otherwise the resolution loss propagates to the
+        output edges.
+    prebin_low, prebin_high
+        Optional lower / upper edge of the pre-binned histogram.
+        Default to ``data.min()`` / ``data.max()``. Values outside
+        ``[prebin_low, prebin_high)`` land in the overflow bins of
+        the fine histogram and are excluded from the output. Only
+        valid when ``prebin_width`` is given. The effective upper
+        edge may exceed ``prebin_high`` by up to ``prebin_width`` so
+        that an integer number of bins covers the requested range.
+    p0
+        False-alarm probability for change-point detection.
+
+    Returns
+    -------
+    h
+        A ``Variable``-axis ``Weight``-storage histogram filled with
+        ``data``.
+    """
+    if isinstance(data, ak.Array):
+        data = np.asarray(ak.ravel(data))
+
+    if prebin_width is not None:
+        if not (np.isfinite(prebin_width) and prebin_width > 0):
+            msg = f"prebin_width must be finite and > 0, got {prebin_width}"
+            raise ValueError(msg)
+        lo = float(np.min(data)) if prebin_low is None else float(prebin_low)
+        hi = float(np.max(data)) if prebin_high is None else float(prebin_high)
+        if hi <= lo:
+            msg = f"prebin_high ({hi}) must be greater than prebin_low ({lo})"
+            raise ValueError(msg)
+        nbins = max(1, int(np.ceil((hi - lo) / prebin_width)))
+        # ensure the requested upper edge falls strictly inside the last bin
+        # (boost_histogram's Regular axis is right-exclusive)
+        if lo + nbins * prebin_width <= hi:
+            nbins += 1
+        fine = bh.Hist(
+            bh.axis.Regular(nbins, lo, lo + nbins * prebin_width),
+            storage=bh.storage.Weight(),
+        )
+        # Filter data to [prebin_low, prebin_high) range when explicitly specified
+        if prebin_low is not None or prebin_high is not None:
+            mask = (data >= lo) & (data < hi)
+            fine.fill(data[mask])
+        else:
+            fine.fill(data)
+        return rebin_bblocks(fine, p0=p0)
+
+    if prebin_low is not None or prebin_high is not None:
+        msg = "prebin_low/prebin_high are only valid when prebin_width is given"
+        raise ValueError(msg)
+
+    edges = bayesian_blocks(data, fitness="events", p0=p0).astype(float)
+    # boost_histogram's Variable axis is right-exclusive; bayesian_blocks
+    # places the last edge at data.max(), so nudge it up by one ULP to
+    # include the rightmost data point in the last bin.
+    edges[-1] = np.nextafter(edges[-1], np.inf)
+    h = bh.Hist(bh.axis.Variable(edges), storage=bh.storage.Weight())
+    h.fill(data)
+    return h
+
+
+def rebin_bblocks(
+    h: bh.Hist,
+    *,
+    p0: float = 0.05,
+) -> bh.Hist:
+    """Rebin a 1D :class:`hist.Hist` using Bayesian-blocks adaptive binning.
+
+    Uses :func:`astropy.stats.bayesian_blocks` with ``fitness='measures'``
+    on the fine-bin centers, snaps the resulting block edges to the
+    fine-bin grid, and aggregates the input histogram onto the new
+    edges by summing counts and variances.
+
+    Parameters
+    ----------
+    h
+        Input finely-binned 1D histogram. If the storage does not
+        track variances, Poisson statistics are assumed.
+    p0
+        False-alarm probability for change-point detection.
+
+    Returns
+    -------
+    out
+        A ``Variable``-axis ``Weight``-storage histogram whose edges
+        are a subset of the input edges.
+    """
+    if len(h.axes) != 1:
+        msg = f"rebin_bblocks only supports 1D histograms, got {len(h.axes)}D"
+        raise ValueError(msg)
+
+    fine_edges = h.axes[0].edges
+    centers = h.axes[0].centers
+    values = h.values()
+    variances = h.variances()
+    if variances is None:
+        variances = values  # Poisson statistics: variance = counts
+
+    sigma = np.sqrt(np.where(variances > 0, variances, 1.0))
+
+    block_edges = bayesian_blocks(
+        centers, x=values, sigma=sigma, fitness="measures", p0=p0
+    )
+
+    # snap block edges to the nearest fine-bin edge
+    right = np.searchsorted(fine_edges, block_edges)
+    left = np.clip(right - 1, 0, len(fine_edges) - 1)
+    right = np.clip(right, 0, len(fine_edges) - 1)
+    left_dist = np.abs(block_edges - fine_edges[left])
+    right_dist = np.abs(block_edges - fine_edges[right])
+    snap_idx = np.where(left_dist <= right_dist, left, right)
+    # endpoints must coincide with the input range
+    snap_idx[0] = 0
+    snap_idx[-1] = len(fine_edges) - 1
+    snap_idx = np.unique(snap_idx)
+
+    new_edges = fine_edges[snap_idx]
+    new_values = np.add.reduceat(values, snap_idx[:-1])
+    new_variances = np.add.reduceat(variances, snap_idx[:-1])
+
+    out = bh.Hist(bh.axis.Variable(new_edges), storage=bh.storage.Weight())
+    view = np.asarray(out.view())
+    view["value"] = new_values
+    view["variance"] = new_variances
+    return out

--- a/src/pygama/math/rebin.py
+++ b/src/pygama/math/rebin.py
@@ -11,6 +11,32 @@ Two adaptive strategies are offered:
 Functions taking a raw data array are named ``hist_*``; those taking a
 finely-binned :class:`hist.Hist` are named ``rebin_*``. All routines
 return a ``Variable``-axis ``Weight``-storage :class:`hist.Hist`.
+
+Public functions
+----------------
+
+- :func:`hist_bblocks`: histogram raw data using Bayesian-blocks edges.
+- :func:`hist_bblocks_with_peaks`: histogram raw data with bblocks edges
+  on the continuum and one merged bin per detected peak.
+- :func:`hist_uniform_with_peaks`: histogram raw data with a uniform
+  continuum binning and one merged bin per detected peak.
+- :func:`rebin_bblocks`: rebin an existing fine histogram onto
+  Bayesian-blocks edges.
+- :func:`rebin_bblocks_with_peaks`: rebin an existing fine histogram
+  onto bblocks edges and merge each detected peak into a single bin.
+- :func:`rebin_uniform_with_peaks`: rebin an existing fine histogram
+  onto a uniform continuum binning and merge each detected peak into
+  a single bin.
+
+Rebinning a histogram with the edges of another
+-----------------------------------------------
+
+To rebin a fine histogram ``h_fine`` onto the edges of another
+histogram ``h_ref``, use :func:`hist.rebin` directly (the edges of
+``h_ref`` must be a subset of those of ``h_fine``):
+
+>>> import hist as bh
+>>> h_out = h_fine[:: bh.rebin(edges=h_ref.axes[0].edges.tolist())]
 """
 
 from __future__ import annotations
@@ -21,22 +47,13 @@ import numpy as np
 from hepstats.modeling import bayesian_blocks
 from scipy import signal
 
-# ---------------------------------------------------------------------------
-# private primitives
-# ---------------------------------------------------------------------------
-
 
 def _prepare_data(
     data: np.ndarray | ak.Array,
     prebin_low: float | None,
     prebin_high: float | None,
 ) -> tuple[np.ndarray, float, float]:
-    """Flatten awkward inputs, derive the data range, and apply the
-    ``[prebin_low, prebin_high)`` mask when a range is requested.
-
-    Returns ``(data, lo, hi)`` with ``lo`` and ``hi`` set to the user-
-    supplied bounds or to ``data.min()``/``data.max()`` as default.
-    """
+    """Flatten awkward inputs and apply the optional range mask."""
     if isinstance(data, ak.Array):
         data = np.asarray(ak.ravel(data))
     if prebin_low is None and prebin_high is None:
@@ -77,16 +94,9 @@ def _walk_peak(
     return i
 
 
-def _bblocks_edges(
-    data: np.ndarray,
-    *,
-    weights: np.ndarray | None = None,
-    p0: float = 0.05,
-) -> np.ndarray:
-    """Bayesian-blocks edges from raw data; last edge nudged by one ULP
-    so :class:`bh.axis.Variable` (right-exclusive) includes ``data.max()``.
-    """
-    edges = bayesian_blocks(data, weights=weights, p0=p0).astype(float)
+def _bblocks_edges(data: np.ndarray, **kwargs) -> np.ndarray:
+    """Bblocks edges; last edge nudged by 1 ULP for right-exclusive axes."""
+    edges = bayesian_blocks(data, **kwargs).astype(float)
     edges[-1] = np.nextafter(edges[-1], np.inf)
     return edges
 
@@ -111,9 +121,10 @@ def _snap_indices(fine_edges: np.ndarray, target_edges: np.ndarray) -> np.ndarra
 
 
 def _bblocks_edges_from_hist(h: bh.Hist, *, p0: float = 0.05) -> np.ndarray:
-    """Bayesian-blocks edges from a finely-binned histogram, snapped to
-    ``h.axes[0].edges``. Empty bins are dropped to avoid the ``log(0)``
-    warning hepstats raises on zero-weight events.
+    """Bayesian-blocks edges from a fine histogram, snapped to its grid.
+
+    Empty bins are dropped to avoid the ``log(0)`` warning hepstats
+    raises on zero-weight events.
     """
     if len(h.axes) != 1:
         msg = f"only 1D histograms supported, got {len(h.axes)}D"
@@ -134,14 +145,16 @@ def _find_peak_regions(
     width_factor: float = 5.0,
     max_bin_width: float | None = None,
 ) -> np.ndarray:
-    """Detect peaks in an adaptive-bin histogram and return the merged
-    region edges in axis units. Shape ``(n_regions, 2)``; empty array
-    if no peaks are detected.
+    """Detect peaks and return ``(n_regions, 2)`` merged region edges.
 
-    Peaks are strict local maxima of the rate (counts/width), filtered
-    by significance ``prominence * w_peak / sqrt(n_peak)`` against
-    ``n_sigma``. Each surviving peak is grown outward via
-    :func:`_walk_peak` and overlapping regions are merged.
+    Edges are in axis units; the array is empty if no peaks pass the
+    significance threshold. Peaks are strict local maxima of the rate
+    (counts/width), filtered by ``prominence * w_peak / sqrt(n_peak)``
+    against ``n_sigma``. When ``max_bin_width`` is given, candidates
+    sitting on a bin wider than the cap are also rejected (line-like
+    features have resolution-bounded widths; wide bins flag Compton
+    edges and smooth-continuum plateaus). Each surviving peak is grown
+    outward via :func:`_walk_peak` and overlapping regions are merged.
     """
     if len(h.axes) != 1:
         msg = f"only 1D histograms supported, got {len(h.axes)}D"
@@ -176,6 +189,8 @@ def _find_peak_regions(
     prominences, _, _ = signal.peak_prominences(rate, peaks)
     significance = prominences * widths[peaks] / np.sqrt(np.maximum(values[peaks], 1.0))
     peaks = peaks[significance >= n_sigma]
+    if max_bin_width is not None:
+        peaks = peaks[widths[peaks] < max_bin_width]
     if len(peaks) == 0:
         return np.empty((0, 2), dtype=float)
 
@@ -207,10 +222,7 @@ def _collapse_peaks(
     width_factor: float = 5.0,
     max_bin_width: float | None = None,
 ) -> bh.Hist:
-    """Merge bins inside each detected peak region into a single bin.
-
-    Output edges are a subset of the input edges.
-    """
+    """Merge bins inside each detected peak region into a single bin."""
     regions = _find_peak_regions(
         h,
         n_sigma=n_sigma,
@@ -237,13 +249,14 @@ def _uniform_edges_with_peaks(
     bin_width: float,
     peak_regions: np.ndarray,
 ) -> np.ndarray:
-    """Uniform grid in ``[low, high]`` with each peak region inserted
-    as a single bin, replacing any uniform edges strictly inside it.
+    """Uniform grid over ``[low, high]`` with peak regions as single bins.
 
-    Assumes ``peak_regions`` is sorted and non-overlapping (the output
-    of :func:`_find_peak_regions` is). Peak regions outside
-    ``[low, high]`` produce out-of-range edges in the result; the
-    caller is responsible for ensuring the range covers them.
+    Any uniform edge strictly inside a peak region, OR within
+    ``bin_width`` of one of its boundaries, is dropped: the peak
+    region's neighboring continuum bins absorb the would-be fragment,
+    making them up to ``2 * bin_width`` wide instead. Uniform edges
+    exactly on a peak boundary are kept. Assumes ``peak_regions`` is
+    sorted and non-overlapping.
     """
     if not (np.isfinite(bin_width) and bin_width > 0):
         msg = f"bin_width must be finite and > 0, got {bin_width}"
@@ -264,13 +277,10 @@ def _uniform_edges_with_peaks(
 
     keep_mask = np.ones(len(uniform), dtype=bool)
     for lo_p, hi_p in peak_regions:
-        keep_mask &= ~((uniform > lo_p) & (uniform < hi_p))
+        in_zone = (uniform > lo_p - bin_width) & (uniform < hi_p + bin_width)
+        is_boundary = (uniform == lo_p) | (uniform == hi_p)
+        keep_mask &= ~(in_zone & ~is_boundary)
     return np.unique(np.concatenate([uniform[keep_mask], peak_regions.flatten()]))
-
-
-# ---------------------------------------------------------------------------
-# public API — raw data → histogram
-# ---------------------------------------------------------------------------
 
 
 def hist_bblocks(
@@ -283,36 +293,39 @@ def hist_bblocks(
 ) -> bh.Hist:
     """Histogram an unbinned data array using Bayesian-blocks edges.
 
-    By default runs :func:`hepstats.modeling.bayesian_blocks` directly
-    on ``data``, which is O(N²) in sample size. Passing
-    ``prebin_width`` first bins ``data`` into a uniform fine histogram
-    and calls :func:`rebin_bblocks` instead, which is the faster path
-    for large samples.
-
-    Awkward inputs are flattened across all axes before binning.
+    For large samples, pass ``prebin_width`` to first bin the data
+    on a uniform fine grid and then call :func:`rebin_bblocks` --
+    this is much faster than running bblocks on the raw data
+    directly. Awkward inputs are flattened before binning.
 
     Parameters
     ----------
     data
-        Array of measurement values.
+        Array of measurement values (numpy or awkward).
     prebin_width
-        Pre-binning width. Must be much finer than the smallest
-        feature to resolve; resolution loss propagates to the output.
+        Width of the uniform pre-binning grid. Should be a few
+        times finer than the narrowest feature you want to
+        resolve (e.g. ~0.5 keV for HPGe lines with ~3 keV FWHM).
     prebin_low, prebin_high
-        Range of the pre-binned histogram. Default to ``data.min()``
-        / ``data.max()``. Data outside ``[prebin_low, prebin_high)``
-        is discarded. Only valid when ``prebin_width`` is given. The
-        effective upper edge may exceed ``prebin_high`` by up to
-        ``prebin_width`` to cover the range with an integer number
-        of bins.
+        Histogram range. Default to ``data.min()`` / ``data.max()``.
+        Data outside the range is discarded. Only valid together
+        with ``prebin_width``. The upper edge may overshoot
+        ``prebin_high`` by up to ``prebin_width`` so the range is
+        covered by an integer number of bins.
     p0
-        False-alarm probability for change-point detection.
+        Bblocks sensitivity: lower values give coarser bins, higher
+        values finer. Typical 0.01-0.1.
 
     Returns
     -------
     h
-        A ``Variable``-axis ``Weight``-storage histogram filled with
-        ``data``.
+        A ``Variable``-axis ``Weight``-storage histogram filled
+        with ``data``.
+
+    Examples
+    --------
+    >>> from pygama.math.rebin import hist_bblocks
+    >>> h = hist_bblocks(energies, prebin_width=0.5, prebin_low=0, prebin_high=3000)
     """
     if prebin_width is None:
         if prebin_low is not None or prebin_high is not None:
@@ -353,12 +366,32 @@ def hist_bblocks_with_peaks(
     width_factor: float = 5.0,
     max_bin_width: float | None = None,
 ) -> bh.Hist:
-    """Histogram raw data with Bayesian-blocks edges, then collapse
-    each detected peak region into a single bin.
+    """Histogram raw data with Bayesian-blocks edges and collapsed peaks.
 
-    Equivalent to applying peak consolidation to the output of
-    :func:`hist_bblocks`. See those two functions for the meaning of
-    each parameter.
+    Equivalent to ``_collapse_peaks(hist_bblocks(data, ...))``.
+
+    Parameters
+    ----------
+    data, prebin_width, prebin_low, prebin_high, p0
+        See :func:`hist_bblocks`.
+    n_sigma, width_factor, max_bin_width
+        See :func:`rebin_bblocks_with_peaks`.
+
+    Returns
+    -------
+    h
+        A ``Variable``-axis ``Weight``-storage histogram.
+
+    Examples
+    --------
+    Starting with a large data array, prebin it for performance and use a
+    maximum peak width of 10.
+
+    >>> from pygama.math.rebin import hist_bblocks_with_peaks
+    >>> data = [...]
+    >>> h = hist_bblocks_with_peaks(
+    ...     data, prebin_width=0.5, prebin_low=0, prebin_high=3000, max_bin_width=10
+    ... )
     """
     bb = hist_bblocks(
         data,
@@ -387,31 +420,42 @@ def hist_uniform_with_peaks(
     width_factor: float = 5.0,
     max_bin_width: float | None = None,
 ) -> bh.Hist:
-    """Histogram raw data with uniform-width continuum bins, with each
-    detected peak collapsed to a single bin.
+    """Histogram raw data with uniform continuum bins and collapsed peaks.
 
     Parameters
     ----------
-    bin_width
-        Uniform continuum bin width. The output spans
-        ``[prebin_low, prebin_high)`` (or ``[data.min(), data.max()]``
-        if not given); bins overlapping any detected peak region are
-        replaced by a single peak-region bin.
-    prebin_width, p0
-        Forwarded to the internal :func:`hist_bblocks` peak-detection
-        pass.
+    data, prebin_width, p0
+        See :func:`hist_bblocks`.
     prebin_low, prebin_high
-        Define both the output range and (after masking ``data`` to
-        ``[prebin_low, prebin_high)``) the input range of the
-        peak-detection pass.
+        See :func:`hist_bblocks`; here they also define the
+        output range.
+    bin_width
+        See :func:`rebin_uniform_with_peaks`.
     n_sigma, width_factor, max_bin_width
-        Forwarded to peak detection; see :func:`_find_peak_regions`.
+        See :func:`rebin_bblocks_with_peaks`.
 
     Returns
     -------
     h
-        A ``Variable``-axis ``Weight``-storage histogram filled with
-        ``data``.
+        A ``Variable``-axis ``Weight``-storage histogram filled
+        with ``data``.
+
+    Examples
+    --------
+    Starting with a large data array, prebin it for performance and use a
+    maximum peak width of 10. In between the peaks use an uniform bin width of
+    2.
+
+    >>> from pygama.math.rebin import hist_uniform_with_peaks
+    >>> data = [...]
+    >>> h = hist_uniform_with_peaks(
+    ...     energies,
+    ...     bin_width=2,
+    ...     prebin_width=0.5,
+    ...     prebin_low=0,
+    ...     prebin_high=3000,
+    ...     max_bin_width=10,
+    ... )
     """
     data, lo, hi = _prepare_data(data, prebin_low, prebin_high)
     bb = hist_bblocks(data, prebin_width=prebin_width, p0=p0)
@@ -431,31 +475,31 @@ def hist_uniform_with_peaks(
     return out
 
 
-# ---------------------------------------------------------------------------
-# public API — fine histogram → coarser histogram
-# ---------------------------------------------------------------------------
-
-
 def rebin_bblocks(h: bh.Hist, *, p0: float = 0.05) -> bh.Hist:
-    """Rebin a 1D :class:`hist.Hist` using Bayesian-blocks adaptive binning.
+    """Rebin a fine 1D histogram using Bayesian-blocks adaptive binning.
 
-    Uses :func:`hepstats.modeling.bayesian_blocks` treating each
-    fine-bin center as a weighted event (weight = bin count), snaps
-    the resulting block edges to the fine-bin grid, and aggregates the
-    input histogram onto the new edges.
+    Each fine bin is treated as a weighted event (weight = bin count);
+    the resulting block edges are snapped to the input grid.
 
     Parameters
     ----------
     h
         Input finely-binned 1D histogram.
     p0
-        False-alarm probability for change-point detection.
+        See :func:`hist_bblocks`.
 
     Returns
     -------
     out
         A ``Variable``-axis ``Weight``-storage histogram whose edges
         are a subset of the input edges.
+
+    Examples
+    --------
+    >>> from pygama.math.rebin import rebin_bblocks
+    >>> import hist
+    >>> h_fine = hist.new.Reg(1000, 0, 1000).Double().fill(...)
+    >>> h_bb = rebin_bblocks(h_fine)
     """
     # _bblocks_edges_from_hist returns edges that are exact members of
     # h.axes[0].edges, so they pass bh.rebin's edge-membership check directly.
@@ -470,11 +514,73 @@ def rebin_bblocks_with_peaks(
     max_bin_width: float | None = None,
     p0: float = 0.05,
 ) -> bh.Hist:
-    """Rebin a 1D :class:`hist.Hist` with Bayesian-blocks adaptive
-    binning, then collapse each detected peak region into a single bin.
+    """Rebin a fine histogram with bblocks edges and collapsed peaks.
 
-    See :func:`rebin_bblocks` and :func:`_find_peak_regions` for the
-    meaning of each parameter.
+    First applies :func:`rebin_bblocks` to get adaptive continuum
+    bins, then merges each detected gamma peak into a single bin.
+
+    Parameters
+    ----------
+    h
+        Input finely-binned 1D histogram.
+    n_sigma
+        How tall a peak must be above its local baseline to be
+        flagged, in units of Poisson noise. Default ``5.0``.
+        Lower values pick up weaker peaks but also more spurious
+        detections.
+    width_factor
+        How far the merge can extend on each side of a peak,
+        relative to the width of the peak's own bblocks bin.
+        The walk stops at the first bin wider than
+        ``width_factor * peak_bin_width``. Default ``5.0``;
+        try ``2.0-3.0`` for tighter merges on HPGe spectra.
+    max_bin_width
+        Maximum allowed width for a peak bin (in axis units).
+        Two effects:
+
+        1. Detection: candidates whose bblocks bin is wider than
+           this are **rejected** -- useful for filtering out
+           Compton edges, continuum plateaus, and other broad
+           features that the peak finder cannot tell apart from
+           real gamma lines based on shape alone (see Notes).
+        2. Walk: the merge walk never extends into a bin wider
+           than this, regardless of ``width_factor``.
+
+        Default ``None`` (no filter). **For HPGe spectra set it
+        to a few times FWHM at the highest energy of interest
+        (5-20 keV is typical)** to suppress non-line features.
+    p0
+        See :func:`hist_bblocks`.
+
+    Returns
+    -------
+    out
+        A ``Variable``-axis ``Weight``-storage histogram whose
+        edges are a subset of the input edges.
+
+    Notes
+    -----
+    The peak finder only looks at local maxima of the rate
+    (counts/width) and how high they stand above their local
+    baseline; it knows nothing about what a real gamma line
+    looks like. It can therefore flag features that aren't
+    line-like:
+
+    * resolution-limited gamma peaks (the intended target);
+    * the upper end of a long Compton-edge ramp;
+    * step transitions;
+    * wide continuum plateaus that bblocks captured in a single
+      wide bin.
+
+    Real HPGe peaks live on narrow bblocks bins (FWHM is a few
+    keV even at multi-MeV energies); the other features end up
+    on much wider bins. ``max_bin_width`` is the simplest filter
+    to reject everything that isn't a real line.
+
+    Examples
+    --------
+    >>> from pygama.math.rebin import rebin_bblocks_with_peaks
+    >>> h_out = rebin_bblocks_with_peaks(h_fine, max_bin_width=10)
     """
     bb = rebin_bblocks(h, p0=p0)
     return _collapse_peaks(
@@ -494,29 +600,39 @@ def rebin_uniform_with_peaks(
     max_bin_width: float | None = None,
     p0: float = 0.05,
 ) -> bh.Hist:
-    """Rebin a 1D :class:`hist.Hist` onto uniform continuum bins, with
-    each detected peak region kept as a single bin.
+    """Rebin a fine histogram onto uniform continuum bins with collapsed peaks.
 
-    Peak detection runs on an internal :func:`rebin_bblocks` pass.
-    Output edges are snapped to ``h.axes[0].edges``, so ``bin_width``
-    need not align exactly with the input grid.
+    Runs an internal :func:`rebin_bblocks` pass to find the peaks,
+    then builds the output: uniform-``bin_width`` continuum bins
+    everywhere except inside detected peak regions, which each
+    become a single bin. Output edges are snapped to
+    ``h.axes[0].edges``, so ``bin_width`` need not align exactly
+    with the input grid.
 
     Parameters
     ----------
     h
         Input finely-binned 1D histogram.
     bin_width
-        Uniform continuum bin width (in axis units).
-    n_sigma, width_factor, max_bin_width
-        Forwarded to peak detection; see :func:`_find_peak_regions`.
-    p0
-        False-alarm probability for the internal bblocks pass.
+        Continuum bin width (in axis units). To avoid tiny
+        fragment bins right next to peaks, the continuum bin
+        bordering each peak absorbs the leftover and can be up
+        to ``2 * bin_width`` wide.
+    n_sigma, width_factor, max_bin_width, p0
+        See :func:`rebin_bblocks_with_peaks`.
 
     Returns
     -------
     out
-        A ``Variable``-axis ``Weight``-storage histogram whose edges
-        are a subset of the input edges.
+        A ``Variable``-axis ``Weight``-storage histogram whose
+        edges are a subset of the input edges.
+
+    Examples
+    --------
+    >>> from pygama.math.rebin import rebin_uniform_with_peaks
+    >>> import hist
+    >>> h_fine = hist.new.Reg(1000, 0, 1000).Double().fill(...)
+    >>> h_out = rebin_uniform_with_peaks(h_fine, bin_width=2, max_bin_width=10)
     """
     bb = rebin_bblocks(h, p0=p0)
     regions = _find_peak_regions(

--- a/src/pygama/math/rebin.py
+++ b/src/pygama/math/rebin.py
@@ -4,7 +4,7 @@ Provides:
 
 - :func:`hist_bblocks` and :func:`rebin_bblocks`: Bayesian-blocks
   adaptive binning (Scargle et al. 2013), backed by
-  :func:`astropy.stats.bayesian_blocks`.
+  :func:`hepstats.modeling.bayesian_blocks`.
 - :func:`collapse_peaks`: merges bins on each side of each detected
   peak by walking outward while the rate is descending and bin widths
   are not yet jumping up to continuum scale. Designed for histograms
@@ -19,7 +19,7 @@ from __future__ import annotations
 import awkward as ak
 import hist as bh
 import numpy as np
-from astropy.stats import bayesian_blocks
+from hepstats.modeling import bayesian_blocks
 from scipy import signal
 
 
@@ -61,11 +61,11 @@ def hist_bblocks(
 ) -> bh.Hist:
     """Histogram an unbinned data array using Bayesian-blocks edges.
 
-    By default runs :func:`astropy.stats.bayesian_blocks` with
-    ``fitness='events'`` directly on ``data``. Since ``events`` is
-    O(N²) in the sample size, passing ``prebin_width`` first bins
-    ``data`` into a uniform fine histogram and runs
-    :func:`rebin_bblocks` (``measures`` fitness) on it instead.
+    By default runs :func:`hepstats.modeling.bayesian_blocks` directly
+    on ``data``, which is O(N²) in sample size. Passing
+    ``prebin_width`` first bins ``data`` into a uniform fine histogram
+    and calls :func:`rebin_bblocks` instead, which is the faster path
+    for large samples.
 
     Awkward inputs are flattened across all axes before binning.
 
@@ -125,7 +125,7 @@ def hist_bblocks(
         msg = "prebin_low/prebin_high are only valid when prebin_width is given"
         raise ValueError(msg)
 
-    edges = bayesian_blocks(data, fitness="events", p0=p0).astype(float)
+    edges = bayesian_blocks(data, p0=p0).astype(float)
     # boost_histogram's Variable axis is right-exclusive; bayesian_blocks
     # places the last edge at data.max(), so nudge it up by one ULP to
     # include the rightmost data point in the last bin.
@@ -142,10 +142,10 @@ def rebin_bblocks(
 ) -> bh.Hist:
     """Rebin a 1D :class:`hist.Hist` using Bayesian-blocks adaptive binning.
 
-    Uses :func:`astropy.stats.bayesian_blocks` with ``fitness='measures'``
-    on the fine-bin centers, snaps the resulting block edges to the
-    fine-bin grid, and aggregates the input histogram onto the new
-    edges by summing counts and variances.
+    Uses :func:`hepstats.modeling.bayesian_blocks` treating each
+    fine-bin center as a weighted event (weight = bin count), snaps
+    the resulting block edges to the fine-bin grid, and aggregates the
+    input histogram onto the new edges by summing counts and variances.
 
     Parameters
     ----------
@@ -172,11 +172,11 @@ def rebin_bblocks(
     if variances is None:
         variances = values  # Poisson statistics: variance = counts
 
-    sigma = np.sqrt(np.where(variances > 0, variances, 1.0))
-
-    block_edges = bayesian_blocks(
-        centers, x=values, sigma=sigma, fitness="measures", p0=p0
-    )
+    # hepstats raises RuntimeWarning on log(0) for empty bins; strip them
+    # before running the algorithm — the snap step below maps block edges
+    # back to fine_edges regardless, so no information is lost.
+    nonzero = values > 0
+    block_edges = bayesian_blocks(centers[nonzero], weights=values[nonzero], p0=p0)
 
     # snap block edges to the nearest fine-bin edge
     right = np.searchsorted(fine_edges, block_edges)

--- a/src/pygama/math/rebin.py
+++ b/src/pygama/math/rebin.py
@@ -1,18 +1,17 @@
-"""Bayesian-blocks adaptive rebinning for 1D histograms.
+"""Adaptive rebinning routines for 1D histograms.
 
-Provides routines for adaptive binning based on the Bayesian-blocks
-algorithm (Scargle et al. 2013), backed by
-:func:`astropy.stats.bayesian_blocks`.
+Provides:
 
-Two entry points are provided:
+- :func:`hist_bblocks` and :func:`rebin_bblocks`: Bayesian-blocks
+  adaptive binning (Scargle et al. 2013), backed by
+  :func:`astropy.stats.bayesian_blocks`.
+- :func:`collapse_peaks`: merges bins on each side of each detected
+  peak by walking outward while the rate is descending and bin widths
+  are not yet jumping up to continuum scale. Designed for histograms
+  with adaptive bin widths (e.g. the output of :func:`rebin_bblocks`).
 
-- :func:`hist_bblocks` histograms an unbinned data array
-  (:class:`numpy.ndarray` or :class:`awkward.Array`) using
-  Bayesian-blocks edges.
-- :func:`rebin_bblocks` rebins a finely-binned :class:`hist.Hist`
-  using the ``measures`` fitness.
-
-Both return a ``Variable``-axis ``Weight``-storage :class:`hist.Hist`.
+All routines return a ``Variable``-axis ``Weight``-storage
+:class:`hist.Hist`.
 """
 
 from __future__ import annotations
@@ -21,6 +20,35 @@ import awkward as ak
 import hist as bh
 import numpy as np
 from astropy.stats import bayesian_blocks
+from scipy import signal
+
+
+def _walk_peak(
+    start: int,
+    step: int,
+    rate: np.ndarray,
+    widths: np.ndarray,
+    width_cap: float,
+    n: int,
+) -> int:
+    """Walk outward from a peak bin and return the farthest index reached.
+
+    Steps in direction ``step`` (-1 or +1), stopping when the rate
+    stops descending, the next bin's width reaches ``width_cap``, or
+    the next bin is a strict local minimum of rate. At the array
+    boundary the missing neighbor is treated as +inf.
+    """
+    i = start
+    while 0 <= i + step <= n - 1:
+        j = i + step
+        if rate[j] >= rate[i] or widths[j] >= width_cap:
+            break
+        next_j = j + step
+        next_rate = rate[next_j] if 0 <= next_j <= n - 1 else np.inf
+        if next_rate >= rate[j]:
+            break
+        i = j
+    return i
 
 
 def hist_bblocks(
@@ -33,13 +61,11 @@ def hist_bblocks(
 ) -> bh.Hist:
     """Histogram an unbinned data array using Bayesian-blocks edges.
 
-    By default uses :func:`astropy.stats.bayesian_blocks` with
-    ``fitness='events'`` directly on ``data``. The ``events`` fitness
-    is O(N²) in the number of points, which becomes prohibitive
-    for large samples; passing ``prebin_width`` first bins the data into
-    a uniform fine histogram of that width and then runs
-    :func:`rebin_bblocks` (``measures`` fitness) on it, which is
-    O(Nₙ²) in the number of fine bins.
+    By default runs :func:`astropy.stats.bayesian_blocks` with
+    ``fitness='events'`` directly on ``data``. Since ``events`` is
+    O(N²) in the sample size, passing ``prebin_width`` first bins
+    ``data`` into a uniform fine histogram and runs
+    :func:`rebin_bblocks` (``measures`` fitness) on it instead.
 
     Awkward inputs are flattened across all axes before binning.
 
@@ -48,20 +74,15 @@ def hist_bblocks(
     data
         Array of measurement values.
     prebin_width
-        Optional pre-binning width. If given, ``data`` is first
-        histogrammed into uniform fine bins of this width and the
-        result is rebinned with :func:`rebin_bblocks`. Choose a
-        ``prebin_width`` much finer than the smallest feature you expect
-        to resolve; otherwise the resolution loss propagates to the
-        output edges.
+        Pre-binning width. Must be much finer than the smallest
+        feature to resolve; resolution loss propagates to the output.
     prebin_low, prebin_high
-        Optional lower / upper edge of the pre-binned histogram.
-        Default to ``data.min()`` / ``data.max()``. Values outside
-        ``[prebin_low, prebin_high)`` land in the overflow bins of
-        the fine histogram and are excluded from the output. Only
-        valid when ``prebin_width`` is given. The effective upper
-        edge may exceed ``prebin_high`` by up to ``prebin_width`` so
-        that an integer number of bins covers the requested range.
+        Range of the pre-binned histogram. Default to ``data.min()``
+        / ``data.max()``. Data outside ``[prebin_low, prebin_high)``
+        is discarded. Only valid when ``prebin_width`` is given. The
+        effective upper edge may exceed ``prebin_high`` by up to
+        ``prebin_width`` to cover the range with an integer number
+        of bins.
     p0
         False-alarm probability for change-point detection.
 
@@ -92,12 +113,12 @@ def hist_bblocks(
             bh.axis.Regular(nbins, lo, lo + nbins * prebin_width),
             storage=bh.storage.Weight(),
         )
-        # Filter data to [prebin_low, prebin_high) range when explicitly specified
+        # mask explicitly to [lo, hi): the regular axis extends slightly past
+        # hi to satisfy the prebin_width constraint, so unmasked data in
+        # [hi, last_edge) would otherwise be silently included.
         if prebin_low is not None or prebin_high is not None:
-            mask = (data >= lo) & (data < hi)
-            fine.fill(data[mask])
-        else:
-            fine.fill(data)
+            data = data[(data >= lo) & (data < hi)]
+        fine.fill(data)
         return rebin_bblocks(fine, p0=p0)
 
     if prebin_low is not None or prebin_high is not None:
@@ -168,6 +189,170 @@ def rebin_bblocks(
     snap_idx[0] = 0
     snap_idx[-1] = len(fine_edges) - 1
     snap_idx = np.unique(snap_idx)
+
+    new_edges = fine_edges[snap_idx]
+    new_values = np.add.reduceat(values, snap_idx[:-1])
+    new_variances = np.add.reduceat(variances, snap_idx[:-1])
+
+    out = bh.Hist(bh.axis.Variable(new_edges), storage=bh.storage.Weight())
+    view = np.asarray(out.view())
+    view["value"] = new_values
+    view["variance"] = new_variances
+    return out
+
+
+def collapse_peaks(
+    h: bh.Hist,
+    *,
+    n_sigma: float = 5.0,
+    width_factor: float = 5.0,
+    max_bin_width: float | None = None,
+) -> bh.Hist:
+    """Merge bins on each side of detected peaks using the peak shape.
+
+    Intended for histograms with adaptive bin widths (e.g. the output
+    of :func:`rebin_bblocks`) and **non-negative bin contents**.
+
+    Peaks are detected as strict local maxima of the rate
+    (counts/width) — the right signal for variable-width histograms,
+    where a real peak may have fewer counts than a wider neighbor but
+    still a higher rate. Candidates are filtered by significance
+    computed from their prominence (see
+    :func:`scipy.signal.peak_prominences`):
+
+        significance = prominence * w_peak / sqrt(n_peak)
+
+    where ``w_peak`` and ``n_peak`` are the width and counts of the
+    peak bin alone (*not* the eventual merged region). The threshold
+    is ``n_sigma``. For peaks that bblocks resolves into several
+    adjacent narrow bins this underestimates the true significance.
+
+    For each surviving peak the walk extends outward on both sides
+    while all of the following hold:
+
+    * the rate is strictly decreasing — still on the descending side
+      of the peak;
+    * the next bin's width is below ``min(width_factor * peak_width,
+      max_bin_width)`` — the walk has not grown beyond the natural
+      scale of the peak;
+    * the next bin is not a strict local minimum of rate — close
+      peaks aren't merged through a shared valley.
+
+    Note that :func:`scipy.signal.find_peaks` never reports the
+    boundary bins (indices 0 or ``n - 1``), so a spike at the first
+    or last bin is silently passed through.
+
+    Parameters
+    ----------
+    h
+        Input 1D histogram with (typically) variable-width bins. Bin
+        contents must be non-negative. Poisson statistics are assumed
+        if the storage does not track variances.
+    n_sigma
+        Significance threshold for peak detection. Must be > 0.
+    width_factor
+        Peak-relative cap on the walk width: the walk stops when a
+        neighboring bin is ``width_factor`` times wider than the peak
+        bin itself. Encodes the resolution-driven width of real peaks.
+        Must be > 1 so the peak bin's immediate neighbors are eligible
+        when no wider than the peak itself.
+    max_bin_width
+        Optional absolute cap (in axis units), applied via
+        ``min(width_factor * peak_width, max_bin_width)``. ``None``
+        disables it.
+
+    Returns
+    -------
+    out
+        A ``Variable``-axis ``Weight``-storage histogram whose edges
+        are a subset of the input edges.
+    """
+    if len(h.axes) != 1:
+        msg = f"collapse_peaks only supports 1D histograms, got {len(h.axes)}D"
+        raise ValueError(msg)
+    if not (np.isfinite(n_sigma) and n_sigma > 0):
+        msg = f"n_sigma must be finite and > 0, got {n_sigma}"
+        raise ValueError(msg)
+    if not (np.isfinite(width_factor) and width_factor > 1):
+        msg = f"width_factor must be finite and > 1, got {width_factor}"
+        raise ValueError(msg)
+    if max_bin_width is not None and not (
+        np.isfinite(max_bin_width) and max_bin_width > 0
+    ):
+        msg = f"max_bin_width must be finite and > 0, got {max_bin_width}"
+        raise ValueError(msg)
+
+    fine_edges = h.axes[0].edges
+    widths = np.diff(fine_edges)
+    if np.any(widths <= 0):
+        msg = "histogram has bins with zero or negative width"
+        raise ValueError(msg)
+    values = h.values()
+    if np.any(values < 0):
+        msg = "collapse_peaks requires non-negative bin contents"
+        raise ValueError(msg)
+    variances = h.variances()
+    if variances is None:
+        variances = values  # Poisson statistics: variance = counts
+
+    # detect peaks as strict local maxima of the rate (counts/width):
+    # the right signal for variable-width histograms, where a real peak
+    # can have fewer counts than a wider neighbor but a higher rate.
+    rate = values / widths
+    peaks, _ = signal.find_peaks(rate)
+
+    if len(peaks) > 0:
+        # significance from scipy's prominence (the rate drop from the
+        # peak down to its lowest surrounding contour that doesn't reach
+        # a higher peak — i.e. the local baseline). For a peak with
+        # rate r_p in a bin of width w_p and a baseline rate r_b, the
+        # excess counts at the peak above what the baseline would
+        # predict is (r_p - r_b) * w_p = prominence_rate * w_p; the
+        # Poisson sigma of the peak counts is sqrt(n_p). Their ratio
+        # is the prominence-based significance.
+        prominences, _, _ = signal.peak_prominences(rate, peaks)
+        excess_counts = prominences * widths[peaks]
+        sigma = np.sqrt(np.maximum(values[peaks], 1.0))
+        significance = excess_counts / sigma
+        peaks = peaks[significance >= n_sigma]
+
+    if len(peaks) == 0:
+        out = bh.Hist(bh.axis.Variable(fine_edges), storage=bh.storage.Weight())
+        view = np.asarray(out.view())
+        view["value"] = values
+        view["variance"] = variances
+        return out
+
+    # walk outward from each peak while rate descends and bin widths stay
+    # within `width_factor` times the peak bin's own width. Additionally
+    # stop before stepping into a local minimum of rate (the valley
+    # between adjacent peaks), so close peaks don't share a tail bin.
+    n = len(values)
+    cap = max_bin_width if max_bin_width is not None else np.inf
+    regions: list[tuple[int, int]] = []
+    for p in peaks:
+        width_cap = min(widths[p] * width_factor, cap)
+        li = _walk_peak(p, -1, rate, widths, width_cap, n)
+        ri = _walk_peak(p, +1, rate, widths, width_cap, n)
+        regions.append((li, ri))
+
+    # resolve overlaps: sweep left-to-right and merge regions that actually
+    # share at least one bin. regions that are merely adjacent (one peak's
+    # walk stopped at bin k and another's started at bin k+1) stay separate
+    # so the boundary edge between them is preserved in the output.
+    regions.sort()
+    merged: list[list[int]] = []
+    for li, ri in regions:
+        if merged and li <= merged[-1][1]:
+            merged[-1][1] = max(merged[-1][1], ri)
+        else:
+            merged.append([li, ri])
+
+    # drop interior edges of each merged region
+    keep = np.ones(len(fine_edges), dtype=bool)
+    for li, ri in merged:
+        keep[li + 1 : ri + 1] = False
+    snap_idx = np.where(keep)[0]
 
     new_edges = fine_edges[snap_idx]
     new_values = np.add.reduceat(values, snap_idx[:-1])

--- a/src/pygama/math/rebin.py
+++ b/src/pygama/math/rebin.py
@@ -1,17 +1,16 @@
 """Adaptive rebinning routines for 1D histograms.
 
-Provides:
+Two adaptive strategies are offered:
 
-- :func:`hist_bblocks` and :func:`rebin_bblocks`: Bayesian-blocks
-  adaptive binning (Scargle et al. 2013), backed by
+- **Bayesian blocks** (Scargle et al. 2013), backed by
   :func:`hepstats.modeling.bayesian_blocks`.
-- :func:`collapse_peaks`: merges bins on each side of each detected
-  peak by walking outward while the rate is descending and bin widths
-  are not yet jumping up to continuum scale. Designed for histograms
-  with adaptive bin widths (e.g. the output of :func:`rebin_bblocks`).
+- **Peak-aware**: peaks are detected and each peak region is collapsed
+  into a single bin. The continuum is either left at bblocks spacing or
+  rebinned to a uniform width.
 
-All routines return a ``Variable``-axis ``Weight``-storage
-:class:`hist.Hist`.
+Functions taking a raw data array are named ``hist_*``; those taking a
+finely-binned :class:`hist.Hist` are named ``rebin_*``. All routines
+return a ``Variable``-axis ``Weight``-storage :class:`hist.Hist`.
 """
 
 from __future__ import annotations
@@ -21,6 +20,33 @@ import hist as bh
 import numpy as np
 from hepstats.modeling import bayesian_blocks
 from scipy import signal
+
+# ---------------------------------------------------------------------------
+# private primitives
+# ---------------------------------------------------------------------------
+
+
+def _prepare_data(
+    data: np.ndarray | ak.Array,
+    prebin_low: float | None,
+    prebin_high: float | None,
+) -> tuple[np.ndarray, float, float]:
+    """Flatten awkward inputs, derive the data range, and apply the
+    ``[prebin_low, prebin_high)`` mask when a range is requested.
+
+    Returns ``(data, lo, hi)`` with ``lo`` and ``hi`` set to the user-
+    supplied bounds or to ``data.min()``/``data.max()`` as default.
+    """
+    if isinstance(data, ak.Array):
+        data = np.asarray(ak.ravel(data))
+    if prebin_low is None and prebin_high is None:
+        return data, float(np.min(data)), float(np.max(data))
+    lo = float(prebin_low) if prebin_low is not None else float(np.min(data))
+    hi = float(prebin_high) if prebin_high is not None else float(np.max(data))
+    if hi <= lo:
+        msg = f"prebin_high ({hi}) must be greater than prebin_low ({lo})"
+        raise ValueError(msg)
+    return data[(data >= lo) & (data < hi)], lo, hi
 
 
 def _walk_peak(
@@ -49,6 +75,202 @@ def _walk_peak(
             break
         i = j
     return i
+
+
+def _bblocks_edges(
+    data: np.ndarray,
+    *,
+    weights: np.ndarray | None = None,
+    p0: float = 0.05,
+) -> np.ndarray:
+    """Bayesian-blocks edges from raw data; last edge nudged by one ULP
+    so :class:`bh.axis.Variable` (right-exclusive) includes ``data.max()``.
+    """
+    edges = bayesian_blocks(data, weights=weights, p0=p0).astype(float)
+    edges[-1] = np.nextafter(edges[-1], np.inf)
+    return edges
+
+
+def _snap_indices(fine_edges: np.ndarray, target_edges: np.ndarray) -> np.ndarray:
+    """Nearest-edge indices into ``fine_edges`` for each ``target_edges``.
+
+    Endpoints are clamped to ``0`` and ``len(fine_edges) - 1`` and
+    duplicates are removed, so the result is a strictly increasing
+    integer array suitable as group boundaries for
+    :func:`hist.rebin`.
+    """
+    right = np.searchsorted(fine_edges, target_edges)
+    left = np.clip(right - 1, 0, len(fine_edges) - 1)
+    right = np.clip(right, 0, len(fine_edges) - 1)
+    left_dist = np.abs(target_edges - fine_edges[left])
+    right_dist = np.abs(target_edges - fine_edges[right])
+    idx = np.where(left_dist <= right_dist, left, right)
+    idx[0] = 0
+    idx[-1] = len(fine_edges) - 1
+    return np.unique(idx)
+
+
+def _bblocks_edges_from_hist(h: bh.Hist, *, p0: float = 0.05) -> np.ndarray:
+    """Bayesian-blocks edges from a finely-binned histogram, snapped to
+    ``h.axes[0].edges``. Empty bins are dropped to avoid the ``log(0)``
+    warning hepstats raises on zero-weight events.
+    """
+    if len(h.axes) != 1:
+        msg = f"only 1D histograms supported, got {len(h.axes)}D"
+        raise ValueError(msg)
+
+    fine_edges = h.axes[0].edges
+    centers = h.axes[0].centers
+    values = h.values()
+    nonzero = values > 0
+    block_edges = bayesian_blocks(centers[nonzero], weights=values[nonzero], p0=p0)
+    return fine_edges[_snap_indices(fine_edges, block_edges)]
+
+
+def _find_peak_regions(
+    h: bh.Hist,
+    *,
+    n_sigma: float = 5.0,
+    width_factor: float = 5.0,
+    max_bin_width: float | None = None,
+) -> np.ndarray:
+    """Detect peaks in an adaptive-bin histogram and return the merged
+    region edges in axis units. Shape ``(n_regions, 2)``; empty array
+    if no peaks are detected.
+
+    Peaks are strict local maxima of the rate (counts/width), filtered
+    by significance ``prominence * w_peak / sqrt(n_peak)`` against
+    ``n_sigma``. Each surviving peak is grown outward via
+    :func:`_walk_peak` and overlapping regions are merged.
+    """
+    if len(h.axes) != 1:
+        msg = f"only 1D histograms supported, got {len(h.axes)}D"
+        raise ValueError(msg)
+    if not (np.isfinite(n_sigma) and n_sigma > 0):
+        msg = f"n_sigma must be finite and > 0, got {n_sigma}"
+        raise ValueError(msg)
+    if not (np.isfinite(width_factor) and width_factor > 1):
+        msg = f"width_factor must be finite and > 1, got {width_factor}"
+        raise ValueError(msg)
+    if max_bin_width is not None and not (
+        np.isfinite(max_bin_width) and max_bin_width > 0
+    ):
+        msg = f"max_bin_width must be finite and > 0, got {max_bin_width}"
+        raise ValueError(msg)
+
+    fine_edges = h.axes[0].edges
+    widths = np.diff(fine_edges)
+    if np.any(widths <= 0):
+        msg = "histogram has bins with zero or negative width"
+        raise ValueError(msg)
+    values = h.values()
+    if np.any(values < 0):
+        msg = "peak detection requires non-negative bin contents"
+        raise ValueError(msg)
+
+    rate = values / widths
+    peaks, _ = signal.find_peaks(rate)
+    if len(peaks) == 0:
+        return np.empty((0, 2), dtype=float)
+
+    prominences, _, _ = signal.peak_prominences(rate, peaks)
+    significance = prominences * widths[peaks] / np.sqrt(np.maximum(values[peaks], 1.0))
+    peaks = peaks[significance >= n_sigma]
+    if len(peaks) == 0:
+        return np.empty((0, 2), dtype=float)
+
+    n = len(values)
+    cap = max_bin_width if max_bin_width is not None else np.inf
+    regions: list[tuple[int, int]] = []
+    for p in peaks:
+        width_cap = min(widths[p] * width_factor, cap)
+        li = _walk_peak(p, -1, rate, widths, width_cap, n)
+        ri = _walk_peak(p, +1, rate, widths, width_cap, n)
+        regions.append((li, ri))
+
+    # merge overlapping regions; adjacent (touching) regions stay separate
+    regions.sort()
+    merged: list[list[int]] = []
+    for li, ri in regions:
+        if merged and li <= merged[-1][1]:
+            merged[-1][1] = max(merged[-1][1], ri)
+        else:
+            merged.append([li, ri])
+
+    return np.array([[fine_edges[li], fine_edges[ri + 1]] for li, ri in merged])
+
+
+def _collapse_peaks(
+    h: bh.Hist,
+    *,
+    n_sigma: float = 5.0,
+    width_factor: float = 5.0,
+    max_bin_width: float | None = None,
+) -> bh.Hist:
+    """Merge bins inside each detected peak region into a single bin.
+
+    Output edges are a subset of the input edges.
+    """
+    regions = _find_peak_regions(
+        h,
+        n_sigma=n_sigma,
+        width_factor=width_factor,
+        max_bin_width=max_bin_width,
+    )
+    fine_edges = h.axes[0].edges
+
+    keep = np.ones(len(fine_edges), dtype=bool)
+    for lo_p, hi_p in regions:
+        li = int(np.searchsorted(fine_edges, lo_p))
+        ri = int(np.searchsorted(fine_edges, hi_p))
+        keep[li + 1 : ri] = False
+    # always route through bh.rebin so the output axis is uniformly Variable,
+    # even when no consolidation happens (a plain copy would preserve a
+    # Regular axis input, violating the module contract).
+    return h[:: bh.rebin(edges=fine_edges[keep].tolist())]
+
+
+def _uniform_edges_with_peaks(
+    low: float,
+    high: float,
+    *,
+    bin_width: float,
+    peak_regions: np.ndarray,
+) -> np.ndarray:
+    """Uniform grid in ``[low, high]`` with each peak region inserted
+    as a single bin, replacing any uniform edges strictly inside it.
+
+    Assumes ``peak_regions`` is sorted and non-overlapping (the output
+    of :func:`_find_peak_regions` is). Peak regions outside
+    ``[low, high]`` produce out-of-range edges in the result; the
+    caller is responsible for ensuring the range covers them.
+    """
+    if not (np.isfinite(bin_width) and bin_width > 0):
+        msg = f"bin_width must be finite and > 0, got {bin_width}"
+        raise ValueError(msg)
+    if high <= low:
+        msg = f"high ({high}) must be greater than low ({low})"
+        raise ValueError(msg)
+
+    n_bins = max(1, int(np.ceil((high - low) / bin_width)))
+    uniform = low + np.arange(n_bins + 1) * bin_width
+    if uniform[-1] > high:
+        uniform[-1] = high
+    elif uniform[-1] < high:
+        uniform = np.append(uniform, high)
+
+    if peak_regions.shape[0] == 0:
+        return uniform
+
+    keep_mask = np.ones(len(uniform), dtype=bool)
+    for lo_p, hi_p in peak_regions:
+        keep_mask &= ~((uniform > lo_p) & (uniform < hi_p))
+    return np.unique(np.concatenate([uniform[keep_mask], peak_regions.flatten()]))
+
+
+# ---------------------------------------------------------------------------
+# public API — raw data → histogram
+# ---------------------------------------------------------------------------
 
 
 def hist_bblocks(
@@ -92,66 +314,140 @@ def hist_bblocks(
         A ``Variable``-axis ``Weight``-storage histogram filled with
         ``data``.
     """
-    if isinstance(data, ak.Array):
-        data = np.asarray(ak.ravel(data))
-
-    if prebin_width is not None:
-        if not (np.isfinite(prebin_width) and prebin_width > 0):
-            msg = f"prebin_width must be finite and > 0, got {prebin_width}"
-            raise ValueError(msg)
-        lo = float(np.min(data)) if prebin_low is None else float(prebin_low)
-        hi = float(np.max(data)) if prebin_high is None else float(prebin_high)
-        if hi <= lo:
-            msg = f"prebin_high ({hi}) must be greater than prebin_low ({lo})"
-            raise ValueError(msg)
-        nbins = max(1, int(np.ceil((hi - lo) / prebin_width)))
-        # ensure the requested upper edge falls strictly inside the last bin
-        # (boost_histogram's Regular axis is right-exclusive)
-        if lo + nbins * prebin_width <= hi:
-            nbins += 1
-        fine = bh.Hist(
-            bh.axis.Regular(nbins, lo, lo + nbins * prebin_width),
-            storage=bh.storage.Weight(),
-        )
-        # mask explicitly to [lo, hi): the regular axis extends slightly past
-        # hi to satisfy the prebin_width constraint, so unmasked data in
-        # [hi, last_edge) would otherwise be silently included.
+    if prebin_width is None:
         if prebin_low is not None or prebin_high is not None:
-            data = data[(data >= lo) & (data < hi)]
-        fine.fill(data)
-        return rebin_bblocks(fine, p0=p0)
+            msg = "prebin_low/prebin_high are only valid when prebin_width is given"
+            raise ValueError(msg)
+        if isinstance(data, ak.Array):
+            data = np.asarray(ak.ravel(data))
+        edges = _bblocks_edges(data, p0=p0)
+        h = bh.Hist(bh.axis.Variable(edges), storage=bh.storage.Weight())
+        h.fill(data)
+        return h
 
-    if prebin_low is not None or prebin_high is not None:
-        msg = "prebin_low/prebin_high are only valid when prebin_width is given"
+    if not (np.isfinite(prebin_width) and prebin_width > 0):
+        msg = f"prebin_width must be finite and > 0, got {prebin_width}"
         raise ValueError(msg)
+    data, lo, hi = _prepare_data(data, prebin_low, prebin_high)
+    # right-exclusive Regular axis: extend by one bin if needed so hi is
+    # strictly inside the last bin
+    nbins = max(1, int(np.ceil((hi - lo) / prebin_width)))
+    if lo + nbins * prebin_width <= hi:
+        nbins += 1
+    fine = bh.Hist(
+        bh.axis.Regular(nbins, lo, lo + nbins * prebin_width),
+        storage=bh.storage.Weight(),
+    )
+    fine.fill(data)
+    return rebin_bblocks(fine, p0=p0)
 
-    edges = bayesian_blocks(data, p0=p0).astype(float)
-    # boost_histogram's Variable axis is right-exclusive; bayesian_blocks
-    # places the last edge at data.max(), so nudge it up by one ULP to
-    # include the rightmost data point in the last bin.
-    edges[-1] = np.nextafter(edges[-1], np.inf)
-    h = bh.Hist(bh.axis.Variable(edges), storage=bh.storage.Weight())
-    h.fill(data)
-    return h
 
-
-def rebin_bblocks(
-    h: bh.Hist,
+def hist_bblocks_with_peaks(
+    data: np.ndarray | ak.Array,
     *,
+    prebin_width: float | None = None,
+    prebin_low: float | None = None,
+    prebin_high: float | None = None,
     p0: float = 0.05,
+    n_sigma: float = 5.0,
+    width_factor: float = 5.0,
+    max_bin_width: float | None = None,
 ) -> bh.Hist:
+    """Histogram raw data with Bayesian-blocks edges, then collapse
+    each detected peak region into a single bin.
+
+    Equivalent to applying peak consolidation to the output of
+    :func:`hist_bblocks`. See those two functions for the meaning of
+    each parameter.
+    """
+    bb = hist_bblocks(
+        data,
+        prebin_width=prebin_width,
+        prebin_low=prebin_low,
+        prebin_high=prebin_high,
+        p0=p0,
+    )
+    return _collapse_peaks(
+        bb,
+        n_sigma=n_sigma,
+        width_factor=width_factor,
+        max_bin_width=max_bin_width,
+    )
+
+
+def hist_uniform_with_peaks(
+    data: np.ndarray | ak.Array,
+    *,
+    bin_width: float,
+    prebin_width: float | None = None,
+    prebin_low: float | None = None,
+    prebin_high: float | None = None,
+    p0: float = 0.05,
+    n_sigma: float = 5.0,
+    width_factor: float = 5.0,
+    max_bin_width: float | None = None,
+) -> bh.Hist:
+    """Histogram raw data with uniform-width continuum bins, with each
+    detected peak collapsed to a single bin.
+
+    Parameters
+    ----------
+    bin_width
+        Uniform continuum bin width. The output spans
+        ``[prebin_low, prebin_high)`` (or ``[data.min(), data.max()]``
+        if not given); bins overlapping any detected peak region are
+        replaced by a single peak-region bin.
+    prebin_width, p0
+        Forwarded to the internal :func:`hist_bblocks` peak-detection
+        pass.
+    prebin_low, prebin_high
+        Define both the output range and (after masking ``data`` to
+        ``[prebin_low, prebin_high)``) the input range of the
+        peak-detection pass.
+    n_sigma, width_factor, max_bin_width
+        Forwarded to peak detection; see :func:`_find_peak_regions`.
+
+    Returns
+    -------
+    h
+        A ``Variable``-axis ``Weight``-storage histogram filled with
+        ``data``.
+    """
+    data, lo, hi = _prepare_data(data, prebin_low, prebin_high)
+    bb = hist_bblocks(data, prebin_width=prebin_width, p0=p0)
+    regions = _find_peak_regions(
+        bb,
+        n_sigma=n_sigma,
+        width_factor=width_factor,
+        max_bin_width=max_bin_width,
+    )
+
+    new_edges = _uniform_edges_with_peaks(
+        lo, hi, bin_width=bin_width, peak_regions=regions
+    ).copy()
+    new_edges[-1] = np.nextafter(new_edges[-1], np.inf)
+    out = bh.Hist(bh.axis.Variable(new_edges), storage=bh.storage.Weight())
+    out.fill(data)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# public API — fine histogram → coarser histogram
+# ---------------------------------------------------------------------------
+
+
+def rebin_bblocks(h: bh.Hist, *, p0: float = 0.05) -> bh.Hist:
     """Rebin a 1D :class:`hist.Hist` using Bayesian-blocks adaptive binning.
 
     Uses :func:`hepstats.modeling.bayesian_blocks` treating each
     fine-bin center as a weighted event (weight = bin count), snaps
     the resulting block edges to the fine-bin grid, and aggregates the
-    input histogram onto the new edges by summing counts and variances.
+    input histogram onto the new edges.
 
     Parameters
     ----------
     h
-        Input finely-binned 1D histogram. If the storage does not
-        track variances, Poisson statistics are assumed.
+        Input finely-binned 1D histogram.
     p0
         False-alarm probability for change-point detection.
 
@@ -161,105 +457,60 @@ def rebin_bblocks(
         A ``Variable``-axis ``Weight``-storage histogram whose edges
         are a subset of the input edges.
     """
-    if len(h.axes) != 1:
-        msg = f"rebin_bblocks only supports 1D histograms, got {len(h.axes)}D"
-        raise ValueError(msg)
-
-    fine_edges = h.axes[0].edges
-    centers = h.axes[0].centers
-    values = h.values()
-    variances = h.variances()
-    if variances is None:
-        variances = values  # Poisson statistics: variance = counts
-
-    # hepstats raises RuntimeWarning on log(0) for empty bins; strip them
-    # before running the algorithm — the snap step below maps block edges
-    # back to fine_edges regardless, so no information is lost.
-    nonzero = values > 0
-    block_edges = bayesian_blocks(centers[nonzero], weights=values[nonzero], p0=p0)
-
-    # snap block edges to the nearest fine-bin edge
-    right = np.searchsorted(fine_edges, block_edges)
-    left = np.clip(right - 1, 0, len(fine_edges) - 1)
-    right = np.clip(right, 0, len(fine_edges) - 1)
-    left_dist = np.abs(block_edges - fine_edges[left])
-    right_dist = np.abs(block_edges - fine_edges[right])
-    snap_idx = np.where(left_dist <= right_dist, left, right)
-    # endpoints must coincide with the input range
-    snap_idx[0] = 0
-    snap_idx[-1] = len(fine_edges) - 1
-    snap_idx = np.unique(snap_idx)
-
-    new_edges = fine_edges[snap_idx]
-    new_values = np.add.reduceat(values, snap_idx[:-1])
-    new_variances = np.add.reduceat(variances, snap_idx[:-1])
-
-    out = bh.Hist(bh.axis.Variable(new_edges), storage=bh.storage.Weight())
-    view = np.asarray(out.view())
-    view["value"] = new_values
-    view["variance"] = new_variances
-    return out
+    # _bblocks_edges_from_hist returns edges that are exact members of
+    # h.axes[0].edges, so they pass bh.rebin's edge-membership check directly.
+    return h[:: bh.rebin(edges=_bblocks_edges_from_hist(h, p0=p0).tolist())]
 
 
-def collapse_peaks(
+def rebin_bblocks_with_peaks(
     h: bh.Hist,
     *,
     n_sigma: float = 5.0,
     width_factor: float = 5.0,
     max_bin_width: float | None = None,
+    p0: float = 0.05,
 ) -> bh.Hist:
-    """Merge bins on each side of detected peaks using the peak shape.
+    """Rebin a 1D :class:`hist.Hist` with Bayesian-blocks adaptive
+    binning, then collapse each detected peak region into a single bin.
 
-    Intended for histograms with adaptive bin widths (e.g. the output
-    of :func:`rebin_bblocks`) and **non-negative bin contents**.
+    See :func:`rebin_bblocks` and :func:`_find_peak_regions` for the
+    meaning of each parameter.
+    """
+    bb = rebin_bblocks(h, p0=p0)
+    return _collapse_peaks(
+        bb,
+        n_sigma=n_sigma,
+        width_factor=width_factor,
+        max_bin_width=max_bin_width,
+    )
 
-    Peaks are detected as strict local maxima of the rate
-    (counts/width) — the right signal for variable-width histograms,
-    where a real peak may have fewer counts than a wider neighbor but
-    still a higher rate. Candidates are filtered by significance
-    computed from their prominence (see
-    :func:`scipy.signal.peak_prominences`):
 
-        significance = prominence * w_peak / sqrt(n_peak)
+def rebin_uniform_with_peaks(
+    h: bh.Hist,
+    *,
+    bin_width: float,
+    n_sigma: float = 5.0,
+    width_factor: float = 5.0,
+    max_bin_width: float | None = None,
+    p0: float = 0.05,
+) -> bh.Hist:
+    """Rebin a 1D :class:`hist.Hist` onto uniform continuum bins, with
+    each detected peak region kept as a single bin.
 
-    where ``w_peak`` and ``n_peak`` are the width and counts of the
-    peak bin alone (*not* the eventual merged region). The threshold
-    is ``n_sigma``. For peaks that bblocks resolves into several
-    adjacent narrow bins this underestimates the true significance.
-
-    For each surviving peak the walk extends outward on both sides
-    while all of the following hold:
-
-    * the rate is strictly decreasing — still on the descending side
-      of the peak;
-    * the next bin's width is below ``min(width_factor * peak_width,
-      max_bin_width)`` — the walk has not grown beyond the natural
-      scale of the peak;
-    * the next bin is not a strict local minimum of rate — close
-      peaks aren't merged through a shared valley.
-
-    Note that :func:`scipy.signal.find_peaks` never reports the
-    boundary bins (indices 0 or ``n - 1``), so a spike at the first
-    or last bin is silently passed through.
+    Peak detection runs on an internal :func:`rebin_bblocks` pass.
+    Output edges are snapped to ``h.axes[0].edges``, so ``bin_width``
+    need not align exactly with the input grid.
 
     Parameters
     ----------
     h
-        Input 1D histogram with (typically) variable-width bins. Bin
-        contents must be non-negative. Poisson statistics are assumed
-        if the storage does not track variances.
-    n_sigma
-        Significance threshold for peak detection. Must be > 0.
-    width_factor
-        Peak-relative cap on the walk width: the walk stops when a
-        neighboring bin is ``width_factor`` times wider than the peak
-        bin itself. Encodes the resolution-driven width of real peaks.
-        Must be > 1 so the peak bin's immediate neighbors are eligible
-        when no wider than the peak itself.
-    max_bin_width
-        Optional absolute cap (in axis units), applied via
-        ``min(width_factor * peak_width, max_bin_width)``. ``None``
-        disables it.
+        Input finely-binned 1D histogram.
+    bin_width
+        Uniform continuum bin width (in axis units).
+    n_sigma, width_factor, max_bin_width
+        Forwarded to peak detection; see :func:`_find_peak_regions`.
+    p0
+        False-alarm probability for the internal bblocks pass.
 
     Returns
     -------
@@ -267,99 +518,19 @@ def collapse_peaks(
         A ``Variable``-axis ``Weight``-storage histogram whose edges
         are a subset of the input edges.
     """
-    if len(h.axes) != 1:
-        msg = f"collapse_peaks only supports 1D histograms, got {len(h.axes)}D"
-        raise ValueError(msg)
-    if not (np.isfinite(n_sigma) and n_sigma > 0):
-        msg = f"n_sigma must be finite and > 0, got {n_sigma}"
-        raise ValueError(msg)
-    if not (np.isfinite(width_factor) and width_factor > 1):
-        msg = f"width_factor must be finite and > 1, got {width_factor}"
-        raise ValueError(msg)
-    if max_bin_width is not None and not (
-        np.isfinite(max_bin_width) and max_bin_width > 0
-    ):
-        msg = f"max_bin_width must be finite and > 0, got {max_bin_width}"
-        raise ValueError(msg)
-
+    bb = rebin_bblocks(h, p0=p0)
+    regions = _find_peak_regions(
+        bb,
+        n_sigma=n_sigma,
+        width_factor=width_factor,
+        max_bin_width=max_bin_width,
+    )
     fine_edges = h.axes[0].edges
-    widths = np.diff(fine_edges)
-    if np.any(widths <= 0):
-        msg = "histogram has bins with zero or negative width"
-        raise ValueError(msg)
-    values = h.values()
-    if np.any(values < 0):
-        msg = "collapse_peaks requires non-negative bin contents"
-        raise ValueError(msg)
-    variances = h.variances()
-    if variances is None:
-        variances = values  # Poisson statistics: variance = counts
-
-    # detect peaks as strict local maxima of the rate (counts/width):
-    # the right signal for variable-width histograms, where a real peak
-    # can have fewer counts than a wider neighbor but a higher rate.
-    rate = values / widths
-    peaks, _ = signal.find_peaks(rate)
-
-    if len(peaks) > 0:
-        # significance from scipy's prominence (the rate drop from the
-        # peak down to its lowest surrounding contour that doesn't reach
-        # a higher peak — i.e. the local baseline). For a peak with
-        # rate r_p in a bin of width w_p and a baseline rate r_b, the
-        # excess counts at the peak above what the baseline would
-        # predict is (r_p - r_b) * w_p = prominence_rate * w_p; the
-        # Poisson sigma of the peak counts is sqrt(n_p). Their ratio
-        # is the prominence-based significance.
-        prominences, _, _ = signal.peak_prominences(rate, peaks)
-        excess_counts = prominences * widths[peaks]
-        sigma = np.sqrt(np.maximum(values[peaks], 1.0))
-        significance = excess_counts / sigma
-        peaks = peaks[significance >= n_sigma]
-
-    if len(peaks) == 0:
-        out = bh.Hist(bh.axis.Variable(fine_edges), storage=bh.storage.Weight())
-        view = np.asarray(out.view())
-        view["value"] = values
-        view["variance"] = variances
-        return out
-
-    # walk outward from each peak while rate descends and bin widths stay
-    # within `width_factor` times the peak bin's own width. Additionally
-    # stop before stepping into a local minimum of rate (the valley
-    # between adjacent peaks), so close peaks don't share a tail bin.
-    n = len(values)
-    cap = max_bin_width if max_bin_width is not None else np.inf
-    regions: list[tuple[int, int]] = []
-    for p in peaks:
-        width_cap = min(widths[p] * width_factor, cap)
-        li = _walk_peak(p, -1, rate, widths, width_cap, n)
-        ri = _walk_peak(p, +1, rate, widths, width_cap, n)
-        regions.append((li, ri))
-
-    # resolve overlaps: sweep left-to-right and merge regions that actually
-    # share at least one bin. regions that are merely adjacent (one peak's
-    # walk stopped at bin k and another's started at bin k+1) stay separate
-    # so the boundary edge between them is preserved in the output.
-    regions.sort()
-    merged: list[list[int]] = []
-    for li, ri in regions:
-        if merged and li <= merged[-1][1]:
-            merged[-1][1] = max(merged[-1][1], ri)
-        else:
-            merged.append([li, ri])
-
-    # drop interior edges of each merged region
-    keep = np.ones(len(fine_edges), dtype=bool)
-    for li, ri in merged:
-        keep[li + 1 : ri + 1] = False
-    snap_idx = np.where(keep)[0]
-
-    new_edges = fine_edges[snap_idx]
-    new_values = np.add.reduceat(values, snap_idx[:-1])
-    new_variances = np.add.reduceat(variances, snap_idx[:-1])
-
-    out = bh.Hist(bh.axis.Variable(new_edges), storage=bh.storage.Weight())
-    view = np.asarray(out.view())
-    view["value"] = new_values
-    view["variance"] = new_variances
-    return out
+    target_edges = _uniform_edges_with_peaks(
+        float(fine_edges[0]),
+        float(fine_edges[-1]),
+        bin_width=bin_width,
+        peak_regions=regions,
+    )
+    snap_idx = _snap_indices(fine_edges, target_edges)
+    return h[:: bh.rebin(edges=fine_edges[snap_idx].tolist())]

--- a/tests/math/test_rebin.py
+++ b/tests/math/test_rebin.py
@@ -365,6 +365,30 @@ def test_collapse_peaks_max_bin_width_caps_wide_peak_walk():
     assert int(np.sum(np.isclose(widths_tight, 50.0))) == 2
 
 
+def test_find_peak_regions_max_bin_width_rejects_wide_peak_bins():
+    # a Compton-edge-like feature: a wide plateau bin (highest rate) sandwiched
+    # between lower-rate continuum on one side and a steep drop on the other.
+    # The plateau bin is a rate local maximum but is not a line-like peak.
+    h = _hist_from_widths_rates(
+        [
+            (50.0, 1000.0),  # left continuum (lower rate)
+            (30.0, 2700.0),  # wide plateau — rate local max, NOT a real line
+            (3.0, 2500.0),  # sharp drop
+            (8.0, 2200.0),
+            (12.0, 2060.0),
+            (50.0, 30.0),  # far continuum
+        ]
+    )
+    # without max_bin_width: the 30-keV plateau is flagged as a "peak"
+    regions_loose = _find_peak_regions(h, n_sigma=5.0, width_factor=2.0)
+    assert len(regions_loose) >= 1
+    # with max_bin_width=15: the wide-bin "peak" is rejected
+    regions_tight = _find_peak_regions(
+        h, n_sigma=5.0, width_factor=2.0, max_bin_width=15.0
+    )
+    assert len(regions_tight) == 0
+
+
 def test_collapse_peaks_handles_low_stats_peak_on_wider_bin():
     # peak sits on a 3 keV bin (low-stats peak); neighbors are also moderately
     # wide. width_factor only kicks in at the boundary to wide continuum.
@@ -556,18 +580,47 @@ def test_uniform_edges_with_peaks_no_peaks_returns_uniform():
     assert np.allclose(edges, np.arange(11.0))
 
 
-def test_uniform_edges_with_peaks_inserts_peaks_and_drops_interior_uniform():
-    # peak region [3.2, 4.7] should drop uniform edge 4 and insert 3.2, 4.7
+def test_uniform_edges_with_peaks_inserts_peaks_and_absorbs_fragments():
+    # peak region [3.2, 4.7] with bin_width=1: the interior uniform edge
+    # (4) AND the fragment-creating edges within bin_width of either
+    # peak boundary (3 and 5) are dropped, so the neighboring continuum
+    # bins absorb the would-be fragments.
     regions = np.array([[3.2, 4.7]])
     edges = _uniform_edges_with_peaks(0.0, 10.0, bin_width=1.0, peak_regions=regions)
-    # 4 was strictly inside the peak region, so it must be gone
-    assert 4.0 not in edges
+    # interior + fragment-creating uniform edges must be gone
+    for x in [3.0, 4.0, 5.0]:
+        assert x not in edges
     # peak boundaries must be present
     assert 3.2 in edges
     assert 4.7 in edges
-    # uniform edges outside the peak region must survive
-    for x in [0.0, 1.0, 2.0, 3.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]:
+    # uniform edges well outside the peak region must survive
+    for x in [0.0, 1.0, 2.0, 6.0, 7.0, 8.0, 9.0, 10.0]:
         assert x in edges
+    # the neighbors of the peak region are now wider than bin_width
+    widths = np.diff(edges)
+    # left neighbor [2.0, 3.2] = 1.2, right neighbor [4.7, 6.0] = 1.3
+    assert any(np.isclose(widths, 1.2))
+    assert any(np.isclose(widths, 1.3))
+
+
+def test_uniform_edges_with_peaks_keeps_uniform_edge_on_peak_boundary():
+    # peak edge coincides with a uniform edge → no fragment, no absorption
+    regions = np.array([[3.0, 4.7]])
+    edges = _uniform_edges_with_peaks(0.0, 10.0, bin_width=1.0, peak_regions=regions)
+    # 3.0 is both a uniform edge and the peak's lo edge — must be present
+    assert 3.0 in edges
+    # the left-neighbor continuum bin should be exactly bin_width
+    # ([2.0, 3.0]) since there is no fragment to absorb
+    widths = np.diff(edges)
+    # interior of peak: no uniform edge between 3.0 and 4.7 to drop (4 is
+    # interior); right side: 5 is in absorption zone → dropped
+    assert 4.0 not in edges
+    assert 5.0 not in edges
+    # left side is preserved exactly
+    for x in [0.0, 1.0, 2.0, 3.0]:
+        assert x in edges
+    # the [2.0, 3.0] continuum bin is intact (no absorption)
+    assert any(np.isclose(widths, 1.0))
 
 
 def test_uniform_edges_with_peaks_bin_width_larger_than_range_keeps_two_edges():

--- a/tests/math/test_rebin.py
+++ b/tests/math/test_rebin.py
@@ -5,7 +5,17 @@ import hist as bh
 import numpy as np
 import pytest
 
-from pygama.math.rebin import collapse_peaks, hist_bblocks, rebin_bblocks
+from pygama.math.rebin import (
+    _collapse_peaks,
+    _find_peak_regions,
+    _uniform_edges_with_peaks,
+    hist_bblocks,
+    hist_bblocks_with_peaks,
+    hist_uniform_with_peaks,
+    rebin_bblocks,
+    rebin_bblocks_with_peaks,
+    rebin_uniform_with_peaks,
+)
 
 
 def _two_population_data(seed: int = 42) -> np.ndarray:
@@ -197,7 +207,7 @@ def test_collapse_peaks_merges_descending_peak_and_stops_at_width_jump():
             (10.0, 100.0),  # right continuum
         ]
     )
-    out = collapse_peaks(h, n_sigma=5.0, width_factor=5.0)
+    out = _collapse_peaks(h, n_sigma=5.0, width_factor=5.0)
 
     # 3 output bins: left continuum, merged peak, right continuum
     new_edges = out.axes[0].edges
@@ -227,7 +237,7 @@ def test_collapse_peaks_walk_stops_at_rate_local_minimum():
             (5.0, 100.0),  # right continuum
         ]
     )
-    out = collapse_peaks(h, n_sigma=5.0, width_factor=5.0)
+    out = _collapse_peaks(h, n_sigma=5.0, width_factor=5.0)
 
     new_edges = out.axes[0].edges
     new_widths = np.diff(new_edges)
@@ -262,7 +272,7 @@ def test_collapse_peaks_walk_stops_at_width_jump_even_if_rate_descends():
             # rate-descent would walk INTO it
         ]
     )
-    out = collapse_peaks(h, n_sigma=5.0, width_factor=5.0)
+    out = _collapse_peaks(h, n_sigma=5.0, width_factor=5.0)
     out_edges = out.axes[0].edges
     out_widths = np.diff(out_edges)
     # the wide continuum bins must remain in the output as 10 keV bins
@@ -287,7 +297,7 @@ def test_collapse_peaks_preserves_counts_and_variances():
             (5.0, 100.0),
         ]
     )
-    out = collapse_peaks(h, n_sigma=5.0)
+    out = _collapse_peaks(h, n_sigma=5.0)
 
     h_var = h.variances()
     out_var = out.variances()
@@ -307,7 +317,7 @@ def test_collapse_peaks_edges_subset_of_input():
             (10.0, 100.0),
         ]
     )
-    out = collapse_peaks(h)
+    out = _collapse_peaks(h)
     fine_edges = h.axes[0].edges
     new_edges = out.axes[0].edges
     assert np.all(np.isin(new_edges, fine_edges))
@@ -318,7 +328,7 @@ def test_collapse_peaks_edges_subset_of_input():
 def test_collapse_peaks_no_peaks_returns_unchanged():
     # flat rate everywhere — no rate-local-maxima, no peaks detected.
     h = _hist_from_widths_rates([(1.0, 100.0)] * 10)
-    out = collapse_peaks(h, n_sigma=5.0)
+    out = _collapse_peaks(h, n_sigma=5.0)
     assert np.array_equal(out.axes[0].edges, h.axes[0].edges)
     assert np.array_equal(out.values(), h.values())
 
@@ -343,12 +353,12 @@ def test_collapse_peaks_max_bin_width_caps_wide_peak_walk():
     )
 
     # without absolute cap: the walk drags in the 8.5-keV bin
-    out_loose = collapse_peaks(h, n_sigma=2.0, width_factor=3.0)
+    out_loose = _collapse_peaks(h, n_sigma=2.0, width_factor=3.0)
     widths_loose = np.diff(out_loose.axes[0].edges)
     assert widths_loose.max() > 10.0  # merged region grew through the 8.5 bin
 
     # with absolute cap of 5 keV: walk stops before the 8.5-keV bin
-    out_tight = collapse_peaks(h, n_sigma=2.0, width_factor=3.0, max_bin_width=5.0)
+    out_tight = _collapse_peaks(h, n_sigma=2.0, width_factor=3.0, max_bin_width=5.0)
     widths_tight = np.diff(out_tight.axes[0].edges)
     # the wide bins remain at their original sizes (8.5 and 50)
     assert int(np.sum(np.isclose(widths_tight, 8.5))) == 1
@@ -367,7 +377,7 @@ def test_collapse_peaks_handles_low_stats_peak_on_wider_bin():
             (50.0, 30.0),  # far-right continuum
         ]
     )
-    out = collapse_peaks(h, n_sigma=5.0, width_factor=5.0)
+    out = _collapse_peaks(h, n_sigma=5.0, width_factor=5.0)
     new_edges = out.axes[0].edges
     new_widths = np.diff(new_edges)
     # all three 3-keV bins should be merged into one 9-keV bin
@@ -388,7 +398,7 @@ def test_collapse_peaks_with_rebin_bblocks_end_to_end():
     fine.fill(data)
 
     bb = rebin_bblocks(fine)
-    out = collapse_peaks(bb, n_sigma=5.0)
+    out = _collapse_peaks(bb, n_sigma=5.0)
 
     assert out.values().sum() == pytest.approx(bb.values().sum())
     assert out.values().size <= bb.values().size
@@ -414,7 +424,7 @@ def test_collapse_peaks_rejects_tail_false_positives_from_width_variation():
     counts = widths_arr * rates
     h = _hist_from_arrays(edges, counts)
 
-    out = collapse_peaks(h, n_sigma=2.0)
+    out = _collapse_peaks(h, n_sigma=2.0)
     assert np.array_equal(out.axes[0].edges, edges)
     assert np.array_equal(out.values(), counts)
 
@@ -423,7 +433,7 @@ def test_collapse_peaks_single_bin_histogram():
     # one-bin histogram: no local maxima possible, output equals input
     edges = np.array([0.0, 1.0])
     h = _hist_from_arrays(edges, np.array([42.0]))
-    out = collapse_peaks(h)
+    out = _collapse_peaks(h)
     assert np.array_equal(out.axes[0].edges, edges)
     assert np.array_equal(out.values(), h.values())
 
@@ -432,7 +442,7 @@ def test_collapse_peaks_all_zero_histogram():
     # all-zero histogram: rate is all zeros, no peaks, output unchanged
     edges = np.linspace(0.0, 10.0, 11)
     h = _hist_from_arrays(edges, np.zeros(10))
-    out = collapse_peaks(h)
+    out = _collapse_peaks(h)
     assert np.array_equal(out.axes[0].edges, edges)
     assert np.array_equal(out.values(), h.values())
 
@@ -444,7 +454,7 @@ def test_collapse_peaks_spike_at_boundary_is_passed_through():
     edges = np.linspace(0.0, 10.0, 11)
     values = np.array([100.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0])
     h = _hist_from_arrays(edges, values)
-    out = collapse_peaks(h, n_sigma=5.0)
+    out = _collapse_peaks(h, n_sigma=5.0)
     # output is unchanged (no peak detected)
     assert np.array_equal(out.axes[0].edges, edges)
     assert np.array_equal(out.values(), values)
@@ -456,7 +466,7 @@ def test_collapse_peaks_rejects_negative_counts():
     view = np.asarray(h.view())
     view["value"] = [1.0, 2.0, 3.0, 4.0, 5.0, -1.0, 5.0, 4.0, 3.0, 2.0]
     with pytest.raises(ValueError, match="non-negative"):
-        collapse_peaks(h)
+        _collapse_peaks(h)
 
 
 def test_collapse_peaks_adjacent_regions_not_merged():
@@ -472,7 +482,7 @@ def test_collapse_peaks_adjacent_regions_not_merged():
             (5.0, 100.0),  # right continuum
         ]
     )
-    out = collapse_peaks(h, n_sigma=5.0, width_factor=5.0)
+    out = _collapse_peaks(h, n_sigma=5.0, width_factor=5.0)
     # output: 5 bins (left cont, peak1, valley, peak2, right cont) —
     # the two peaks must NOT merge even though their walks could end
     # at adjacent indices
@@ -484,17 +494,17 @@ def test_collapse_peaks_input_validation():
     h = bh.Hist(bh.axis.Variable(edges), storage=bh.storage.Weight())
 
     with pytest.raises(ValueError, match="n_sigma"):
-        collapse_peaks(h, n_sigma=0.0)
+        _collapse_peaks(h, n_sigma=0.0)
     with pytest.raises(ValueError, match="n_sigma"):
-        collapse_peaks(h, n_sigma=-1.0)
+        _collapse_peaks(h, n_sigma=-1.0)
     with pytest.raises(ValueError, match="width_factor"):
-        collapse_peaks(h, width_factor=1.0)
+        _collapse_peaks(h, width_factor=1.0)
     with pytest.raises(ValueError, match="width_factor"):
-        collapse_peaks(h, width_factor=0.5)
+        _collapse_peaks(h, width_factor=0.5)
     with pytest.raises(ValueError, match="max_bin_width"):
-        collapse_peaks(h, max_bin_width=0.0)
+        _collapse_peaks(h, max_bin_width=0.0)
     with pytest.raises(ValueError, match="max_bin_width"):
-        collapse_peaks(h, max_bin_width=-1.0)
+        _collapse_peaks(h, max_bin_width=-1.0)
 
     h2 = bh.Hist(
         bh.axis.Regular(10, 0.0, 1.0),
@@ -502,4 +512,288 @@ def test_collapse_peaks_input_validation():
         storage=bh.storage.Weight(),
     )
     with pytest.raises(ValueError, match="1D"):
-        collapse_peaks(h2)
+        _collapse_peaks(h2)
+
+
+# ---------------------------------------------------------------------------
+# _find_peak_regions
+# ---------------------------------------------------------------------------
+
+
+def test_find_peak_regions_no_peaks_returns_empty():
+    h = _hist_from_widths_rates([(1.0, 100.0)] * 10)
+    regions = _find_peak_regions(h, n_sigma=5.0)
+    assert regions.shape == (0, 2)
+
+
+def test_find_peak_regions_returns_edges_in_axis_units():
+    h = _hist_from_widths_rates(
+        [
+            (10.0, 100.0),
+            (0.5, 1000.0),
+            (0.5, 50000.0),
+            (0.5, 1000.0),
+            (10.0, 100.0),
+        ]
+    )
+    regions = _find_peak_regions(h, n_sigma=5.0, width_factor=5.0)
+    assert regions.shape == (1, 2)
+    # the merged peak should span the three narrow bins (indices 1-3)
+    in_edges = h.axes[0].edges
+    assert np.isclose(regions[0, 0], in_edges[1])
+    assert np.isclose(regions[0, 1], in_edges[4])
+
+
+# ---------------------------------------------------------------------------
+# _uniform_edges_with_peaks
+# ---------------------------------------------------------------------------
+
+
+def test_uniform_edges_with_peaks_no_peaks_returns_uniform():
+    edges = _uniform_edges_with_peaks(
+        0.0, 10.0, bin_width=1.0, peak_regions=np.empty((0, 2))
+    )
+    assert np.allclose(edges, np.arange(11.0))
+
+
+def test_uniform_edges_with_peaks_inserts_peaks_and_drops_interior_uniform():
+    # peak region [3.2, 4.7] should drop uniform edge 4 and insert 3.2, 4.7
+    regions = np.array([[3.2, 4.7]])
+    edges = _uniform_edges_with_peaks(0.0, 10.0, bin_width=1.0, peak_regions=regions)
+    # 4 was strictly inside the peak region, so it must be gone
+    assert 4.0 not in edges
+    # peak boundaries must be present
+    assert 3.2 in edges
+    assert 4.7 in edges
+    # uniform edges outside the peak region must survive
+    for x in [0.0, 1.0, 2.0, 3.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]:
+        assert x in edges
+
+
+def test_uniform_edges_with_peaks_bin_width_larger_than_range_keeps_two_edges():
+    edges = _uniform_edges_with_peaks(
+        0.0, 1.0, bin_width=10.0, peak_regions=np.empty((0, 2))
+    )
+    assert edges[0] == 0.0
+    assert edges[-1] == 1.0
+
+
+def test_uniform_edges_with_peaks_validation():
+    with pytest.raises(ValueError, match="bin_width"):
+        _uniform_edges_with_peaks(
+            0.0, 1.0, bin_width=0.0, peak_regions=np.empty((0, 2))
+        )
+    with pytest.raises(ValueError, match="bin_width"):
+        _uniform_edges_with_peaks(
+            0.0, 1.0, bin_width=-1.0, peak_regions=np.empty((0, 2))
+        )
+    with pytest.raises(ValueError, match="greater than"):
+        _uniform_edges_with_peaks(
+            1.0, 0.0, bin_width=0.1, peak_regions=np.empty((0, 2))
+        )
+
+
+# ---------------------------------------------------------------------------
+# hist_bblocks_with_peaks / rebin_bblocks_with_peaks
+# ---------------------------------------------------------------------------
+
+
+def _peaked_data(seed: int = 42) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    return np.concatenate(
+        [
+            rng.uniform(0.0, 100.0, 20_000),
+            rng.normal(50.0, 0.3, 10_000),
+        ]
+    )
+
+
+def test_hist_bblocks_with_peaks_preserves_total_counts():
+    data = _peaked_data()
+    out = hist_bblocks_with_peaks(data, prebin_width=0.05, n_sigma=5.0)
+    assert out.values().sum() == pytest.approx(len(data))
+
+
+def test_hist_bblocks_with_peaks_consolidates_peak_region():
+    # the function should produce a merged bin around the true peak at 50
+    data = _peaked_data()
+    out = hist_bblocks_with_peaks(data, prebin_width=0.05, n_sigma=5.0)
+    edges = out.axes[0].edges
+    widths = np.diff(edges)
+    # at least one wide bin should contain the peak center
+    for i, w in enumerate(widths):
+        center = (edges[i] + edges[i + 1]) / 2
+        if w > 0.5 and 45.0 < center < 55.0:
+            return  # success
+    pytest.fail("no merged region found around the true peak at 50")
+
+
+def test_rebin_bblocks_with_peaks_equals_collapse_after_rebin():
+    data = _peaked_data()
+    fine = bh.Hist(bh.axis.Regular(2000, 0.0, 100.0), storage=bh.storage.Weight())
+    fine.fill(data)
+
+    expected = _collapse_peaks(rebin_bblocks(fine, p0=0.05), n_sigma=5.0)
+    actual = rebin_bblocks_with_peaks(fine, n_sigma=5.0, p0=0.05)
+
+    assert np.allclose(expected.axes[0].edges, actual.axes[0].edges)
+    assert np.allclose(expected.values(), actual.values())
+
+
+# ---------------------------------------------------------------------------
+# hist_uniform_with_peaks / rebin_uniform_with_peaks
+# ---------------------------------------------------------------------------
+
+
+def test_hist_uniform_with_peaks_continuum_is_bin_width():
+    data = _peaked_data()
+    out = hist_uniform_with_peaks(data, bin_width=1.0, prebin_width=0.05, n_sigma=5.0)
+    edges = out.axes[0].edges
+    widths = np.diff(edges)
+    # most bins should be exactly bin_width wide (continuum); only peak
+    # regions are wider/narrower
+    n_at_bin_width = int(np.sum(np.isclose(widths, 1.0, atol=1e-6)))
+    assert n_at_bin_width > 50  # majority of the 100-unit range
+
+
+def test_hist_uniform_with_peaks_preserves_total_counts():
+    data = _peaked_data()
+    out = hist_uniform_with_peaks(data, bin_width=1.0, prebin_width=0.05, n_sigma=5.0)
+    assert out.values().sum() == pytest.approx(len(data))
+
+
+def test_hist_uniform_with_peaks_with_range():
+    data = _peaked_data()
+    out = hist_uniform_with_peaks(
+        data,
+        bin_width=1.0,
+        prebin_width=0.05,
+        prebin_low=10.0,
+        prebin_high=90.0,
+        n_sigma=5.0,
+    )
+    edges = out.axes[0].edges
+    assert edges[0] == 10.0
+    in_range = int(np.sum((data >= 10.0) & (data < 90.0)))
+    assert out.values().sum() == pytest.approx(in_range)
+
+
+def test_rebin_uniform_with_peaks_preserves_total_counts():
+    data = _peaked_data()
+    fine = bh.Hist(bh.axis.Regular(2000, 0.0, 100.0), storage=bh.storage.Weight())
+    fine.fill(data)
+    out = rebin_uniform_with_peaks(fine, bin_width=1.0, n_sigma=5.0)
+    assert out.values().sum() == pytest.approx(fine.values().sum())
+
+
+def test_rebin_uniform_with_peaks_edges_are_subset_of_fine_grid():
+    data = _peaked_data()
+    fine = bh.Hist(bh.axis.Regular(2000, 0.0, 100.0), storage=bh.storage.Weight())
+    fine.fill(data)
+    out = rebin_uniform_with_peaks(fine, bin_width=1.0, n_sigma=5.0)
+    assert np.all(np.isin(out.axes[0].edges, fine.axes[0].edges))
+
+
+def test_rebin_uniform_with_peaks_continuum_near_bin_width():
+    data = _peaked_data()
+    fine = bh.Hist(bh.axis.Regular(2000, 0.0, 100.0), storage=bh.storage.Weight())
+    fine.fill(data)
+    out = rebin_uniform_with_peaks(fine, bin_width=1.0, n_sigma=5.0)
+    widths = np.diff(out.axes[0].edges)
+    n_continuum = int(np.sum(np.isclose(widths, 1.0, atol=0.05)))
+    assert n_continuum > 50
+
+
+def test_hist_bblocks_with_peaks_with_range():
+    data = _peaked_data()
+    out = hist_bblocks_with_peaks(
+        data,
+        prebin_width=0.05,
+        prebin_low=10.0,
+        prebin_high=90.0,
+        n_sigma=5.0,
+    )
+    edges = out.axes[0].edges
+    assert edges[0] == 10.0
+    in_range = int(np.sum((data >= 10.0) & (data < 90.0)))
+    assert out.values().sum() == pytest.approx(in_range)
+
+
+# ---------------------------------------------------------------------------
+# zero-peaks paths through all four *_with_peaks public entry points
+# ---------------------------------------------------------------------------
+
+
+def _flat_data(seed: int = 42) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    return rng.uniform(0.0, 10.0, 10_000)
+
+
+def test_hist_bblocks_with_peaks_zero_peaks_returns_variable_axis():
+    data = _flat_data()
+    out = hist_bblocks_with_peaks(data, prebin_width=0.1, n_sigma=5.0)
+    assert isinstance(out.axes[0], bh.axis.Variable)
+    assert out.values().sum() == pytest.approx(len(data))
+
+
+def test_rebin_bblocks_with_peaks_zero_peaks_returns_variable_axis():
+    data = _flat_data()
+    fine = bh.Hist(bh.axis.Regular(100, 0.0, 10.0), storage=bh.storage.Weight())
+    fine.fill(data)
+    out = rebin_bblocks_with_peaks(fine, n_sigma=5.0)
+    # _collapse_peaks must promote to Variable even when no peaks were found
+    assert isinstance(out.axes[0], bh.axis.Variable)
+    assert out.values().sum() == pytest.approx(fine.values().sum())
+
+
+def test_hist_uniform_with_peaks_zero_peaks_returns_uniform_grid():
+    data = _flat_data()
+    out = hist_uniform_with_peaks(data, bin_width=1.0, prebin_width=0.1, n_sigma=5.0)
+    widths = np.diff(out.axes[0].edges)
+    # all bins should be close to bin_width when no peaks were inserted
+    assert np.allclose(widths, 1.0, atol=0.01)
+
+
+def test_rebin_uniform_with_peaks_zero_peaks_returns_uniform_grid():
+    data = _flat_data()
+    fine = bh.Hist(bh.axis.Regular(1000, 0.0, 10.0), storage=bh.storage.Weight())
+    fine.fill(data)
+    out = rebin_uniform_with_peaks(fine, bin_width=1.0, n_sigma=5.0)
+    widths = np.diff(out.axes[0].edges)
+    # snapped to fine grid (0.01 wide), so bins should be within ~0.01 of 1.0
+    assert np.allclose(widths, 1.0, atol=0.02)
+
+
+# ---------------------------------------------------------------------------
+# _snap_indices
+# ---------------------------------------------------------------------------
+
+
+def test_snap_indices_exact_targets_return_exact_indices():
+    from pygama.math.rebin import _snap_indices
+
+    fine = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+    idx = _snap_indices(fine, np.array([0.0, 2.0, 4.0]))
+    assert np.array_equal(idx, [0, 2, 4])
+
+
+def test_snap_indices_misaligned_targets_snap_to_nearest():
+    from pygama.math.rebin import _snap_indices
+
+    fine = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+    # 1.4 → nearest 1, 2.6 → nearest 3
+    idx = _snap_indices(fine, np.array([0.0, 1.4, 2.6, 4.0]))
+    assert np.array_equal(idx, [0, 1, 3, 4])
+
+
+def test_snap_indices_endpoints_clamped_and_duplicates_removed():
+    from pygama.math.rebin import _snap_indices
+
+    fine = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+    # two close targets snap to the same fine index — dedup must collapse
+    idx = _snap_indices(fine, np.array([0.0, 1.1, 1.2, 4.0]))
+    # both 1.1 and 1.2 → 1; result must be strictly increasing
+    assert np.all(np.diff(idx) > 0)
+    # endpoints must be 0 and len(fine) - 1
+    assert idx[0] == 0
+    assert idx[-1] == len(fine) - 1

--- a/tests/math/test_rebin.py
+++ b/tests/math/test_rebin.py
@@ -5,7 +5,7 @@ import hist as bh
 import numpy as np
 import pytest
 
-from pygama.math.rebin import hist_bblocks, rebin_bblocks
+from pygama.math.rebin import collapse_peaks, hist_bblocks, rebin_bblocks
 
 
 def _two_population_data(seed: int = 42) -> np.ndarray:
@@ -154,3 +154,352 @@ def test_rebin_bblocks_flat_input_collapses():
     # uniform input should collapse to very few blocks
     assert out.values().size <= 3
     assert out.values().sum() == pytest.approx(h.values().sum())
+
+
+def _hist_from_arrays(edges: np.ndarray, values: np.ndarray) -> bh.Hist:
+    """Build a Variable-axis Weight-storage histogram with Poisson variances."""
+    h = bh.Hist(bh.axis.Variable(edges), storage=bh.storage.Weight())
+    view = np.asarray(h.view())
+    view["value"] = values
+    view["variance"] = values
+    return h
+
+
+def _hist_from_widths_rates(blocks: list[tuple[float, float]]) -> bh.Hist:
+    """Build a histogram from a list of ``(width, rate)`` blocks.
+
+    Counts are deterministic ``width * rate`` (no Poisson noise) so the
+    rate shape on each side of a peak is exactly under test.
+    """
+    widths = np.array([w for w, _ in blocks])
+    rates = np.array([r for _, r in blocks])
+    edges = np.concatenate([[0.0], np.cumsum(widths)])
+    counts = widths * rates
+    return _hist_from_arrays(edges, counts)
+
+
+def test_collapse_peaks_merges_descending_peak_and_stops_at_width_jump():
+    # narrow bins forming a peak (rates rise then fall), bordered on each
+    # side by a wide continuum bin. Walk should include the narrow run
+    # only, stopping at the width jump to continuum.
+    # widths: [10, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 10]
+    # rates:  [100, 200, 1000, 5000, 50000, 5000, 1000, 200, 100]
+    h = _hist_from_widths_rates(
+        [
+            (10.0, 100.0),  # left continuum
+            (0.5, 200.0),  # peak structure starts
+            (0.5, 1000.0),
+            (0.5, 5000.0),
+            (0.5, 50000.0),  # peak top
+            (0.5, 5000.0),
+            (0.5, 1000.0),
+            (0.5, 200.0),  # peak structure ends
+            (10.0, 100.0),  # right continuum
+        ]
+    )
+    out = collapse_peaks(h, n_sigma=5.0, width_factor=5.0)
+
+    # 3 output bins: left continuum, merged peak, right continuum
+    new_edges = out.axes[0].edges
+    assert out.values().size == 3
+    in_edges = h.axes[0].edges
+    assert new_edges[0] == in_edges[0]
+    assert new_edges[1] == in_edges[1]  # boundary between continuum and peak
+    assert new_edges[2] == in_edges[-2]  # boundary between peak and continuum
+    assert new_edges[3] == in_edges[-1]
+
+
+def test_collapse_peaks_walk_stops_at_rate_local_minimum():
+    # two peaks separated by a narrow valley (all narrow bins; no width jump
+    # between them). Walk must stop at the rate minimum, giving two regions.
+    h = _hist_from_widths_rates(
+        [
+            (5.0, 100.0),  # left continuum
+            (0.5, 1000.0),
+            (0.5, 5000.0),
+            (0.5, 30000.0),  # peak 1
+            (0.5, 5000.0),
+            (0.5, 2000.0),  # valley between peaks
+            (0.5, 5000.0),
+            (0.5, 30000.0),  # peak 2
+            (0.5, 5000.0),
+            (0.5, 1000.0),
+            (5.0, 100.0),  # right continuum
+        ]
+    )
+    out = collapse_peaks(h, n_sigma=5.0, width_factor=5.0)
+
+    new_edges = out.axes[0].edges
+    new_widths = np.diff(new_edges)
+    in_edges = h.axes[0].edges
+    # expect 5 output bins: left continuum (5), peak1 merge, valley (0.5),
+    # peak2 merge, right continuum (5)
+    assert out.values().size == 5
+    # exactly two merged peak regions of width 2.0 (4 narrow bins of 0.5)
+    assert int(np.sum(np.isclose(new_widths, 2.0))) == 2
+    # the valley bin stays as a single 0.5 bin
+    assert int(np.sum(np.isclose(new_widths, 0.5))) == 1
+    # verify the valley bin's identity: input bin index 5 (zero-indexed)
+    # is the valley (rate 2000). Its left/right edges are in_edges[5]/[6].
+    # The output bin at index 2 must coincide with that valley bin.
+    assert np.isclose(new_edges[2], in_edges[5])
+    assert np.isclose(new_edges[3], in_edges[6])
+
+
+def test_collapse_peaks_walk_stops_at_width_jump_even_if_rate_descends():
+    # rate keeps descending past the peak/continuum boundary, but the
+    # width jumps up — walk must stop at the jump, not extend into the
+    # continuum bin.
+    h = _hist_from_widths_rates(
+        [
+            (10.0, 30.0),  # far left continuum
+            (0.5, 100.0),  # rising side
+            (0.5, 1000.0),
+            (0.5, 10000.0),  # peak
+            (0.5, 1000.0),
+            (0.5, 100.0),  # last narrow bin, rate still > continuum
+            (10.0, 50.0),  # continuum bin: lower rate than 100 → pure
+            # rate-descent would walk INTO it
+        ]
+    )
+    out = collapse_peaks(h, n_sigma=5.0, width_factor=5.0)
+    out_edges = out.axes[0].edges
+    out_widths = np.diff(out_edges)
+    # the wide continuum bins must remain in the output as 10 keV bins
+    assert int(np.sum(np.isclose(out_widths, 10.0))) == 2
+
+
+def test_collapse_peaks_preserves_counts_and_variances():
+    h = _hist_from_widths_rates(
+        [
+            (5.0, 100.0),
+            (0.5, 500.0),
+            (0.5, 5000.0),
+            (0.5, 50000.0),
+            (0.5, 5000.0),
+            (0.5, 500.0),
+            (5.0, 100.0),
+            (0.5, 500.0),
+            (0.5, 8000.0),
+            (0.5, 80000.0),
+            (0.5, 8000.0),
+            (0.5, 500.0),
+            (5.0, 100.0),
+        ]
+    )
+    out = collapse_peaks(h, n_sigma=5.0)
+
+    h_var = h.variances()
+    out_var = out.variances()
+    assert h_var is not None
+    assert out_var is not None
+    assert out.values().sum() == pytest.approx(h.values().sum())
+    assert out_var.sum() == pytest.approx(h_var.sum())
+
+
+def test_collapse_peaks_edges_subset_of_input():
+    h = _hist_from_widths_rates(
+        [
+            (10.0, 100.0),
+            (0.5, 1000.0),
+            (0.5, 50000.0),
+            (0.5, 1000.0),
+            (10.0, 100.0),
+        ]
+    )
+    out = collapse_peaks(h)
+    fine_edges = h.axes[0].edges
+    new_edges = out.axes[0].edges
+    assert np.all(np.isin(new_edges, fine_edges))
+    assert new_edges[0] == fine_edges[0]
+    assert new_edges[-1] == fine_edges[-1]
+
+
+def test_collapse_peaks_no_peaks_returns_unchanged():
+    # flat rate everywhere — no rate-local-maxima, no peaks detected.
+    h = _hist_from_widths_rates([(1.0, 100.0)] * 10)
+    out = collapse_peaks(h, n_sigma=5.0)
+    assert np.array_equal(out.axes[0].edges, h.axes[0].edges)
+    assert np.array_equal(out.values(), h.values())
+
+
+def test_collapse_peaks_max_bin_width_caps_wide_peak_walk():
+    # a peak on a 3-keV bin, surrounded by gradually widening shoulders
+    # that would all sit under the peak-relative cap (3 * 3 = 9 keV).
+    # The absolute cap must clip the walk before reaching the wide bins.
+    h = _hist_from_widths_rates(
+        [
+            (50.0, 30.0),  # far-left continuum
+            (3.0, 8500.0),  # rising shoulder
+            (3.0, 11000.0),  # peak
+            (2.0, 10000.0),  # shoulder
+            (
+                8.5,
+                9000.0,
+            ),  # would pass relative cap (8.5 < 9) — should be stopped by absolute cap
+            (5.0, 8500.0),
+            (50.0, 30.0),
+        ]
+    )
+
+    # without absolute cap: the walk drags in the 8.5-keV bin
+    out_loose = collapse_peaks(h, n_sigma=2.0, width_factor=3.0)
+    widths_loose = np.diff(out_loose.axes[0].edges)
+    assert widths_loose.max() > 10.0  # merged region grew through the 8.5 bin
+
+    # with absolute cap of 5 keV: walk stops before the 8.5-keV bin
+    out_tight = collapse_peaks(h, n_sigma=2.0, width_factor=3.0, max_bin_width=5.0)
+    widths_tight = np.diff(out_tight.axes[0].edges)
+    # the wide bins remain at their original sizes (8.5 and 50)
+    assert int(np.sum(np.isclose(widths_tight, 8.5))) == 1
+    assert int(np.sum(np.isclose(widths_tight, 50.0))) == 2
+
+
+def test_collapse_peaks_handles_low_stats_peak_on_wider_bin():
+    # peak sits on a 3 keV bin (low-stats peak); neighbors are also moderately
+    # wide. width_factor only kicks in at the boundary to wide continuum.
+    h = _hist_from_widths_rates(
+        [
+            (50.0, 30.0),  # far-left continuum
+            (3.0, 100.0),  # peak shoulder
+            (3.0, 500.0),  # peak top
+            (3.0, 100.0),  # peak shoulder
+            (50.0, 30.0),  # far-right continuum
+        ]
+    )
+    out = collapse_peaks(h, n_sigma=5.0, width_factor=5.0)
+    new_edges = out.axes[0].edges
+    new_widths = np.diff(new_edges)
+    # all three 3-keV bins should be merged into one 9-keV bin
+    assert int(np.sum(np.isclose(new_widths, 9.0))) == 1
+    # continuum bins preserved
+    assert int(np.sum(np.isclose(new_widths, 50.0))) == 2
+
+
+def test_collapse_peaks_with_rebin_bblocks_end_to_end():
+    rng = np.random.default_rng(42)
+    data = np.concatenate(
+        [
+            rng.uniform(0.0, 100.0, 20_000),
+            rng.normal(50.0, 0.3, 10_000),
+        ]
+    )
+    fine = bh.Hist(bh.axis.Regular(2000, 0.0, 100.0), storage=bh.storage.Weight())
+    fine.fill(data)
+
+    bb = rebin_bblocks(fine)
+    out = collapse_peaks(bb, n_sigma=5.0)
+
+    assert out.values().sum() == pytest.approx(bb.values().sum())
+    assert out.values().size <= bb.values().size
+    # there should be a wide merged output bin near the true peak at 50
+    new_edges = out.axes[0].edges
+    new_widths = np.diff(new_edges)
+    # at least one merged output bin centered close to 50
+    for i, w in enumerate(new_widths):
+        if w > 0.5:  # a region that combined multiple fine bblocks bins
+            center = (new_edges[i] + new_edges[i + 1]) / 2
+            if 45.0 < center < 55.0:
+                return  # success
+    pytest.fail("no merged region found around the true peak at 50")
+
+
+def test_collapse_peaks_rejects_tail_false_positives_from_width_variation():
+    # narrow bins with alternating widths along a monotonically rising rate.
+    # counts have local maxima at the wider bins, but those are not
+    # rate-local-maxima and must be rejected by the rate filter.
+    widths_arr = np.array([0.1, 0.2, 0.1, 0.2, 0.1])
+    edges = np.concatenate([[0.0], np.cumsum(widths_arr)])
+    rates = np.array([100.0, 110.0, 120.0, 130.0, 140.0]) * 1000.0
+    counts = widths_arr * rates
+    h = _hist_from_arrays(edges, counts)
+
+    out = collapse_peaks(h, n_sigma=2.0)
+    assert np.array_equal(out.axes[0].edges, edges)
+    assert np.array_equal(out.values(), counts)
+
+
+def test_collapse_peaks_single_bin_histogram():
+    # one-bin histogram: no local maxima possible, output equals input
+    edges = np.array([0.0, 1.0])
+    h = _hist_from_arrays(edges, np.array([42.0]))
+    out = collapse_peaks(h)
+    assert np.array_equal(out.axes[0].edges, edges)
+    assert np.array_equal(out.values(), h.values())
+
+
+def test_collapse_peaks_all_zero_histogram():
+    # all-zero histogram: rate is all zeros, no peaks, output unchanged
+    edges = np.linspace(0.0, 10.0, 11)
+    h = _hist_from_arrays(edges, np.zeros(10))
+    out = collapse_peaks(h)
+    assert np.array_equal(out.axes[0].edges, edges)
+    assert np.array_equal(out.values(), h.values())
+
+
+def test_collapse_peaks_spike_at_boundary_is_passed_through():
+    # scipy.signal.find_peaks never reports indices 0 or n-1 as peaks,
+    # so a spike at the very first or last bin is silently passed through
+    # unchanged (not a bug, but a documented behavior).
+    edges = np.linspace(0.0, 10.0, 11)
+    values = np.array([100.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0])
+    h = _hist_from_arrays(edges, values)
+    out = collapse_peaks(h, n_sigma=5.0)
+    # output is unchanged (no peak detected)
+    assert np.array_equal(out.axes[0].edges, edges)
+    assert np.array_equal(out.values(), values)
+
+
+def test_collapse_peaks_rejects_negative_counts():
+    edges = np.linspace(0.0, 10.0, 11)
+    h = bh.Hist(bh.axis.Variable(edges), storage=bh.storage.Weight())
+    view = np.asarray(h.view())
+    view["value"] = [1.0, 2.0, 3.0, 4.0, 5.0, -1.0, 5.0, 4.0, 3.0, 2.0]
+    with pytest.raises(ValueError, match="non-negative"):
+        collapse_peaks(h)
+
+
+def test_collapse_peaks_adjacent_regions_not_merged():
+    # two close peaks where each walk stops exactly one bin apart;
+    # the regions are adjacent (share an edge) but do NOT overlap, and
+    # must remain two separate output bins, preserving the boundary.
+    h = _hist_from_widths_rates(
+        [
+            (5.0, 100.0),  # left continuum
+            (0.5, 20000.0),  # peak 1 (sharp, isolated bin)
+            (0.5, 1000.0),  # immediate valley
+            (0.5, 20000.0),  # peak 2 (sharp, isolated bin)
+            (5.0, 100.0),  # right continuum
+        ]
+    )
+    out = collapse_peaks(h, n_sigma=5.0, width_factor=5.0)
+    # output: 5 bins (left cont, peak1, valley, peak2, right cont) —
+    # the two peaks must NOT merge even though their walks could end
+    # at adjacent indices
+    assert out.values().size == 5
+
+
+def test_collapse_peaks_input_validation():
+    edges = np.linspace(0.0, 100.0, 101)
+    h = bh.Hist(bh.axis.Variable(edges), storage=bh.storage.Weight())
+
+    with pytest.raises(ValueError, match="n_sigma"):
+        collapse_peaks(h, n_sigma=0.0)
+    with pytest.raises(ValueError, match="n_sigma"):
+        collapse_peaks(h, n_sigma=-1.0)
+    with pytest.raises(ValueError, match="width_factor"):
+        collapse_peaks(h, width_factor=1.0)
+    with pytest.raises(ValueError, match="width_factor"):
+        collapse_peaks(h, width_factor=0.5)
+    with pytest.raises(ValueError, match="max_bin_width"):
+        collapse_peaks(h, max_bin_width=0.0)
+    with pytest.raises(ValueError, match="max_bin_width"):
+        collapse_peaks(h, max_bin_width=-1.0)
+
+    h2 = bh.Hist(
+        bh.axis.Regular(10, 0.0, 1.0),
+        bh.axis.Regular(10, 0.0, 1.0),
+        storage=bh.storage.Weight(),
+    )
+    with pytest.raises(ValueError, match="1D"):
+        collapse_peaks(h2)

--- a/tests/math/test_rebin.py
+++ b/tests/math/test_rebin.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import awkward as ak
+import hist as bh
+import numpy as np
+import pytest
+
+from pygama.math.rebin import hist_bblocks, rebin_bblocks
+
+
+def _two_population_data(seed: int = 42) -> np.ndarray:
+    rng = np.random.default_rng(seed)
+    return np.concatenate([rng.normal(-3.0, 0.5, 2000), rng.normal(3.0, 0.5, 2000)])
+
+
+def test_hist_bblocks_numpy():
+    rng = np.random.default_rng(42)
+    data = rng.normal(0.0, 1.0, 5000)
+
+    h = hist_bblocks(data)
+
+    edges = h.axes[0].edges
+    assert len(edges) >= 2
+    assert np.all(np.diff(edges) > 0)
+    assert edges[0] <= data.min()
+    assert edges[-1] >= data.max()
+    assert h.values().sum() == pytest.approx(len(data))
+
+
+def test_hist_bblocks_awkward_matches_numpy():
+    rng = np.random.default_rng(42)
+    flat = rng.normal(0.0, 1.0, 600)
+
+    h_np = hist_bblocks(flat)
+
+    # same data wrapped as a jagged awkward array
+    jagged = ak.Array([flat[:100], flat[100:350], flat[350:]])
+    h_ak = hist_bblocks(jagged)
+
+    assert h_np.axes[0].edges == pytest.approx(h_ak.axes[0].edges)
+    assert h_np.values() == pytest.approx(h_ak.values())
+
+
+def test_hist_bblocks_two_populations():
+    data = _two_population_data()
+    h = hist_bblocks(data)
+
+    # at least one internal change-point must fall in the gap between modes
+    internal = h.axes[0].edges[1:-1]
+    assert np.any((internal > -2.0) & (internal < 2.0))
+
+
+def test_hist_bblocks_prebin_preserves_counts_and_finds_gap():
+    data = _two_population_data()
+    h = hist_bblocks(data, prebin_width=0.05)
+
+    assert h.values().sum() == pytest.approx(len(data))
+    edges = h.axes[0].edges
+    assert edges[0] <= data.min()
+    assert edges[-1] >= data.max()
+    # gap between the two populations must still be detected
+    internal = edges[1:-1]
+    assert np.any((internal > -2.0) & (internal < 2.0))
+
+
+def test_hist_bblocks_prebin_with_range():
+    data = _two_population_data()  # spans roughly [-5, 5]
+    low, high = -4.0, 4.0
+    h = hist_bblocks(data, prebin_width=0.05, prebin_low=low, prebin_high=high)
+
+    edges = h.axes[0].edges
+    # output must stay within the requested range (up to ~prebin_width slack
+    # on the upper edge from the ceil-and-extend step)
+    assert edges[0] == low
+    assert high <= edges[-1] <= high + 0.05 + 1e-9
+    # only data in [low, high) contributes (as documented)
+    in_range_count = int(np.sum((data >= low) & (data < high)))
+    assert h.values().sum() == pytest.approx(in_range_count)
+
+
+def test_hist_bblocks_prebin_low_high_require_prebin_width():
+    data = _two_population_data()
+    with pytest.raises(ValueError, match="prebin_width"):
+        hist_bblocks(data, prebin_low=-1.0)
+    with pytest.raises(ValueError, match="prebin_width"):
+        hist_bblocks(data, prebin_high=1.0)
+
+
+def test_hist_bblocks_prebin_width_validation():
+    data = _two_population_data()
+    # Test invalid prebin_width values
+    with pytest.raises(ValueError, match="finite and > 0"):
+        hist_bblocks(data, prebin_width=0.0)
+    with pytest.raises(ValueError, match="finite and > 0"):
+        hist_bblocks(data, prebin_width=-0.1)
+    with pytest.raises(ValueError, match="finite and > 0"):
+        hist_bblocks(data, prebin_width=np.inf)
+    with pytest.raises(ValueError, match="finite and > 0"):
+        hist_bblocks(data, prebin_width=np.nan)
+
+
+def test_rebin_bblocks_preserves_total_counts():
+    data = _two_population_data()
+    h = bh.Hist(bh.axis.Regular(500, -6.0, 6.0), storage=bh.storage.Weight())
+    h.fill(data)
+
+    out = rebin_bblocks(h)
+
+    out_var = out.variances()
+    h_var = h.variances()
+    assert out_var is not None
+    assert h_var is not None
+    assert out.values().sum() == pytest.approx(h.values().sum())
+    assert out_var.sum() == pytest.approx(h_var.sum())
+
+
+def test_rebin_bblocks_edges_subset_of_fine_grid():
+    data = _two_population_data()
+    h = bh.Hist(bh.axis.Regular(500, -6.0, 6.0), storage=bh.storage.Weight())
+    h.fill(data)
+
+    out = rebin_bblocks(h)
+
+    fine_edges = h.axes[0].edges
+    new_edges = out.axes[0].edges
+    # every new edge must be exactly one of the input edges
+    # (rebin_bblocks indexes fine_edges by integer position; no arithmetic)
+    assert np.all(np.isin(new_edges, fine_edges))
+    # endpoints must coincide with the input range
+    assert new_edges[0] == fine_edges[0]
+    assert new_edges[-1] == fine_edges[-1]
+    # also exercise on an irregular input grid
+    irregular = np.unique(
+        np.concatenate([np.linspace(-6.0, 0.0, 200), np.linspace(0.0, 6.0, 350)])
+    )
+    h2 = bh.Hist(bh.axis.Variable(irregular), storage=bh.storage.Weight())
+    h2.fill(data)
+    out2 = rebin_bblocks(h2)
+    new_edges2 = out2.axes[0].edges
+    fine_edges2 = h2.axes[0].edges
+    assert np.all(np.isin(new_edges2, fine_edges2))
+    assert new_edges2[0] == fine_edges2[0]
+    assert new_edges2[-1] == fine_edges2[-1]
+
+
+def test_rebin_bblocks_flat_input_collapses():
+    rng = np.random.default_rng(42)
+    data = rng.uniform(0.0, 10.0, 10_000)
+    h = bh.Hist(bh.axis.Regular(100, 0.0, 10.0), storage=bh.storage.Weight())
+    h.fill(data)
+
+    out = rebin_bblocks(h)
+
+    # uniform input should collapse to very few blocks
+    assert out.values().size <= 3
+    assert out.values().sum() == pytest.approx(h.values().sum())


### PR DESCRIPTION
## Summary

- Adds `pygama.math.rebin` with two entry points backed by `astropy.stats.bayesian_blocks`:
  - `hist_bblocks(data, *, prebin_width=None, prebin_low=None, prebin_high=None, p0=0.05)` — adaptive histogram of an unbinned data array (numpy or awkward). `prebin_width` activates a pre-binning step (fine `Regular` axis → `rebin_bblocks`) that brings the O(N²) `events`-fitness cost down to O(N_bins²); `prebin_low`/`prebin_high` bound the pre-binned range.
  - `rebin_bblocks(h, *, p0=0.05)` — rebin a finely-binned 1D `hist.Hist` using `fitness='measures'`; snaps block edges to the input grid and aggregates counts/variances via `np.add.reduceat`, so output edges are an exact subset of the input edges and total counts/variances are conserved.
- Adds `astropy` and `awkward` as runtime dependencies.

## Test plan

- [x] `pytest tests/math/test_rebin.py -v` — 9 tests pass
  - `hist_bblocks` on numpy / awkward inputs and on two-population data
  - pre-binning path: count preservation, gap detection, range restriction, error when `prebin_low`/`prebin_high` is set without `prebin_width`
  - `rebin_bblocks` total counts / variances preserved
  - `rebin_bblocks` output edges are an exact subset of the input edges (both regular and irregular input grids)
  - flat input collapses to ≤ 3 blocks
- [x] `pre-commit run --files src/pygama/math/rebin.py tests/math/test_rebin.py pyproject.toml` — clean
- [x] `cd docs && make` — both functions appear in `build/html/api/pygama.math.html` with no Sphinx warnings about the new module

🤖 Generated with [Claude Code](https://claude.com/claude-code)