### PR TITLE
fix DOI format in CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,6 +1,6 @@
 cff-version: 1.2.0
 title: pygama
-doi: https://doi.org/10.5281/zenodo.10614246
+doi: 10.5281/zenodo.10614246
 date-released: 2024-02-03
 message: "If you use this software, please cite it as below."
 authors:


### PR DESCRIPTION
otherwise GitHub duplicates the doi.org prefix
