### PR TITLE
Fix to plot function in pargen.survival_fractions.get_survival_fractions()

### DIFF
--- a/src/pygama/pargen/survival_fractions.py
+++ b/src/pygama/pargen/survival_fractions.py
@@ -607,7 +607,7 @@ def get_survival_fraction(
 
     if display > 1:
         _fig, (ax1, ax2) = plt.subplots(1, 2)
-        bins = np.arange(fit_range[0], fit_range[1], 1) 
+        bins = np.arange(fit_range[0], fit_range[1], 1)
         ax1.hist(energy[(~nan_idxs) & (idxs)], bins=bins, histtype="step")
 
         ax2.hist(energy[(~nan_idxs) & (~idxs)], bins=bins, histtype="step")

--- a/src/pygama/pargen/survival_fractions.py
+++ b/src/pygama/pargen/survival_fractions.py
@@ -607,7 +607,7 @@ def get_survival_fraction(
 
     if display > 1:
         _fig, (ax1, ax2) = plt.subplots(1, 2)
-        bins = np.arange(1552, 1612, 1)
+        bins = np.arange(fit_range[0], fit_range[1], 1) 
         ax1.hist(energy[(~nan_idxs) & (idxs)], bins=bins, histtype="step")
 
         ax2.hist(energy[(~nan_idxs) & (~idxs)], bins=bins, histtype="step")


### PR DESCRIPTION
if display > 1:
fig, (ax1, ax2) = plt.subplots(1, 2)
# bins = np.arange(1552, 1612, 1) # The original version 
bins = np.arange(fit_range[0], fit_range[1], 1) # Plots figure according to the given fit_range

#instead of bins = np.arange(1552,1612,1) using bins = np.arange(fit_range[0],fit_range[1],1)

<!---

Before submitting a pull request, please make sure you've read and understood the pygama developer's guide: https://pygama.readthedocs.io/en/latest/developer.html. In particular, do not forget to:

- Conform to our coding conventions
- Update existing or add new tests
- Update existing or add new documentation
- Address any issue reported by GitHub checks

--->
