### PR TITLE
Reduce memory usage of queries

### DIFF
--- a/src/pygama/flow/__init__.py
+++ b/src/pygama/flow/__init__.py
@@ -78,7 +78,7 @@ be provided with most dataprods! If you set the environment variable $REFPROD th
 the file will automatically be accessed from the referenced directory!
 """
 
-from .query_runs import query_runs
+from .query_runs import query_runs, list_run_fields
 from .query_meta import query_meta
 from .build_iterator import build_iterator
 from .query_data import query_data
@@ -92,4 +92,5 @@ __all__ = [
     "query_hist",
     "query_evt",
     "build_iterator",
+    "list_run_fields",
 ]

--- a/src/pygama/flow/build_iterator.py
+++ b/src/pygama/flow/build_iterator.py
@@ -7,6 +7,7 @@ import awkward as ak
 import numpy as np
 import pandas as pd
 from dbetto import Props
+from pygama.flow.query_runs import list_run_fields
 from . import query_meta
 from .utils import format_vars, parse_query_paths
 from lh5 import LH5Iterator
@@ -105,6 +106,8 @@ def build_iterator(
 
         # identify fields we need to get from the metadata
         field_names = [parse_query_paths(f, fullmatch=True) for f in fields]
+        run_fields = list_run_fields(dataflow_config=df_config, tiers=tiers, cycle_def=query_meta_kwargs.get("cycle_def"))
+        run_fields = {f for f, _, path in field_names if path in run_fields}
         meta_fields = {f for f, _, path in field_names if path[0] == "@"}
 
         if tables is None:
@@ -123,13 +126,12 @@ def build_iterator(
             gp_fields[tier] = fields
 
         run_data, alias_map = query_meta(
-            meta_fields,
+            meta_fields | run_fields | {"cycle", "relpath"},
             runs,
             channels,
             dataflow_config=df_config,
             tiers=tiers,
             group_chans=True,
-            return_query_vals=True,
             return_alias_map=True,
             progress=status,
             **query_meta_kwargs,

--- a/src/pygama/flow/query_runs.py
+++ b/src/pygama/flow/query_runs.py
@@ -243,6 +243,67 @@ def query_runs(
             os.chdir(cwd)
 
 
+def list_run_fields(
+    dataflow_config: Path | str | Mapping = "$REFPROD/dataflow-config.yaml",
+    cycle_def: str | None = None,
+    tiers: str | Collection[str] | Mapping[str, str] | None = None,
+) -> list[str]:
+    """
+    List the fields that are available to :meth:`query_runs`.
+
+    Parameters
+    ----------
+    dataflow_config
+        config file of reference production. If not provided, use the environment
+        variable ``$REFPROD`` as a directory, and find file ``dataflow-config.yaml``
+
+    cycle_def
+        hyphen-separated names of fields in cycle names; names will be used for columns.
+        By default get from dataflow-config.
+
+        Examples:
+        - ``experiment-period-run-datatype-cycle`` for a L200 cycle, e.g. ``l200-p03-r001-cal-19720101T000000Z``
+        - ``experiment-chan-datatype-run-starttime`` for a Hades cycle, e.g. ``char_data-V05268A-th_HS2_lat_psa-r001-20201008T122118Z``
+
+    tiers
+        tiers used to find files. First tier in list is used to walk through
+        directories to populate run DB. Remaining tiers are checked for presence of
+        cycles; a cycle is only added if it exists for each tier. File relative path
+        for each tier's file is added as a column called ``tier_[t]``. Can provide:
+        - Mapping from tier name to path to root of tier
+        - List of tier names/single tier name. Paths will be found in ``dataflow_config["paths"]``
+        - ``None``: read from ``dataflow_config``; if ``tiers`` entry not found, use ``"raw"``
+    """
+    if isinstance(dataflow_config, (Path, str)):
+        df_config = Props.read_from(
+            os.path.expandvars(dataflow_config), subst_pathvar=True
+        )
+    elif isinstance(dataflow_config, Mapping):
+        df_config = dataflow_config
+    else:
+        msg = "dataflow_config must be a str, Path, or Mapping"
+        raise ValueError(msg)
+    df_paths = df_config.get("paths")
+    query_config = df_config.get("query", {})
+
+    if cycle_def is None:
+        if "cycle_def" not in query_config:
+            msg = "cycle_def must be provided either as kwarg or in dataflow_config"
+            raise ValueError(msg)
+        cycle_def = query_config["cycle_def"]
+
+    # turn tiers into list of tier-name/path pairs
+    if tiers is None:
+        tiers = query_config.get("tiers", ["raw"])
+    if isinstance(tiers, str):
+        tiers = [tiers]
+    if isinstance(tiers, Mapping):
+        tiers = [(f"tier_{t}", p) for t, p in tiers.items()]
+    else:
+        tiers = [(f"tier_{t}", df_paths[f"tier_{t}"]) for t in tiers]
+
+    return {"relpath", "cycle"} | set(cycle_def.split("-")) | set(t[0] for t in tiers)
+
 def _get_run_records_loop(
     files: list[str],
     relpath: str,

--- a/tests/flow/test_query_runs.py
+++ b/tests/flow/test_query_runs.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from pygama.flow import list_run_fields
+
+
+def test_list_run_fields():
+    dataflow_config = {
+        "paths": {
+            "tier_raw": "/tmp/raw",
+            "tier_dsp": "/tmp/dsp",
+        },
+        "query": {
+            "cycle_def": "experiment-period-run-datatype",
+            "tiers": ["raw", "dsp"],
+        },
+    }
+
+    fields = list_run_fields(dataflow_config=dataflow_config)
+    assert fields == {
+        "relpath",
+        "cycle",
+        "experiment",
+        "period",
+        "run",
+        "datatype",
+        "tier_raw",
+        "tier_dsp",
+    }
+
+    fields = list_run_fields(
+        dataflow_config=dataflow_config, tiers=["raw"], cycle_def="experiment-run"
+    )
+    assert fields == {
+        "relpath",
+        "cycle",
+        "experiment",
+        "run",
+        "tier_raw",
+    }


### PR DESCRIPTION
When building an iterator for queries, it was taking all metadata + run parameters and joining them to the table. This started causing memory problems with the addition of the full paths of different tiers (and was non-ideal before that). Now, only propagate necessary fields into the iterator.
- Added `list_run_fields` to get list of available run fields for a given config
- Only add fields to iterator if they are in the fields arg for run + parameter values