### PR TITLE
drop python 3.10 support and modernize license metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools>=61.2",
+    "setuptools>=77",
     "setuptools_scm[toml]>=7",
 ]
 build-backend = "setuptools.build_meta"
@@ -15,11 +15,12 @@ maintainers = [
     { name = "The LEGEND collaboration" },
 ]
 readme = "README.md"
+license = "GPL-3.0"
+license-files = ["LICENSE"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     "Operating System :: MacOS",
     "Operating System :: POSIX",
     "Operating System :: Unix",
@@ -90,9 +91,6 @@ pygama = "pygama.cli:pygama_cli"
 [tool.setuptools]
 include-package-data = true
 zip-safe = false
-license-files = [
-    "LICENSE",
-]
 
 [tool.setuptools.package-dir]
 "" = "src"


### PR DESCRIPTION
Updated setuptools version and switch license information to new metadata format.

python 3.10 was already dropped on the conda-forge package. The new license metadata format adresses a deprecation warning that will lead to errors in February 2027. So nothing of this is urgent, feel free to leave it open for some time.

<!---

Before submitting a pull request, please make sure you've read and understood the pygama developer's guide: https://pygama.readthedocs.io/en/latest/developer.html. In particular, do not forget to:

- Conform to our coding conventions
- Update existing or add new tests
- Update existing or add new documentation
- Address any issue reported by GitHub checks

--->
