### PR TITLE
Reduce memory usage of noise optimisation

### DIFF
--- a/src/pygama/pargen/noise_optimization.py
+++ b/src/pygama/pargen/noise_optimization.py
@@ -81,6 +81,7 @@ def noise_optimization(
         plot_dict["nopt"] = {"fft": {"frequency": freq, "psd": psd, "fig": fig}}
         plt.close()
 
+    dsp_proc_chain = {**dsp_proc_chain, "outputs": dsp_proc_chain["outputs"].copy()}
     if opt_dict.get("fft_field", "wf_psd") in dsp_proc_chain["outputs"]:
         dsp_proc_chain["outputs"].remove(opt_dict.get("fft_field", "wf_psd"))
 

--- a/src/pygama/pargen/noise_optimization.py
+++ b/src/pygama/pargen/noise_optimization.py
@@ -112,9 +112,12 @@ def noise_optimization(
         plot_dict["nopt"] = {"fft": {"frequency": freq, "psd": psd, "fig": fig}}
         plt.close()
 
-    dsp_proc_chain = {**dsp_proc_chain, "outputs": dsp_proc_chain["outputs"].copy()}
-    if opt_dict.get("fft_field", "wf_psd") in dsp_proc_chain["outputs"]:
-        dsp_proc_chain["outputs"].remove(opt_dict.get("fft_field", "wf_psd"))
+    # the grid-search loop only ever reads the ene_str fields, so request just
+    # those: dspeed then skips every unused output buffer -- most notably
+    # wf_presum, a waveform-length output (~160 MB at the production 10k
+    # events) that was otherwise reallocated on every grid point
+    ene_outputs = list(dict.fromkeys(cfg["ene_str"] for cfg in opt_dict_par.values()))
+    dsp_proc_chain = {**dsp_proc_chain, "outputs": ene_outputs}
 
     result_dict = {}
     ene_pars = list(opt_dict_par.keys())

--- a/src/pygama/pargen/noise_optimization.py
+++ b/src/pygama/pargen/noise_optimization.py
@@ -66,8 +66,9 @@ def noise_optimization(
     res_dict = {}
     if display > 0:
         dsp_data = run_one_dsp(tb_data, dsp_proc_chain, db_dict=par_dsp)
+        
         psd = np.mean(dsp_data["wf_psd"].values.nda, axis=0)
-        sample_us = float(dsp_data["wf_presum"].dt.nda[0]) / 1000
+        sample_us = float(tb_data["waveform"].dt.nda[0]) / 1000
         freq = np.linspace(0, (1 / sample_us) / 2, len(psd))
         fig, ax = plt.subplots(figsize=(12, 6.75), facecolor="white")
         ax.plot(freq, psd)
@@ -79,7 +80,10 @@ def noise_optimization(
         plot_dict = {}
         plot_dict["nopt"] = {"fft": {"frequency": freq, "psd": psd, "fig": fig}}
         plt.close()
-
+    
+    if opt_dict.get("fft_field", "wf_psd") in dsp_proc_chain["outputs"]:
+        dsp_proc_chain["outputs"].remove(opt_dict.get("fft_field", "wf_psd"))
+        
     result_dict = {}
     ene_pars = list(opt_dict_par.keys())
     log.info("\nRunning optimization for %s", ene_pars)

--- a/src/pygama/pargen/noise_optimization.py
+++ b/src/pygama/pargen/noise_optimization.py
@@ -66,7 +66,7 @@ def noise_optimization(
     res_dict = {}
     if display > 0:
         dsp_data = run_one_dsp(tb_data, dsp_proc_chain, db_dict=par_dsp)
-        
+
         psd = np.mean(dsp_data["wf_psd"].values.nda, axis=0)
         sample_us = float(tb_data["waveform"].dt.nda[0]) / 1000
         freq = np.linspace(0, (1 / sample_us) / 2, len(psd))
@@ -80,10 +80,10 @@ def noise_optimization(
         plot_dict = {}
         plot_dict["nopt"] = {"fft": {"frequency": freq, "psd": psd, "fig": fig}}
         plt.close()
-    
+
     if opt_dict.get("fft_field", "wf_psd") in dsp_proc_chain["outputs"]:
         dsp_proc_chain["outputs"].remove(opt_dict.get("fft_field", "wf_psd"))
-        
+
     result_dict = {}
     ene_pars = list(opt_dict_par.keys())
     log.info("\nRunning optimization for %s", ene_pars)

--- a/src/pygama/pargen/noise_optimization.py
+++ b/src/pygama/pargen/noise_optimization.py
@@ -24,6 +24,30 @@ from pygama.pargen.dsp_optimize import run_one_dsp
 log = logging.getLogger(__name__)
 
 
+def _batched_mean_psd(tb_data, dsp_proc_chain, par_dsp, fft_field, batch_size):
+    """Mean PSD over *tb_data*, processed in slices of *batch_size* waveforms.
+
+    Only *fft_field* is requested from the proc chain, so dspeed builds just
+    the subgraph it needs and the energy-filter outputs are skipped entirely.
+    The single full-table, full-output run this replaces was the memory peak
+    of the whole optimisation (~2 GB for 10k waveforms of 32k samples).
+    """
+    fft_chain = {**dsp_proc_chain, "outputs": [fft_field]}
+    psd_sum = None
+    n = 0
+    for start in range(0, len(tb_data), batch_size):
+        batch_psd = run_one_dsp(
+            tb_data[start : start + batch_size], fft_chain, db_dict=par_dsp
+        )[fft_field].values.nda
+        s = batch_psd.sum(axis=0, dtype=np.float64)
+        psd_sum = s if psd_sum is None else psd_sum + s
+        n += len(batch_psd)
+    if n == 0:
+        msg = "no waveforms to compute the FFT plot from"
+        raise ValueError(msg)
+    return psd_sum / n
+
+
 def noise_optimization(
     tb_data: lgdo.Table,
     dsp_proc_chain: dict,
@@ -44,7 +68,10 @@ def noise_optimization(
     par_dsp
         Dictionary with default DSP parameters.
     opt_dict
-        Dictionary with parameters for the optimisation.
+        Dictionary with parameters for the optimisation.  The optional key
+        ``fft_field`` (default ``wf_psd``) names the PSD output of the proc
+        chain; ``fft_batch_size`` (default 1000) sets how many waveforms are
+        processed per batch when computing the FFT plot for ``display > 0``.
     _lh5_path
         Name of the channel to process (LH5 group name in raw files).
     display
@@ -65,9 +92,13 @@ def noise_optimization(
 
     res_dict = {}
     if display > 0:
-        dsp_data = run_one_dsp(tb_data, dsp_proc_chain, db_dict=par_dsp)
+        fft_field = opt_dict.get("fft_field", "wf_psd")
+        batch_size = int(opt_dict.get("fft_batch_size", 1000))
+        if batch_size < 1:
+            msg = f"fft_batch_size must be positive, got {batch_size}"
+            raise ValueError(msg)
 
-        psd = np.mean(dsp_data["wf_psd"].values.nda, axis=0)
+        psd = _batched_mean_psd(tb_data, dsp_proc_chain, par_dsp, fft_field, batch_size)
         sample_us = float(tb_data["waveform"].dt.nda[0]) / 1000
         freq = np.linspace(0, (1 / sample_us) / 2, len(psd))
         fig, ax = plt.subplots(figsize=(12, 6.75), facecolor="white")

--- a/tests/pargen/test_noise_optimization.py
+++ b/tests/pargen/test_noise_optimization.py
@@ -73,9 +73,7 @@ def _fake_psd_run_one_dsp(record, fft_field="wf_psd"):
     """A run_one_dsp stand-in whose 'PSD' is the batch's own waveform values."""
 
     def fake(tb_data, dsp_proc_chain, db_dict=None):  # noqa: ARG001
-        record.append(
-            {"outputs": dsp_proc_chain["outputs"].copy(), "n": len(tb_data)}
-        )
+        record.append({"outputs": dsp_proc_chain["outputs"].copy(), "n": len(tb_data)})
         if dsp_proc_chain["outputs"] == [fft_field]:
             vals = tb_data["waveform"].values.nda.astype(np.float32)
             return {fft_field: SimpleNamespace(values=SimpleNamespace(nda=vals))}

--- a/tests/pargen/test_noise_optimization.py
+++ b/tests/pargen/test_noise_optimization.py
@@ -27,7 +27,9 @@ def test_noise_optimization_does_not_mutate_outputs(monkeypatch):
         noise_optimization_module, "simple_gaussian_fit", fake_simple_gaussian_fit
     )
 
-    dsp_proc_chain = {"outputs": ["wf_psd", "energy"]}
+    # extra unread outputs (wf_presum, bl_mean) and two optimisation entries
+    # sharing one ene_str: the grid runs must request exactly ["energy"]
+    dsp_proc_chain = {"outputs": ["wf_psd", "energy", "wf_presum", "bl_mean"]}
     noise_optimization_module.noise_optimization(
         tb_data=object(),
         dsp_proc_chain=dsp_proc_chain,
@@ -39,10 +41,15 @@ def test_noise_optimization_does_not_mutate_outputs(monkeypatch):
             "step_val": 1,
             "optimization": {
                 "trap": {
-                    "dict_str": "trap",
+                    "dict_str": "etrap",
                     "filter_par": "rise",
                     "ene_str": "energy",
-                }
+                },
+                "cusp": {
+                    "dict_str": "cusp",
+                    "filter_par": "sigma",
+                    "ene_str": "energy",
+                },
             },
             "perform_fit": True,
             "dx": 1,
@@ -52,7 +59,7 @@ def test_noise_optimization_does_not_mutate_outputs(monkeypatch):
         _lh5_path="",
     )
 
-    assert dsp_proc_chain["outputs"] == ["wf_psd", "energy"]
+    assert dsp_proc_chain["outputs"] == ["wf_psd", "energy", "wf_presum", "bl_mean"]
     assert outputs_seen == [["energy"], ["energy"]]
 
 

--- a/tests/pargen/test_noise_optimization.py
+++ b/tests/pargen/test_noise_optimization.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
-import matplotlib
+import matplotlib as mpl
 import numpy as np
 import pytest
 from lgdo import Table, WaveformTable
 
 from pygama.pargen import noise_optimization as noise_optimization_module
 
-matplotlib.use("Agg", force=True)
+mpl.use("Agg", force=True)
 
 
 def test_noise_optimization_does_not_mutate_outputs(monkeypatch):

--- a/tests/pargen/test_noise_optimization.py
+++ b/tests/pargen/test_noise_optimization.py
@@ -2,9 +2,14 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import matplotlib
 import numpy as np
+import pytest
+from lgdo import Table, WaveformTable
 
 from pygama.pargen import noise_optimization as noise_optimization_module
+
+matplotlib.use("Agg", force=True)
 
 
 def test_noise_optimization_does_not_mutate_outputs(monkeypatch):
@@ -49,3 +54,163 @@ def test_noise_optimization_does_not_mutate_outputs(monkeypatch):
 
     assert dsp_proc_chain["outputs"] == ["wf_psd", "energy"]
     assert outputs_seen == [["energy"], ["energy"]]
+
+
+def _waveform_table(n_rows=10, wf_len=8):
+    rng = np.random.default_rng(1)
+    return Table(
+        col_dict={
+            "waveform": WaveformTable(
+                values=rng.normal(size=(n_rows, wf_len)).astype(np.float32),
+                dt=16.0,
+                dt_units="ns",
+            )
+        }
+    )
+
+
+def _fake_psd_run_one_dsp(record, fft_field="wf_psd"):
+    """A run_one_dsp stand-in whose 'PSD' is the batch's own waveform values."""
+
+    def fake(tb_data, dsp_proc_chain, db_dict=None):  # noqa: ARG001
+        record.append(
+            {"outputs": dsp_proc_chain["outputs"].copy(), "n": len(tb_data)}
+        )
+        if dsp_proc_chain["outputs"] == [fft_field]:
+            vals = tb_data["waveform"].values.nda.astype(np.float32)
+            return {fft_field: SimpleNamespace(values=SimpleNamespace(nda=vals))}
+        return {"energy": SimpleNamespace(nda=np.array([1.0, 2.0, 3.0]))}
+
+    return fake
+
+
+def test_batched_mean_psd_matches_the_full_mean(monkeypatch):
+    tb_data = _waveform_table(n_rows=10)
+    calls = []
+    monkeypatch.setattr(
+        noise_optimization_module, "run_one_dsp", _fake_psd_run_one_dsp(calls)
+    )
+
+    psd = noise_optimization_module._batched_mean_psd(
+        tb_data, {"outputs": ["wf_psd", "energy"]}, {}, "wf_psd", batch_size=3
+    )
+
+    full_mean = tb_data["waveform"].values.nda.mean(axis=0, dtype=np.float64)
+    assert np.allclose(psd, full_mean, rtol=1e-12)
+    # 10 rows in batches of 3 -> 4 calls of sizes 3,3,3,1
+    assert [c["n"] for c in calls] == [3, 3, 3, 1]
+    # the plot run must only request the fft field
+    assert all(c["outputs"] == ["wf_psd"] for c in calls)
+
+
+def test_batched_mean_psd_rejects_empty_input(monkeypatch):
+    monkeypatch.setattr(
+        noise_optimization_module, "run_one_dsp", _fake_psd_run_one_dsp([])
+    )
+    with pytest.raises(ValueError, match="no waveforms"):
+        noise_optimization_module._batched_mean_psd(
+            _waveform_table(n_rows=0), {"outputs": ["wf_psd"]}, {}, "wf_psd", 3
+        )
+
+
+def test_display_path_batches_and_does_not_mutate(monkeypatch):
+    tb_data = _waveform_table(n_rows=10)
+    calls = []
+    rng = np.random.default_rng(2)
+
+    def fake_run_one_dsp(tb, dsp_proc_chain, db_dict=None):  # noqa: ARG001
+        calls.append({"outputs": dsp_proc_chain["outputs"].copy(), "n": len(tb)})
+        if dsp_proc_chain["outputs"] == ["wf_psd"]:
+            vals = tb["waveform"].values.nda.astype(np.float32)
+            return {"wf_psd": SimpleNamespace(values=SimpleNamespace(nda=vals))}
+        return {"energy": SimpleNamespace(nda=rng.normal(5, 1, size=200))}
+
+    monkeypatch.setattr(noise_optimization_module, "run_one_dsp", fake_run_one_dsp)
+
+    dsp_proc_chain = {"outputs": ["wf_psd", "energy"]}
+    res_dict, plot_dict = noise_optimization_module.noise_optimization(
+        tb_data=tb_data,
+        dsp_proc_chain=dsp_proc_chain,
+        par_dsp={},
+        opt_dict={
+            "start": 1,
+            "stop": 3,
+            "step": 1,
+            "step_val": 1,
+            "optimization": {
+                "trap": {"dict_str": "trap", "filter_par": "rise", "ene_str": "energy"}
+            },
+            "perform_fit": False,
+            "percentile_low": 10,
+            "percentile_high": 90,
+            "dx": 1,
+            "fit_deg": 1,
+            "n_bootstrap_samples": 2,
+            "plot_range": (0, 10),
+            "fft_batch_size": 4,
+        },
+        _lh5_path="",
+        display=1,
+    )
+
+    # fft plot ran in batches of <= fft_batch_size, requesting only wf_psd
+    fft_calls = [c for c in calls if c["outputs"] == ["wf_psd"]]
+    assert [c["n"] for c in fft_calls] == [4, 4, 2]
+    # the plotted psd is the mean over all waveforms
+    assert np.allclose(
+        plot_dict["nopt"]["fft"]["psd"],
+        tb_data["waveform"].values.nda.mean(axis=0, dtype=np.float64),
+        rtol=1e-12,
+    )
+    assert plot_dict["nopt"]["fft"]["fig"] is not None
+    assert len(plot_dict["nopt"]["fft"]["frequency"]) == len(
+        plot_dict["nopt"]["fft"]["psd"]
+    )
+    # grid-search runs saw outputs without the fft field
+    grid_calls = [c for c in calls if c["outputs"] != ["wf_psd"]]
+    assert all(c["outputs"] == ["energy"] for c in grid_calls)
+    # and the caller's chain is unmutated
+    assert dsp_proc_chain["outputs"] == ["wf_psd", "energy"]
+    assert "trap" in res_dict
+
+
+def test_fft_batch_size_must_be_positive(monkeypatch):
+    monkeypatch.setattr(
+        noise_optimization_module, "run_one_dsp", _fake_psd_run_one_dsp([])
+    )
+    with pytest.raises(ValueError, match="fft_batch_size must be positive"):
+        noise_optimization_module.noise_optimization(
+            tb_data=_waveform_table(),
+            dsp_proc_chain={"outputs": ["wf_psd", "energy"]},
+            par_dsp={},
+            opt_dict={
+                "start": 1,
+                "stop": 3,
+                "step": 1,
+                "step_val": 1,
+                "optimization": {},
+                "perform_fit": True,
+                "fit_deg": 1,
+                "fft_batch_size": 0,
+            },
+            _lh5_path="",
+            display=1,
+        )
+
+
+def test_custom_fft_field_is_respected(monkeypatch):
+    tb_data = _waveform_table(n_rows=6)
+    calls = []
+    monkeypatch.setattr(
+        noise_optimization_module,
+        "run_one_dsp",
+        _fake_psd_run_one_dsp(calls, fft_field="my_psd"),
+    )
+
+    psd = noise_optimization_module._batched_mean_psd(
+        tb_data, {"outputs": ["my_psd", "energy"]}, {}, "my_psd", batch_size=4
+    )
+    assert np.allclose(
+        psd, tb_data["waveform"].values.nda.mean(axis=0, dtype=np.float64)
+    )
+    assert all(c["outputs"] == ["my_psd"] for c in calls)

--- a/tests/pargen/test_noise_optimization.py
+++ b/tests/pargen/test_noise_optimization.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import numpy as np
+
+from pygama.pargen import noise_optimization as noise_optimization_module
+
+
+def test_noise_optimization_does_not_mutate_outputs(monkeypatch):
+    outputs_seen = []
+
+    def fake_run_one_dsp(_tb_data, dsp_proc_chain, db_dict=None):  # noqa: ARG001
+        outputs_seen.append(dsp_proc_chain["outputs"].copy())
+        return {"energy": SimpleNamespace(nda=np.array([1.0, 2.0, 3.0]))}
+
+    def fake_simple_gaussian_fit(_energies, dx):
+        return {"fom": dx, "fom_err": 0.1}
+
+    monkeypatch.setattr(noise_optimization_module, "run_one_dsp", fake_run_one_dsp)
+    monkeypatch.setattr(
+        noise_optimization_module, "simple_gaussian_fit", fake_simple_gaussian_fit
+    )
+
+    dsp_proc_chain = {"outputs": ["wf_psd", "energy"]}
+    noise_optimization_module.noise_optimization(
+        tb_data=object(),
+        dsp_proc_chain=dsp_proc_chain,
+        par_dsp={},
+        opt_dict={
+            "start": 1,
+            "stop": 3,
+            "step": 1,
+            "step_val": 1,
+            "optimization": {
+                "trap": {
+                    "dict_str": "trap",
+                    "filter_par": "rise",
+                    "ene_str": "energy",
+                }
+            },
+            "perform_fit": True,
+            "dx": 1,
+            "fit_deg": 1,
+            "n_bootstrap_samples": 2,
+        },
+        _lh5_path="",
+    )
+
+    assert dsp_proc_chain["outputs"] == ["wf_psd", "energy"]
+    assert outputs_seen == [["energy"], ["energy"]]


### PR DESCRIPTION
- [x] Remove fft field when not needed — superseded: the grid-search loop now requests **only** the configured `ene_str` outputs, which drops the fft field implicitly along with every other unread output buffer (most notably `wf_presum`, a waveform-length output of ~160 MB at the production `n_events=10000`, previously reallocated on every grid point).
- [x] Make the fft plot process in batches to reduce memory — the lgdo requirement (`Table`/`WaveformTable` slicing, legend-exp/legend-pydataobj#212) landed in legend-pydataobj v2.0.0, inside the existing `>=2` pin, so no pin change was needed.

Also in this PR: the FFT plot's frequency axis previously used `wf_presum.dt`, but the PSD is computed on `wf_blsub_full`, which derives from the full `waveform` — the axis was off by the presum factor. It now uses `tb_data['waveform'].dt`.