### PR TITLE
Enforce fit_range and data_mask in survival fraction calculations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # New additions go at the top!
+.vscode
 *.c
 .DS_Store
 *.npz

--- a/src/pygama/pargen/energy_cal.py
+++ b/src/pygama/pargen/energy_cal.py
@@ -2595,9 +2595,10 @@ def unbinned_staged_energy_fit(
     if gof_range is None:
         gof_range = fit_range
 
+    energy = np.asarray(energy)
+
     # enforce fit_range on the data that enters the likelihood. This also drops NaNs.
     energy = energy[(energy >= fit_range[0]) & (energy <= fit_range[1])]
-
     if bin_width is None:
         init_bin_width = (
             2

--- a/src/pygama/pargen/energy_cal.py
+++ b/src/pygama/pargen/energy_cal.py
@@ -2600,7 +2600,9 @@ def unbinned_staged_energy_fit(
     # enforce fit_range on the data that enters the likelihood. This also drops NaNs.
     energy = energy[(energy >= fit_range[0]) & (energy <= fit_range[1])]
     if energy.size == 0:
-        msg = f"No events remain after applying fit_range={fit_range}; cannot perform fit"
+        msg = (
+            f"No events remain after applying fit_range={fit_range}; cannot perform fit"
+        )
         raise ValueError(msg)
 
     if bin_width is None:

--- a/src/pygama/pargen/energy_cal.py
+++ b/src/pygama/pargen/energy_cal.py
@@ -2595,6 +2595,9 @@ def unbinned_staged_energy_fit(
     if gof_range is None:
         gof_range = fit_range
 
+    # enforce fit_range on the data that enters the likelihood. This also drops NaNs.
+    energy = energy[(energy >= fit_range[0]) & (energy <= fit_range[1])]
+
     if bin_width is None:
         init_bin_width = (
             2

--- a/src/pygama/pargen/energy_cal.py
+++ b/src/pygama/pargen/energy_cal.py
@@ -2599,6 +2599,10 @@ def unbinned_staged_energy_fit(
 
     # enforce fit_range on the data that enters the likelihood. This also drops NaNs.
     energy = energy[(energy >= fit_range[0]) & (energy <= fit_range[1])]
+    if energy.size == 0:
+        msg = f"No events remain after applying fit_range={fit_range}; cannot perform fit"
+        raise ValueError(msg)
+
     if bin_width is None:
         init_bin_width = (
             2

--- a/src/pygama/pargen/survival_fractions.py
+++ b/src/pygama/pargen/survival_fractions.py
@@ -524,20 +524,29 @@ def get_survival_fraction(
     if fit_range is None:
         fit_range = (np.nanmin(energy), np.nanmax(energy))
 
+    # enforce fit_range on the data that enters the likelihood by folding it into
+    # data_mask, so both the passing and failing selections below are restricted
+    # to the fit window.
+    data_mask = data_mask & (energy >= fit_range[0]) & (energy <= fit_range[1])
+
     nan_idxs = np.isnan(cut_param)
     if high_cut is not None:
-        idxs = (cut_param > cut_val) & (cut_param < high_cut) & data_mask
+        passing_cut = (cut_param > cut_val) & (cut_param < high_cut)
     elif mode == "greater":
-        idxs = (cut_param > cut_val) & data_mask
+        passing_cut = cut_param > cut_val
     elif mode == "less":
-        idxs = (cut_param < cut_val) & data_mask
+        passing_cut = cut_param < cut_val
     else:
         msg = "mode not recognised"
         raise ValueError(msg)
 
+    # apply data_mask symmetrically to both selections.
+    pass_idxs = passing_cut & data_mask
+    fail_idxs = (~passing_cut) & data_mask
+
     if pars is None:
         (pars, _errs, _cov, _, func, _, _, _) = pgc.unbinned_staged_energy_fit(
-            energy,
+            energy[(~nan_idxs) & data_mask],
             func,
             guess_func=energy_guess,
             bounds_func=get_bounds,
@@ -548,7 +557,7 @@ def get_survival_fraction(
     guess_pars_surv = copy.deepcopy(pars)
 
     # add update guess here for n_sig and n_bkg
-    guess_pars_surv = update_guess(func, guess_pars_surv, energy[(~nan_idxs) & (idxs)])
+    guess_pars_surv = update_guess(func, guess_pars_surv, energy[(~nan_idxs) & (pass_idxs)])
 
     parguess = {
         "x_lo": pars["x_lo"],
@@ -577,12 +586,12 @@ def get_survival_fraction(
 
     if func == hpge_peak:
         lh = cost.ExtendedUnbinnedNLL(
-            energy[(~nan_idxs) & (idxs)], pass_pdf_hpge
-        ) + cost.ExtendedUnbinnedNLL(energy[(~nan_idxs) & (~idxs)], fail_pdf_hpge)
+            energy[(~nan_idxs) & (pass_idxs)], pass_pdf_hpge
+        ) + cost.ExtendedUnbinnedNLL(energy[(~nan_idxs) & (fail_idxs)], fail_pdf_hpge)
     elif func == gauss_on_step:
         lh = cost.ExtendedUnbinnedNLL(
-            energy[(~nan_idxs) & (idxs)], pass_pdf_gos
-        ) + cost.ExtendedUnbinnedNLL(energy[(~nan_idxs) & (~idxs)], fail_pdf_gos)
+            energy[(~nan_idxs) & (pass_idxs)], pass_pdf_gos
+        ) + cost.ExtendedUnbinnedNLL(energy[(~nan_idxs) & (fail_idxs)], fail_pdf_gos)
 
     else:
         msg = "Unknown func"
@@ -608,9 +617,9 @@ def get_survival_fraction(
     if display > 1:
         _fig, (ax1, ax2) = plt.subplots(1, 2)
         bins = np.arange(fit_range[0], fit_range[1], 1)
-        ax1.hist(energy[(~nan_idxs) & (idxs)], bins=bins, histtype="step")
+        ax1.hist(energy[(~nan_idxs) & (pass_idxs)], bins=bins, histtype="step")
 
-        ax2.hist(energy[(~nan_idxs) & (~idxs)], bins=bins, histtype="step")
+        ax2.hist(energy[(~nan_idxs) & (fail_idxs)], bins=bins, histtype="step")
 
         if func == hpge_peak:
             ax1.plot(bins, pass_pdf_hpge(bins, **m.values.to_dict())[1])  # noqa: PD011
@@ -781,12 +790,15 @@ def compton_sf(
     if not isinstance(cut_param, np.ndarray):
         cut_param = np.array(cut_param)
 
+    # restrict to the data_mask population
+    cut_param = cut_param[data_mask]
+
     if high_cut_val is not None:
-        mask = (cut_param > low_cut_val) & (cut_param < high_cut_val) & data_mask
+        mask = (cut_param > low_cut_val) & (cut_param < high_cut_val)
     elif mode == "greater":
-        mask = (cut_param > low_cut_val) & data_mask
+        mask = cut_param > low_cut_val
     elif mode == "less":
-        mask = (cut_param < low_cut_val) & data_mask
+        mask = cut_param < low_cut_val
     else:
         msg = "mode not recognised"
         raise ValueError(msg)

--- a/src/pygama/pargen/survival_fractions.py
+++ b/src/pygama/pargen/survival_fractions.py
@@ -527,8 +527,8 @@ def get_survival_fraction(
     # enforce fit_range on the data that enters the likelihood by folding it into
     # data_mask, so both the passing and failing selections below are restricted
     # to the fit window.
+    data_mask = np.asarray(data_mask, dtype=bool)
     data_mask = data_mask & (energy >= fit_range[0]) & (energy <= fit_range[1])
-
     nan_idxs = np.isnan(cut_param)
     if high_cut is not None:
         passing_cut = (cut_param > cut_val) & (cut_param < high_cut)

--- a/src/pygama/pargen/survival_fractions.py
+++ b/src/pygama/pargen/survival_fractions.py
@@ -557,7 +557,9 @@ def get_survival_fraction(
     guess_pars_surv = copy.deepcopy(pars)
 
     # add update guess here for n_sig and n_bkg
-    guess_pars_surv = update_guess(func, guess_pars_surv, energy[(~nan_idxs) & (pass_idxs)])
+    guess_pars_surv = update_guess(
+        func, guess_pars_surv, energy[(~nan_idxs) & (pass_idxs)]
+    )
 
     parguess = {
         "x_lo": pars["x_lo"],

--- a/src/pygama/pargen/survival_fractions.py
+++ b/src/pygama/pargen/survival_fractions.py
@@ -789,6 +789,10 @@ def compton_sf(
     if data_mask is None:
         data_mask = np.full(len(cut_param), True, dtype=bool)
 
+    if np.sum(data_mask) == 0:
+        msg = "data_mask selects zero events; cannot compute survival fraction"
+        raise ValueError(msg)
+
     if not isinstance(cut_param, np.ndarray):
         cut_param = np.array(cut_param)
 

--- a/src/pygama/pargen/survival_fractions.py
+++ b/src/pygama/pargen/survival_fractions.py
@@ -789,6 +789,7 @@ def compton_sf(
     if data_mask is None:
         data_mask = np.full(len(cut_param), True, dtype=bool)
 
+    data_mask = np.asarray(data_mask, dtype=bool)
     if np.sum(data_mask) == 0:
         msg = "data_mask selects zero events; cannot compute survival fraction"
         raise ValueError(msg)

--- a/tests/pargen/test_survival_fractions.py
+++ b/tests/pargen/test_survival_fractions.py
@@ -15,8 +15,12 @@ def test_compton_sf_data_mask_restricts_population():
     diluting the survival fraction.
     """
     # First four events are inside the mask; three of them pass (>0).
-    cut_param = np.array([5.0, 5.0, 5.0, -5.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0])
-    data_mask = np.array([True, True, True, True, False, False, False, False, False, False])
+    cut_param = np.array(
+        [5.0, 5.0, 5.0, -5.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0]
+    )
+    data_mask = np.array(
+        [True, True, True, True, False, False, False, False, False, False]
+    )
 
     result = compton_sf(cut_param, low_cut_val=0.0, mode="greater", data_mask=data_mask)
 

--- a/tests/pargen/test_survival_fractions.py
+++ b/tests/pargen/test_survival_fractions.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from pygama.math.distributions import gauss_on_step
+from pygama.pargen.survival_fractions import compton_sf, get_survival_fraction
+
+
+def test_compton_sf_data_mask_restricts_population():
+    """``data_mask`` must restrict both numerator and denominator.
+
+    Regression test for the bug where ``data_mask`` was applied to the
+    passing count but the total was left as the full, unmasked length,
+    diluting the survival fraction.
+    """
+    # First four events are inside the mask; three of them pass (>0).
+    cut_param = np.array([5.0, 5.0, 5.0, -5.0, 100.0, 100.0, 100.0, 100.0, 100.0, 100.0])
+    data_mask = np.array([True, True, True, True, False, False, False, False, False, False])
+
+    result = compton_sf(cut_param, low_cut_val=0.0, mode="greater", data_mask=data_mask)
+
+    # 3 of 4 masked-in events survive -> 75 %, independent of the six
+    # masked-out events (which would drag it to 90 % under the old bug).
+    assert result["sf"] == pytest.approx(75.0)
+    assert result["sf_err"] == pytest.approx(100 * np.sqrt((0.75 * 0.25) / 4))
+
+
+def test_compton_sf_masking_equivalent_to_pre_slicing():
+    """Masking is equivalent to counting only the masked sub-population."""
+    rng = np.random.default_rng(1234)
+    cut_param = rng.normal(size=500)
+    data_mask = rng.random(size=500) < 0.6
+
+    masked = compton_sf(cut_param, low_cut_val=0.0, mode="greater", data_mask=data_mask)
+    direct = compton_sf(cut_param[data_mask], low_cut_val=0.0, mode="greater")
+
+    assert masked["sf"] == pytest.approx(direct["sf"])
+    assert masked["sf_err"] == pytest.approx(direct["sf_err"])
+
+
+def _toy_peak(rng, n_sig=800, n_bkg=200, mu=1000.0, sigma=2.0, lo=980.0, hi=1020.0):
+    """Gaussian signal on a flat background, with a correlated cut parameter."""
+    sig_e = rng.normal(mu, sigma, size=n_sig)
+    sig_e = sig_e[(sig_e >= lo) & (sig_e <= hi)]
+    bkg_e = rng.uniform(lo, hi, size=n_bkg)
+    energy = np.concatenate([sig_e, bkg_e])
+
+    # 80 % of signal passes, 50 % of background passes (cut_val = 0, "greater").
+    sig_cut = np.where(rng.random(len(sig_e)) < 0.8, 1.0, -1.0)
+    bkg_cut = np.where(rng.random(len(bkg_e)) < 0.5, 1.0, -1.0)
+    cut_param = np.concatenate([sig_cut, bkg_cut])
+    return energy, cut_param, (lo, hi), mu
+
+
+def _manual_pars(energy, fit_range, peak, sigma=2.0):
+    """A fixed-shape parameter set so the efficiency fit skips the staged fit."""
+    return {
+        "x_lo": fit_range[0],
+        "x_hi": fit_range[1],
+        "mu": peak,
+        "sigma": sigma,
+        "hstep": 0.0,
+        "n_sig": float(np.sum(np.abs(energy - peak) < 3 * sigma)),
+        "n_bkg": float(np.sum(np.abs(energy - peak) >= 3 * sigma)),
+    }
+
+
+def test_get_survival_fraction_excludes_out_of_range_and_masked():
+    """Events outside ``fit_range`` or ``data_mask`` must not affect the fit.
+
+    Regression test for two bugs fixed together: the failing selection used
+    ``~(passing & data_mask)`` (so masked-out events leaked into the failing
+    side), and ``fit_range`` was never enforced on the data entering the
+    likelihood.  With both fixed, appending events that are either outside the
+    fit window or masked out leaves the survival fraction unchanged.
+    """
+    rng = np.random.default_rng(42)
+    energy, cut_param, fit_range, peak = _toy_peak(rng)
+    pars = _manual_pars(energy, fit_range, peak)
+
+    sf_clean, err_clean, _, _ = get_survival_fraction(
+        energy,
+        cut_param,
+        cut_val=0.0,
+        peak=peak,
+        eres_pars=2.0 * 2.355,
+        fit_range=fit_range,
+        pars=pars,
+        func=gauss_on_step,
+    )
+
+    # Pollute the sample with at least as many garbage events as clean ones.
+    # Every garbage event MUST be ignored, via one of two independent routes:
+    #  - out of fit_range (energies far below/above the window), mask True
+    #  - inside the window but masked out
+    n_clean = len(energy)
+    n_out = n_clean // 2 + 1
+    n_masked = n_clean - n_out + 1  # total garbage >= n_clean
+    out_e = rng.uniform(900.0, 960.0, size=n_out)  # below the fit window
+    masked_e = rng.uniform(fit_range[0], fit_range[1], size=n_masked)  # in-window
+    garbage_e = np.concatenate([out_e, masked_e])
+    garbage_cut = np.where(rng.random(len(garbage_e)) < 0.5, 1.0, -1.0)
+    garbage_mask = np.concatenate(
+        [
+            np.ones(n_out, dtype=bool),  # kept in mask, excluded by fit_range
+            np.zeros(n_masked, dtype=bool),  # masked out
+        ]
+    )
+    assert len(garbage_e) >= n_clean
+
+    poll_energy = np.concatenate([energy, garbage_e])
+    poll_cut = np.concatenate([cut_param, garbage_cut])
+    poll_mask = np.concatenate([np.ones(n_clean, dtype=bool), garbage_mask])
+
+    sf_poll, err_poll, _, _ = get_survival_fraction(
+        poll_energy,
+        poll_cut,
+        cut_val=0.0,
+        peak=peak,
+        eres_pars=2.0 * 2.355,
+        fit_range=fit_range,
+        data_mask=poll_mask,
+        pars=pars,
+        func=gauss_on_step,
+    )
+
+    assert sf_poll == pytest.approx(sf_clean, rel=1e-9)
+    assert err_poll == pytest.approx(err_clean, rel=1e-9)


### PR DESCRIPTION
This PR fixes three issues in the survival-fraction code where the fit range and the data mask were not applied consistently to the data.

- Fixes #692: the requested fit range is now actually applied to the data that enters the fit.
- Fixes #694: events removed by the data mask are no longer wrongly counted as "failing" the cut. The passing and failing selections now treat the mask the same way.
- Fixes a similar oversight in `compton_sf`. Previously the data mask affected only the survival fraction numerator, so the result could be off whenever a non-trivial mask was used.

🤖 Generated with the help of [Claude Code](https://claude.com/claude-code) with _my human_ supervision.