### PR TITLE
feat: persist and unpack bit aggregations in build_hit

### DIFF
--- a/docs/source/manuals/hit.rst
+++ b/docs/source/manuals/hit.rst
@@ -91,6 +91,40 @@ evaluated in a dependency-respecting order rather than strictly in JSON
 insertion order.  This dependency-based reordering is what allows forward
 references like this to be supported.
 
+Bit aggregations
+^^^^^^^^^^^^^^^^
+
+An optional ``aggregations`` block packs several boolean columns into a single
+integer column, with one bit per source column.  Each aggregation entry is a
+mapping from bit name to source-column name; bit ``i`` corresponds to the
+``i``-th entry in insertion order.  Example:
+
+.. code-block:: json
+
+    {
+      "outputs": ["aggr1"],
+      "operations": {
+        "is_valid_rt":   {"expression": "(tp_90-tp_10) > 96", "parameters": {}},
+        "is_valid_t0":   {"expression": "tp_0_est > 47000",   "parameters": {}},
+        "is_valid_tmax": {"expression": "tp_max < 120000",    "parameters": {}}
+      },
+      "aggregations": {
+        "aggr1": {
+          "bit0": "is_valid_rt",
+          "bit1": "is_valid_t0",
+          "bit2": "is_valid_tmax"
+        }
+      }
+    }
+
+The dtype of the aggregated column is the smallest unsigned integer that fits
+the number of bits (``uint8``, ``uint16``, ``uint32``, or ``uint64``).  The
+source-column names are persisted on disk as the ``bit_names`` LGDO attribute
+of the aggregated column (a comma-separated string in bit order), so the
+encoding can be recovered at read time.  Use
+:func:`~pygama.hit.aggregations.unpack_bitmask` to expand an aggregation back
+into an awkward record array with one boolean field per bit name.
+
 Per-table configuration
 ^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -117,5 +151,8 @@ API reference
    * - :func:`~pygama.hit.build_hit.build_hit`
      - Read DSP-tier LH5 tables and write calibrated hit-tier quantities by
        evaluating the supplied configuration expressions.
+   * - :func:`~pygama.hit.aggregations.unpack_bitmask`
+     - Expand a bit-aggregation column into an awkward record array with one
+       boolean field per bit name.
 
 For the complete parameter reference see :mod:`pygama.hit`.

--- a/src/pygama/hit/__init__.py
+++ b/src/pygama/hit/__init__.py
@@ -5,6 +5,7 @@ to produce the hit-tier from the dsp-tier.
 
 from __future__ import annotations
 
+from pygama.hit.aggregations import unpack_bitmask
 from pygama.hit.build_hit import build_hit
 
-__all__ = ["build_hit"]
+__all__ = ["build_hit", "unpack_bitmask"]

