### PR TITLE
feat(evt): forward LGDO attrs from lower-tier fields to evt columns

### DIFF
--- a/src/pygama/evt/build_evt.py
+++ b/src/pygama/evt/build_evt.py
@@ -70,6 +70,13 @@ def build_evt(
         - ``dtype`` defines the NumPy data type of the resulting data.
         - ``initial`` defines the initial/default value. Useful with some types
           of aggregators.
+        - ``lgdo_attrs`` defines LGDO attributes to attach to the output column.
+          When ``expression`` references a single lower-tier field (e.g.
+          ``hit.quality_flags``), any LGDO attributes stored on that source
+          field (such as ``bit_names``) are automatically forwarded to the evt
+          column. Attributes specified via ``lgdo_attrs`` take precedence over
+          forwarded ones. Forwarding is skipped for ``function`` mode and for
+          expressions that reference more than one field.
 
         For example:
 
@@ -278,6 +285,28 @@ def build_evt_cols(
     ):
         Path(datainfo.evt.file).unlink()
 
+    # Pre-compute source attrs for single-field aggregation operations.
+    # Done once here because attrs are file-level metadata, not per-chunk data.
+    # Excluded: function mode (result is unrelated to the referenced field).
+    lower_tiers = [k for k in datainfo._asdict() if k not in ("tcm", "evt")]
+    all_channels = list(itertools.chain.from_iterable(channels.values()))
+    op_source_attrs = {}
+    for _op_field, _op_v in config["operations"].items():
+        mode = _op_v.get("aggregation_mode", "")
+        if not mode or mode == "function":
+            continue
+        expr_fields = re.findall(
+            rf"({'|'.join(lower_tiers)}).([a-zA-Z_$][\w$]*)",
+            _op_v["expression"],
+        )
+        if len(expr_fields) == 1:
+            _tier_name, _field_name = expr_fields[0]
+            src_attrs = utils.get_lgdo_attrs(
+                datainfo, all_channels, _tier_name, _field_name
+            )
+            if src_attrs:
+                op_source_attrs[_op_field] = src_attrs
+
     for tcm_lh5 in lh5.LH5Iterator(
         datainfo.tcm.file,
         datainfo.tcm.group,
@@ -357,7 +386,11 @@ def build_evt_cols(
                     channel_mapping=channel_mapping,
                 )
 
-                # add attribute if present
+                # forward attrs pre-computed from the source lower-tier field
+                if field in op_source_attrs:
+                    obj.attrs |= op_source_attrs[field]
+
+                # add attribute if present (user attrs override source attrs)
                 if "lgdo_attrs" in v:
                     obj.attrs |= v["lgdo_attrs"]
 

--- a/src/pygama/evt/build_evt.py
+++ b/src/pygama/evt/build_evt.py
@@ -296,7 +296,7 @@ def build_evt_cols(
         if not mode or mode == "function":
             continue
         expr_fields = re.findall(
-            rf"({'|'.join(lower_tiers)}).([a-zA-Z_$][\w$]*)",
+            rf"({'|'.join(re.escape(t) for t in lower_tiers)})\.([a-zA-Z_$][\w$]*)",
             _op_v["expression"],
         )
         if len(expr_fields) == 1:

--- a/src/pygama/evt/utils.py
+++ b/src/pygama/evt/utils.py
@@ -76,17 +76,14 @@ def get_lgdo_attrs(datainfo, channels, tier_name, field):
     if tier is None or tier.file is None:
         return {}
 
-    try:
-        with h5py.File(tier.file, "r") as f:
-            for ch in channels:
-                path = f"{ch.replace('/', '')}/{tier.group}/{field}"
-                if path not in f:
-                    continue
-                attrs = dict(f[path].attrs)
-                attrs.pop("datatype", None)
-                return attrs
-    except OSError:
-        pass
+    with h5py.File(tier.file, "r") as f:
+        for ch in channels:
+            path = f"{ch.replace('/', '')}/{tier.group}/{field}"
+            if path not in f:
+                continue
+            attrs = dict(f[path].attrs)
+            attrs.pop("datatype", None)
+            return attrs
     return {}
 
 

--- a/src/pygama/evt/utils.py
+++ b/src/pygama/evt/utils.py
@@ -9,6 +9,7 @@ import re
 from collections import namedtuple
 
 import awkward as ak
+import h5py
 import lh5
 import numpy as np
 from numpy.typing import NDArray
@@ -53,6 +54,41 @@ def copy_lgdo_attrs(obj):
     attrs = copy.copy(obj.attrs)
     attrs.pop("datatype")
     return attrs
+
+
+def get_lgdo_attrs(datainfo, channels, tier_name, field):
+    """Read LGDO attrs for a field from the first available channel in the LH5 file.
+
+    Uses a metadata-only h5py read — no data is loaded from disk.
+
+    Parameters
+    ----------
+    datainfo
+        input/output LH5 datainfo.
+    channels
+        flat list of channel strings (e.g. ``["ch1000000", "ch1000001"]``).
+    tier_name
+        name of the tier (e.g. ``"hit"``).
+    field
+        field name within the tier table.
+    """
+    tier = datainfo._asdict().get(tier_name)
+    if tier is None or tier.file is None:
+        return {}
+
+    for ch in channels:
+        ch_key = ch.replace("/", "")
+        path = f"{ch_key}/{tier.group}/{field}"
+        try:
+            with h5py.File(tier.file, "r") as f:
+                if path not in f:
+                    continue
+                attrs = dict(f[path].attrs)
+                attrs.pop("datatype", None)
+                return attrs
+        except Exception:
+            continue
+    return {}
 
 
 def get_tcm_id_by_pattern(table_id_fmt: str, ch: str) -> int:

--- a/src/pygama/evt/utils.py
+++ b/src/pygama/evt/utils.py
@@ -76,18 +76,17 @@ def get_lgdo_attrs(datainfo, channels, tier_name, field):
     if tier is None or tier.file is None:
         return {}
 
-    for ch in channels:
-        ch_key = ch.replace("/", "")
-        path = f"{ch_key}/{tier.group}/{field}"
-        try:
-            with h5py.File(tier.file, "r") as f:
+    try:
+        with h5py.File(tier.file, "r") as f:
+            for ch in channels:
+                path = f"{ch.replace('/', '')}/{tier.group}/{field}"
                 if path not in f:
                     continue
                 attrs = dict(f[path].attrs)
                 attrs.pop("datatype", None)
                 return attrs
-        except Exception:
-            continue
+    except OSError:
+        pass
     return {}
 
 

--- a/tests/evt/test_build_evt.py
+++ b/tests/evt/test_build_evt.py
@@ -397,6 +397,72 @@ def test_description_attr(files_config_nowrite):
     )
 
 
+@pytest.fixture
+def bitmask_files_config(tmp_path):
+    """Minimal hit + TCM LH5 pair where the hit field carries bit_names attrs."""
+    hit_file = str(tmp_path / "hit.lh5")
+    tcm_file = str(tmp_path / "tcm.lh5")
+
+    # 3 events, 1 channel (ch1000000 → table_id 1000000), 1 hit each
+    n = 3
+    flags = Array(np.array([0b001, 0b010, 0b101], dtype=np.uint8))
+    flags.attrs["bit_names"] = "rt,t0,tmax"
+    energy = Array(np.array([10.0, 20.0, 30.0], dtype=np.float32))
+    lh5.write(
+        Table(col_dict={"flags": flags, "energy": energy}), "ch1000000/hit", hit_file
+    )
+
+    # TCM: each event has exactly one hit from ch1000000
+    table_key = VectorOfVectors(
+        flattened_data=Array(np.full(n, 1000000, dtype=np.int32)),
+        cumulative_length=Array(np.arange(1, n + 1, dtype=np.uint32)),
+    )
+    row_in_table = VectorOfVectors(
+        flattened_data=Array(np.arange(n, dtype=np.int32)),
+        cumulative_length=Array(np.arange(1, n + 1, dtype=np.uint32)),
+    )
+    tcm_table = Table(col_dict={"table_key": table_key, "row_in_table": row_in_table})
+    lh5.write(tcm_table, "hardware_tcm_1", tcm_file)
+
+    return {
+        "tcm": (tcm_file, "hardware_tcm_1"),
+        "hit": (hit_file, "hit", "ch{}"),
+        "evt": (None, "evt"),
+    }
+
+
+def test_source_attrs_forwarding(bitmask_files_config):
+    config = {
+        "channels": {"all": ["ch1000000"]},
+        "outputs": ["flags", "combo", "flags_custom"],
+        "operations": {
+            # single field reference → bit_names forwarded from hit
+            "flags": {
+                "channels": "all",
+                "aggregation_mode": "first_at:hit.energy",
+                "expression": "hit.flags",
+            },
+            # multi-field expression → no forwarding (ambiguous source)
+            "combo": {
+                "channels": "all",
+                "aggregation_mode": "first_at:hit.energy",
+                "expression": "hit.flags | hit.flags",
+            },
+            # user lgdo_attrs override the forwarded source attrs
+            "flags_custom": {
+                "channels": "all",
+                "aggregation_mode": "first_at:hit.energy",
+                "expression": "hit.flags",
+                "lgdo_attrs": {"bit_names": "custom_a,custom_b"},
+            },
+        },
+    }
+    evt = build_evt(bitmask_files_config, config)
+    assert evt.flags.attrs.get("bit_names") == "rt,t0,tmax"
+    assert "bit_names" not in evt.combo.attrs
+    assert evt.flags_custom.attrs.get("bit_names") == "custom_a,custom_b"
+
+
 def test_buffered_build_evt(files_config_nowrite):
     evt1 = build_evt(
         files_config_nowrite,

--- a/tests/evt/test_evt_utils.py
+++ b/tests/evt/test_evt_utils.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import lh5
+import numpy as np
+from lgdo import Array
+
 from pygama.evt import utils
 
 
@@ -22,3 +26,28 @@ def test_tier_data_tuple():
     assert files.hit.group == "g3"
     assert files.evt.file == "f4"
     assert files.evt.group == "g4"
+
+
+def test_get_lgdo_attrs(tmp_path):
+    hit_file = str(tmp_path / "hit.lh5")
+    arr = Array(np.array([0b01, 0b10], dtype=np.uint8))
+    arr.attrs["bit_names"] = "low,high"
+    lh5.write(arr, "ch1000000/hit/flags", hit_file)
+
+    datainfo = utils.make_files_config(
+        {
+            "tcm": (None, "tcm"),
+            "hit": (hit_file, "hit"),
+            "evt": (None, "evt"),
+        }
+    )
+    attrs = utils.get_lgdo_attrs(datainfo, ["ch1000000"], "hit", "flags")
+    assert attrs.get("bit_names") == "low,high"
+    assert "datatype" not in attrs
+
+    # non-existent channel is skipped; valid one still returns attrs
+    attrs = utils.get_lgdo_attrs(datainfo, ["ch9999999", "ch1000000"], "hit", "flags")
+    assert attrs.get("bit_names") == "low,high"
+
+    # unknown tier returns an empty dict rather than raising
+    assert utils.get_lgdo_attrs(datainfo, ["ch1000000"], "dsp", "flags") == {}


### PR DESCRIPTION
## Summary

- When `build_evt` aggregates a lower-tier field via a single-field expression (e.g. `hit.quality_flags`), LGDO attributes stored on the source field — such as `bit_names` written by `build_hit`'s bitmask aggregation — are now automatically forwarded to the evt output column.
- User-specified `lgdo_attrs` in the operation config always take precedence over forwarded attrs.
- Forwarding is skipped for `function` mode (output unrelated to referenced field) and for expressions referencing more than one field (ambiguous source).
- Source attrs are read once per operation before the TCM buffer loop via a metadata-only `h5py` read, so there is no per-chunk I/O overhead.

## Test plan

- [ ] `test_get_lgdo_attrs` in `test_evt_utils.py`: unit-tests the new utility (happy path, graceful channel-skip, unknown-tier fallback)
- [ ] `test_source_attrs_forwarding` in `test_build_evt.py`: integration test covering single-field forwarding, multi-field no-forwarding, and user-override precedence in one `build_evt` call
- [ ] Full `tests/evt/` suite passes