--- a/src/pygama/hit/aggregations.py
+++ b/src/pygama/hit/aggregations.py
@@ -1,0 +1,65 @@
+"""
+Utilities for working with bit-aggregation columns produced by
+:func:`.build_hit`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+import awkward as ak
+import lgdo
+import numpy as np
+from numpy.typing import ArrayLike
+
+
+def unpack_bitmask(
+    aggregation: lgdo.LGDO | ArrayLike,
+    bit_names: Iterable[str] | None = None,
+) -> ak.Array:
+    """Unpack a bit-aggregation column into an awkward record array.
+
+    The returned array has one boolean field per bit, with field names taken
+    from `bit_names` or from the ``bit_names`` attribute of `aggregation` when
+    it is an :class:`lgdo.LGDO`. Bit ``i`` maps to ``bit_names[i]``, matching
+    the encoding used by :func:`.build_hit`.
+
+    Works on flat columns (e.g. :class:`lgdo.Array`) as well as jagged ones
+    (e.g. :class:`lgdo.VectorOfVectors`): the returned record array preserves
+    the input shape.
+
+    Parameters
+    ----------
+    aggregation
+        a bit-aggregation column. Either an :class:`lgdo.LGDO` carrying a
+        ``bit_names`` attribute, or a plain integer numpy/awkward array — in
+        the latter case `bit_names` must be passed explicitly.
+    bit_names
+        ordered names for each bit. If ``None`` and `aggregation` is an
+        :class:`lgdo.LGDO`, names are read from its ``bit_names`` attribute
+        (a comma-separated string).
+    """
+    if isinstance(aggregation, lgdo.LGDO):
+        values = aggregation.view_as("ak")
+        if bit_names is None:
+            attr = aggregation.attrs.get("bit_names")
+            if attr is None:
+                msg = (
+                    "aggregation has no 'bit_names' attribute; pass bit_names "
+                    "explicitly"
+                )
+                raise ValueError(msg)
+            bit_names = attr.split(",")
+    else:
+        if bit_names is None:
+            msg = "bit_names must be provided when aggregation is not an LGDO"
+            raise ValueError(msg)
+        values = (
+            aggregation
+            if isinstance(aggregation, ak.Array)
+            else np.asarray(aggregation)
+        )
+
+    names = list(bit_names)
+    fields = {name: ((values >> i) & 1) == 1 for i, name in enumerate(names)}
+    return ak.zip(fields)

--- a/src/pygama/hit/build_hit.py
+++ b/src/pygama/hit/build_hit.py
@@ -182,7 +182,9 @@ def build_hit(
                     multiplier = 2 ** np.arange(n_flags, dtype=flag_values.dtype)
                     flag_out = np.dot(flag_values, multiplier)
 
-                    outtbl_obj.add_field(high_lvl_flag, lgdo.Array(flag_out))
+                    aggr_col = lgdo.Array(flag_out)
+                    aggr_col.attrs["bit_names"] = ",".join(flags_list)
+                    outtbl_obj.add_field(high_lvl_flag, aggr_col)
 
             # remove or add columns according to "outputs" in the configuration
             # dictionary

--- a/tests/hit/test_aggregations.py
+++ b/tests/hit/test_aggregations.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import awkward as ak
+import lgdo
+import numpy as np
+import pytest
+
+from pygama.hit import unpack_bitmask
+
+
+def test_from_lgdo_array_uses_attr():
+    arr = lgdo.Array(np.array([0b000, 0b001, 0b010, 0b101, 0b111], dtype=np.uint8))
+    arr.attrs["bit_names"] = "rt,t0,tmax"
+
+    rec = unpack_bitmask(arr)
+
+    assert rec.fields == ["rt", "t0", "tmax"]
+    assert ak.to_list(rec["rt"]) == [False, True, False, True, True]
+    assert ak.to_list(rec["t0"]) == [False, False, True, False, True]
+    assert ak.to_list(rec["tmax"]) == [False, False, False, True, True]
+
+
+def test_explicit_bit_names_override_attr():
+    arr = lgdo.Array(np.array([0b01, 0b10, 0b11], dtype=np.uint8))
+    arr.attrs["bit_names"] = "a,b"
+
+    rec = unpack_bitmask(arr, bit_names=["foo", "bar"])
+
+    assert rec.fields == ["foo", "bar"]
+
+
+def test_from_numpy_with_names():
+    rec = unpack_bitmask(np.array([0b01, 0b10, 0b11]), bit_names=["low", "high"])
+    assert rec.fields == ["low", "high"]
+    assert ak.to_list(rec["low"]) == [True, False, True]
+    assert ak.to_list(rec["high"]) == [False, True, True]
+
+
+def test_from_awkward_with_names():
+    rec = unpack_bitmask(ak.Array([0b01, 0b10, 0b11]), bit_names=["low", "high"])
+    assert ak.to_list(rec["low"]) == [True, False, True]
+    assert ak.to_list(rec["high"]) == [False, True, True]
+
+
+def test_from_vector_of_vectors_uses_attr():
+    vov = lgdo.VectorOfVectors([[0b01, 0b10], [0b11]])
+    vov.attrs["bit_names"] = "low,high"
+
+    rec = unpack_bitmask(vov)
+
+    assert rec.fields == ["low", "high"]
+    assert ak.to_list(rec["low"]) == [[True, False], [True]]
+    assert ak.to_list(rec["high"]) == [[False, True], [True]]
+
+
+def test_field_equality_filtering():
+    arr = lgdo.Array(np.array([0b00, 0b01, 0b10, 0b11], dtype=np.uint8))
+    arr.attrs["bit_names"] = "low,high"
+
+    rec = unpack_bitmask(arr)
+
+    assert ak.to_list(rec.low == True) == [False, True, False, True]  # noqa: E712
+    assert ak.to_list(rec.low == False) == [True, False, True, False]  # noqa: E712
+    assert ak.to_list(rec.high == True) == [False, False, True, True]  # noqa: E712
+
+    both_set = rec[(rec.low == True) & (rec.high == True)]  # noqa: E712
+    assert len(both_set) == 1
+
+
+def test_lgdo_array_without_attr_raises():
+    arr = lgdo.Array(np.array([1, 2, 3]))
+    with pytest.raises(ValueError, match="bit_names"):
+        unpack_bitmask(arr)
+
+
+def test_numpy_without_names_raises():
+    with pytest.raises(ValueError, match="bit_names"):
+        unpack_bitmask(np.array([1, 2, 3]))

--- a/tests/hit/test_build_hit.py
+++ b/tests/hit/test_build_hit.py
@@ -139,6 +139,9 @@ def test_aggregation_outputs(dsp_test_file, tmp_dir):
         "is_valid_tmax",
     ]
 
+    assert obj["aggr1"].attrs["bit_names"] == "is_valid_rt,is_valid_t0,is_valid_tmax"
+    assert obj["aggr2"].attrs["bit_names"] == "is_valid_t0,is_valid_tmax"
+
     hit_df = lh5.read_as("ch1084803/hit", outfile, "pd")
 
     # aggr1 consists of 3 bits --> max number can be 7, aggr2 consists of 2 bits so max number can be 3


### PR DESCRIPTION
## Summary

- ``build_hit`` now writes the source-column names of each bit aggregation as a comma-separated ``bit_names`` LGDO attribute on the aggregated column, so the encoding can be recovered downstream.
- Adds ``pygama.hit.aggregations.unpack_bitmask`` which expands a bit-aggregation column into an awkward record array (one boolean field per bit), accepting either an LGDO (``Array``, ``VectorOfVectors``, …) that carries the ``bit_names`` attribute, or a plain numpy/awkward array plus an explicit ``bit_names`` list.
- Documents the ``aggregations`` config block in the hit-tier manual.

This will work nicely when passing an LGDO to the function that has the attribute holding the names of the bits (upcoming data production). Otherwise the user has to provide the names. Unfortunately one needs to provide the names also if passing an Awkward/NumPy array, as `LGDO.view_as()` does not forward all attributes and attributes are typically dropped when manipulating the array...