### PR TITLE
Re-add the old data loader

### DIFF
--- a/src/pygama/flow/__init__.py
+++ b/src/pygama/flow/__init__.py
@@ -85,6 +85,8 @@ be provided with most dataprods! If you set the environment variable $REFPROD th
 the file will automatically be accessed from the referenced directory!
 """
 
+from .data_loader import DataLoader
+from .file_db import FileDB
 from .query_runs import query_runs, list_run_fields
 from .query_meta import query_meta
 from .build_iterator import build_iterator
@@ -93,6 +95,8 @@ from .query_evt import query_evt
 from .query_hist import query_hist
 
 __all__ = [
+    "DataLoader",
+    "FileDB",
     "query_runs",
     "query_meta",
     "query_data",

--- a/src/pygama/flow/data_loader.py
+++ b/src/pygama/flow/data_loader.py
@@ -1,0 +1,1618 @@
+"""Routines for high-level data loading and skimming."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import string
+from itertools import product
+from keyword import iskeyword
+from typing import Iterator
+
+import lh5
+import numpy as np
+import pandas as pd
+from awkward_pandas import AwkwardDtype
+from dspeed.vis import WaveformBrowser
+from lh5 import LH5Iterator
+from lh5.io.utils import expand_vars
+from lgdo.types import Array, Struct, Table
+from lgdo.types.vovutils import build_cl, explode_arrays
+from tqdm.auto import tqdm
+
+from . import utils
+from .file_db import FileDB
+
+log = logging.getLogger(__name__)
+
+
+class DataLoader:
+    """Facilitate loading of processed data across several tiers.
+
+    Where possible, uses a :class:`FileDB` object so that a user can quickly
+    select a subset of cycle files for interest, and access information at each
+    processing tier.
+
+    Example JSON configuration file:
+
+    .. code-block:: json
+
+        {
+            "filedb": "path/to/filedb.h5"
+            "levels": {
+                "hit": {
+                    "tiers": ["raw", "dsp", "hit"]
+                },
+                "tcm": {
+                    "tiers": ["tcm"],
+                    "parent": "hit",
+                    "child": "evt",
+                    "tcm_cols": {
+                        "child_idx": "coin_idx",
+                        "parent_tb": "table_key",
+                        "parent_idx": "row_in_table"
+                    }
+                },
+                "evt": {
+                    "tiers": ["evt"]
+                }
+            }
+        }
+
+
+    Examples
+    --------
+
+    >>> from pygama.flow import DataLoader
+    >>> dl = DataLoader("loader-config.json")
+    >>> dl.set_files("file_status == 26 and timestamp == '20220716T130443Z'")
+    >>> dl.set_datastreams([3, 6, 8], "ch")
+    >>> dl.set_cuts({"hit": "daqenergy > 1000 and AoE > 3", "evt": "muon_veto == False"})
+    >>> dl.set_output(fmt="pd.DataFrame", columns=["daqenergy", "channel"])
+    >>> data = dl.load()
+
+    Be careful, :meth:`.load()` loads data in memory regardless of its size. If
+    loading a lot of data (e.g. waveforms), you might want to do it in chunks.
+    :class:`.next()` does exactly this:
+
+    >>> for chunk in dl.load():
+    ...   run_my_processing(chunk)
+
+    Advanced Usage:
+
+    >>> from pygama.flow import DataLoader
+    >>> dl = DataLoader("loader-config.json", filedb="filedb-config.json")  # or any value accepted by the FileDB constructor
+    >>> dl.set_files("all")
+    >>> dl.set_datastreams([0], "ch")
+    >>> dl.set_cuts({"hit": "wf_max > 30000"})
+    >>> el = dl.build_entry_list(tcm_level="tcm", mode="any")
+    >>> el.query("hit_table == 20", inplace=True)
+    >>> dl.set_output(fmt="pd.DataFrame", columns=["daqenergy", "channel"])
+    >>> data = dl.load(el)
+    """
+
+    def __init__(
+        self,
+        config: str | dict,
+        filedb: str | dict | FileDB = None,
+        file_query: str = None,
+    ) -> None:
+        """
+        Parameters
+        ----------
+        config
+            configuration dictionary or JSON file, see above for a specification.
+            Accepts strings in the following format: ::
+
+              path/to/config.json[field1/field2/...]]
+
+            to specify the location of the :class:`DataLoader` configuration in
+            the ``config.json`` dictionary, if not at the first level.
+
+        filedb
+            the loader needs a file database. It can be specified in multiple ways:
+
+            - an instance of :class:`.FileDB`.
+            - an LH5 file containing a :class:`.FileDB` (see also
+              :meth:`.FileDB.to_disk`).
+            - a :class:`.FileDB` configuration dictionary or JSON file.
+
+            If ``None``, uses the value of the ``filedb`` key in `config` to
+            instantiate a :class:`.FileDB` object.
+
+        file_query
+            string query that should operate on columns of a :class:`.FileDB`.
+
+        Note
+        ----
+        No data is loaded in memory at this point.
+        """
+        # declare all member variables
+        self.config: dict = None
+        self.filedb: FileDB = None
+        self.file_list: list = None
+        self.table_list = None
+        self.cuts = None
+        self.merge_files = True
+        self.output_format = "lgdo.Table"
+        self.output_columns = None
+        self.aoesa_to_vov = False
+        self.data = None
+
+        # already set FileDB, if supplied
+        if isinstance(filedb, FileDB):
+            self.filedb = filedb
+        elif filedb is not None:
+            self.filedb = FileDB(filedb)
+
+        # load things if available
+        if config is not None:
+            self.set_config(config)
+
+        # set the file_list
+        if file_query is not None:
+            self.file_list = list(self.filedb.df.query(file_query).index)
+
+    def set_config(self, config: dict | str) -> None:
+        """Load configuration dictionary.
+
+        ``$_`` expands to the config file location, if possible, otherwise the
+        current working directory.
+        """
+
+        # define directory for $_ path substitution later in the config
+        # - if a JSON file is provided, it is set to the directory where the
+        #   file is located
+        # - if a dict is provided, it is set to the current directory
+        config_dir = os.getcwd()
+        if isinstance(config, str):
+            # the config string supports this syntax:
+            #  file.json[level1/level2[/...]]
+            # to specify where the data loader config shall be found in the
+            # json file
+            config_loc = None
+            m = re.match(r"^(.*)\[(.*)\]$", config)
+            if m is not None:
+                g = m.groups()
+                config = g[0]
+                config_loc = g[1].split("/")
+
+            # if a directory is provided, try looking for a file named
+            # config.json
+            if os.path.isdir(config):
+                config_dir = config
+                config = os.path.join(config, "config.json")
+            else:
+                config_dir = os.path.dirname(config)
+
+            with open(config) as f:
+                config = json.load(f)
+
+            if config_loc is not None:
+                for loc in config_loc:
+                    config = config[loc]
+
+        # look for info in configuration if FileDB is not set
+        if self.filedb is None:
+            # expand $_ variables
+            value = expand_vars(config["filedb"], substitute={"_": config_dir})
+            self.filedb = FileDB(value)
+
+        if not os.path.isdir(self.filedb.data_dir):
+            raise FileNotFoundError(
+                f"{self.filedb.data_dir} (path to data root directory in FileDB) does not exist"
+            )
+
+        self.config = config
+        self.data_dir = self.filedb.data_dir
+        self.levels = list(config["levels"].keys())
+        self.tiers = {}
+        self.cut_priority = {}
+        self.evts = {}
+        self.tcms = {}
+
+        for level in self.levels:
+            self.tiers[level] = config["levels"][level]["tiers"]
+            # Set cut priority
+            if "parent" in config["levels"][level].keys():  # This level is a TCM
+                parent = config["levels"][level]["parent"]
+                child = config["levels"][level]["child"]
+                self.tcms[level] = config["levels"][level]
+                self.cut_priority[level] = self.cut_priority[parent] + 2
+                self.cut_priority[child] = self.cut_priority[parent] + 1
+                self.evts[child] = {"tcm": level, "parent": parent}
+
+                # Set TCM columns to lookup
+                if "tcm_cols" not in config["levels"][level].keys():
+                    log.warning(
+                        f"TCM levels, e.g. {level}, need to specify the TCM lookup columns"
+                    )
+            else:
+                self.cut_priority[level] = 0
+
+    def set_files(self, query: str | list[str], append: bool = False) -> None:
+        """Apply a file selection.
+
+        Sets `self.file_list`, which is a list of indices corresponding to the
+        rows in the file database.
+
+        Parameters
+        ----------
+        query
+            if single string, defines an operation on the file database columns
+            supported by :meth:`pandas.DataFrame.query`. In addition, the
+            ``all`` keyword is supported to select all files in the database.
+            If list of strings, will be interpreted as key (cycle timestamp) list.
+        append
+            if ``True``, appends files to the existing `self.file_list`
+            instead of overwriting.
+
+        Note
+        ----
+        Call this function before any other operation. A second call to
+        :meth:`set_files` does not replace the current file list, which gets
+        instead integrated with the new list. Use :meth:`reset` to reset the
+        file query.
+
+        Example
+        -------
+        >>> dl.set_files("file_status == 26 and timestamp == '20220716T130443Z'")
+        """
+
+        if isinstance(query, (list, tuple)) and query:
+            query = " or ".join([f"timestamp == '{key}'" for key in query])
+
+        if isinstance(query, str):
+            if query.replace(" ", "") == "all":
+                inds = list(self.filedb.df.index)
+            else:
+                inds = list(
+                    self.filedb.df.query(query, engine="python", inplace=False).index
+                )
+        else:
+            raise ValueError("bad query format")
+
+        if not inds:
+            log.warning("no files matching selection found")
+
+        if append and self.file_list is not None:
+            self.file_list += inds
+            self.file_list = sorted(list(set(self.file_list)))
+        else:
+            self.file_list = inds
+
+    def get_file_list(self) -> pd.DataFrame:
+        """
+        Returns a copy of the file database with its dataframe pared down to
+        the current file list.
+        """
+        return self.filedb.df.iloc[self.file_list]
+
+    def set_datastreams(
+        self, ds: list | tuple | np.ndarray, word: str, append: bool = False
+    ) -> None:
+        """Apply selection on data streams (or channels).
+
+        Sets `self.table_list`.
+
+        Parameters
+        ----------
+        ds
+            identifies the detectors of interest. Can be a list of detector
+            names, serial numbers, or channels or a list of subsystems of
+            interest e.g.  ``ged``.
+        word
+            the type of identifier used in ds. Should be a key in the given
+            channel map or a word defined in the configuration file.
+        append
+            if ``True``, appends datastreams to the existing `self.table_list`
+            instead of overwriting.
+
+        Example
+        -------
+        >>> dl.set_datastreams(np.arange(40, 45), "ch")
+        """
+        if self.table_list is None or not append:
+            self.table_list = {}
+
+        ds = list(ds)
+
+        found = False
+        for level in self.levels:
+            tier = self.tiers[level][0]
+
+            template = self.filedb.table_format[tier]
+            fm = string.Formatter()
+            parse_arr = np.array(list(fm.parse(template)))
+            names = list(parse_arr[:, 1])  # fields required to generate file name
+            if len(names) > 0:
+                keyword = names[0]
+
+            if word == keyword:
+                found = True
+                if level in self.table_list.keys():
+                    self.table_list[level] += ds
+                    self.table_list[level] = sorted(list(set(self.table_list[level])))
+                else:
+                    self.table_list[level] = ds
+
+        if not found:
+            # look for word in channel map
+            raise NotImplementedError
+
+    def set_cuts(self, cuts: dict | list, append: bool = False) -> None:
+        """Apply a selection on columns in the data tables.
+
+        Parameters
+        ----------
+        cut
+            the cuts on the columns of the data table, e.g. ``trapEftp_cal >
+            1000``.  If passing a dictionary, the dictionary should be
+            structured as ``dict[tier] = cut_expr``. If passing a list, each
+            item in the array should be able to be applied on one level of
+            tables. The cuts at different levels will be joined with an AND.
+        append
+            if True, appends cuts to the existing cuts instead of overwriting
+
+        Example
+        -------
+        >>> dl.set_cuts({"raw": "daqenergy > 1000", "hit": "AoE > 3"})
+        """
+        if self.cuts is None or not append:
+            self.cuts = {}
+        if isinstance(cuts, dict):
+            # verify the correct structure
+            for key, value in cuts.items():
+                if not (key in self.levels and isinstance(value, str)):
+                    raise ValueError(
+                        r"cuts dictionary must be in the format \{ level: string \}"
+                    )
+                if key in self.cuts.keys() and append:
+                    self.cuts[key] += " and " + value
+                else:
+                    self.cuts[key] = value
+        elif isinstance(cuts, list):
+            raise NotImplementedError
+            self.cuts = {}
+            # TODO Parse strings to match column names so you don't have to specify which level it is
+
+    def set_output(
+        self,
+        fmt: str = None,
+        merge_files: bool = None,
+        columns: list = None,
+        aoesa_to_vov: bool = None,
+    ) -> None:
+        """
+        Set the parameters for the output format of load
+
+        Parameters
+        ---------
+        fmt
+            ``lgdo.Table`` or ``pd.DataFrame``.
+        merge_files
+            if ``True``, information from multiple files will be merged into
+            one table.
+        columns
+            the columns that should be copied into the output.
+        aoesa_to_vov
+            output :class:`.ArrayOfEqualSizedArrays` as :class:`.VectorOfVectors`.
+
+        Example
+        -------
+        >>> dl.set_output(
+        ...   fmt="pd.DataFrame",
+        ...   merge_files=False,
+        ...   columns=["daqenergy", "trapEmax", "channel"]
+        ... )
+        """
+        if fmt not in ["lgdo.Table", "pd.DataFrame", None]:
+            raise ValueError(f"'{fmt}' output format not supported")
+
+        if fmt is not None:
+            self.output_format = fmt
+        if merge_files is not None:
+            self.merge_files = merge_files
+        if columns is not None:
+            self.output_columns = columns
+        if aoesa_to_vov is not None:
+            self.aoesa_to_vov = aoesa_to_vov
+
+    def reset(self):
+        """Resets all fields to their default values.
+
+        As if this is a newly created data loader.
+        """
+        self.file_list = None
+        self.table_list = None
+        self.cuts = None
+        self.merge_files = True
+        self.output_format = "lgdo.Table"
+        self.output_columns = None
+        self.aoesa_to_vov = False
+        self.data = None
+
+    def build_entry_list(
+        self,
+        tcm_level: str = None,
+        tcm_table: int | str = None,
+        mode: str = "only",
+        save_output_columns: bool = False,
+        in_memory: bool = True,
+        output_file: str = None,
+    ) -> dict[int, pd.DataFrame] | pd.DataFrame | None:
+        """Applies cuts to the tables and files of interest.
+
+        Can only load up to two levels, those joined by `tcm_level`.
+
+        Parameters
+        ----------
+        tcm_level
+            the type of TCM to be used. If ``None``, will only return
+            information from lowest level.
+        tcm_table
+            the identifier of the table inside this TCM level that you want to
+            use.  If unspecified, there must only be one table inside a TCM
+            file in `tcm_level`.
+        mode
+            if ``any``, returns every hit in the event if any hit in the event
+            passes the cuts. If ``only``, only returns hits that pass the cuts.
+        save_output_columns
+            if ``True``, saves any columns needed for both the cut and the
+            output to the `self.entry_list`.
+        in_memory
+            if ``True``, returns the generated entry list in memory.
+        output_file
+            HDF5 file name to write the entry list to.
+
+        Returns
+        -------
+        entries
+            the entry list containing columns for ``{parent}_idx``,
+            ``{parent}_table``, ``{child}_idx`` and output columns if
+            applicable.  Only returned if `in_memory` is ``True``.
+
+        Note
+        ----
+        Does *not* load the column information into memory. This is done by
+        :meth:`.load`.
+        """
+        if self.file_list is None:
+            raise ValueError("You need to make a query on filedb, use set_files()")
+
+        if not in_memory and output_file is None:
+            raise ValueError("If in_memory is False, need to specify an output file")
+
+        if in_memory:
+            entries = {}
+
+        log.debug("generating entry list determined by cuts")
+
+        # Default columns in the entry_list
+        if tcm_level is None:
+            return self.build_hit_entries(save_output_columns, in_memory, output_file)
+
+        # Assumes only one tier in a TCM level
+        parent = self.tcms[tcm_level]["parent"]
+        child = self.tcms[tcm_level]["child"]
+        entry_cols = [
+            f"{parent}_table",
+            f"{parent}_idx",
+            f"{child}_idx",
+        ]
+        if save_output_columns:
+            for_output = []
+
+        # Find out which columns are needed for any cuts
+        cut_cols = {}
+        # ... and pre-load which tiers need to be loaded to make the cuts
+        col_tiers_dict = {}
+
+        for level in [child, parent]:
+            cut_cols[level] = []
+            if self.cuts is not None and level in self.cuts.keys():
+                cut = self.cuts[level]
+            else:
+                cut = ""
+            # String parsing to determine which columns need to be loaded
+            # Matches any valid python variable name
+            terms = re.findall(r"[^\W0-9]\w*", cut)
+            for term in terms:
+                # Assumes that column names are valid python variable names
+                if term.isidentifier() and not iskeyword(term):
+                    cut_cols[level].append(term)
+                    # Add column to entry_cols if they are needed for both the cut and the output
+                    if self.output_columns is not None:
+                        if (
+                            term in self.output_columns
+                            and term not in entry_cols
+                            and save_output_columns
+                        ):
+                            for_output.append(term)
+            col_tiers_dict[level] = self.get_tiers_for_col(
+                cut_cols[level], merge_files=False
+            )
+
+        if save_output_columns:
+            entry_cols += for_output
+
+        if log.getEffectiveLevel() >= logging.INFO:
+            progress_bar = tqdm(
+                desc="Building entry list",
+                total=len(self.file_list),
+                delay=2,
+                unit="keys",
+            )
+
+        # Make the entry list for each file
+        for file in self.file_list:
+            if log.getEffectiveLevel() >= logging.INFO:
+                progress_bar.update()
+                progress_bar.set_postfix(
+                    key=self.filedb.df.iloc[file][self.filedb.sortby]
+                )
+
+            # Get the TCM specified
+            # Assumes that each TCM level only has one tier
+            tcm_tier = self.tiers[tcm_level][0]
+            tcm_tables = self.filedb.df.loc[file, f"{tcm_tier}_tables"]
+            if len(tcm_tables) > 1 and tcm_table is None:
+                raise ValueError(
+                    f"There are {len(tcm_tables)} TCM tables, need to specify which to use"
+                )
+            else:
+                if tcm_table is not None:
+                    if tcm_table in tcm_tables:
+                        tcm_tb = tcm_table
+                    else:
+                        raise ValueError(
+                            f"Table {tcm_table} doesn't exist in {tcm_level}"
+                        )
+                else:
+                    tcm_tb = tcm_tables[0]
+
+            tcm_path = os.path.join(
+                self.data_dir,
+                self.filedb.tier_dirs[tcm_tier].lstrip("/"),
+                self.filedb.df.iloc[file][f"{tcm_tier}_file"].lstrip("/"),
+            )
+
+            if not os.path.exists(tcm_path):
+                raise FileNotFoundError(f"Can't find TCM file for {tcm_level}")
+
+            tcm_table_name = self.filedb.get_table_name(tcm_tier, tcm_tb)
+            try:
+                tcm_lgdo = lh5.read(tcm_table_name, tcm_path)
+            except KeyError:
+                log.warning(f"Cannot find table {tcm_table_name} in file {tcm_path}")
+                continue
+            # vector of tables should have a better explode method
+            # Have to do some hacky stuff until I get a view_as("pd") method
+            f_entries = tcm_lgdo.view_as("pd")
+            for col in f_entries:
+                if isinstance(f_entries[col].dtype, AwkwardDtype):
+                    f_entries[col] = f_entries[col].to_list()
+            f_entries = f_entries.explode(list(f_entries.columns))
+            f_entries.reset_index(inplace=True)
+            renaming = {
+                "index": f"{child}_idx",
+                self.tcms[tcm_level]["tcm_cols"]["parent_tb"]: f"{parent}_table",
+                self.tcms[tcm_level]["tcm_cols"]["parent_idx"]: f"{parent}_idx",
+            }
+            f_entries.rename(columns=renaming, inplace=True)
+            if self.merge_files:
+                f_entries["file"] = file
+            # At this point, should have a list of all available hits/evts joined by tcm
+
+            if mode == "any":
+                drop_idx = None
+
+            # Perform cuts specified for child or parent level, in that order
+            for level in [child, parent]:
+                # Extract the cut condition if given, otherwise set to ""
+                cut = ""
+                if self.cuts is not None:
+                    if level in self.cuts.keys():
+                        cut = self.cuts[level]
+
+                col_tiers = col_tiers_dict[level]
+
+                # Tables in first tier of event should be the same for all tiers in one level
+                tables = self.filedb.df.loc[file, f"{self.tiers[level][0]}_tables"]
+                if self.table_list is not None:
+                    if level in self.table_list.keys():
+                        tables = self.table_list[level]
+                    else:
+                        continue
+                if tables is None:
+                    continue
+
+                # Cut any rows of TCM not relating to requested tables
+                if level == parent:
+                    f_entries.query(f"{level}_table in {tables}", inplace=True)
+
+                for tb in tables:
+                    tb_table = None
+                    if level == parent:
+                        tcm_idx = f_entries.query(f"{level}_table == {tb}").index
+                    else:
+                        tcm_idx = f_entries.index
+                    idx_mask = f_entries.loc[tcm_idx, f"{level}_idx"]
+                    for tier in self.tiers[level]:
+                        tier_path = os.path.join(
+                            self.data_dir,
+                            self.filedb.tier_dirs[tier].lstrip("/"),
+                            self.filedb.df.loc[file, f"{tier}_file"].lstrip("/"),
+                        )
+                        if tier in col_tiers[file]["tables"].keys():
+                            if tb in col_tiers[file]["tables"][tier]:
+                                table_name = self.filedb.get_table_name(tier, tb)
+                                try:
+                                    tier_table = lh5.read(
+                                        table_name,
+                                        tier_path,
+                                        field_mask=cut_cols[level],
+                                        idx=idx_mask.tolist(),
+                                    )
+                                except KeyError:
+                                    log.warning(
+                                        f"Cannot find {table_name} in file {tier_path}"
+                                    )
+                                    continue
+                                if tb_table is None:
+                                    tb_table = tier_table
+                                else:
+                                    tb_table.join(tier_table)
+                    if tb_table is None:
+                        continue
+                    tb_df = tb_table.view_as("pd")
+                    tb_df.query(cut, inplace=True)
+                    idx_match = f_entries.query(f"{level}_idx in {list(tb_df.index)}")
+                    if level == parent:
+                        idx_match = idx_match.query(f"{level}_table == {tb}")
+                    if mode == "only":
+                        keep_idx = idx_match.index
+                        drop_idx = set.symmetric_difference(
+                            set(tcm_idx), list(keep_idx)
+                        )
+                        f_entries.drop(drop_idx, inplace=True)
+                    elif mode == "any":
+                        evts = idx_match[f"{child}_idx"].unique().tolist()
+                        keep_idx = f_entries.query(f"{child}_idx in {evts}").index
+                        drop = set.symmetric_difference(
+                            set(f_entries.index), list(keep_idx)
+                        )
+                        if drop_idx is None:
+                            drop_idx = drop
+                        else:
+                            drop_idx = set.intersection(drop_idx, drop)
+                    else:
+                        raise ValueError("mode must be either 'any' or 'only'")
+
+                    if save_output_columns:
+                        for col in tb_df.columns:
+                            if col in for_output:
+                                f_entries.loc[keep_idx, col] = tb_df[col].tolist()
+
+            if mode == "any":
+                if drop_idx is not None:
+                    f_entries.drop(index=drop_idx, inplace=True)
+
+            f_entries.reset_index(inplace=True, drop=True)
+
+            if in_memory:
+                entries[file] = f_entries
+            if output_file:
+                # Convert f_entries DataFrame to Struct
+                f_dict = f_entries.to_dict("list")
+                f_struct = Struct(f_dict)
+                if self.merge_files:
+                    lh5.write(f_struct, "entries", output_file, wo_mode="a")
+                else:
+                    lh5.write(f_struct, f"entries/{file}", output_file, wo_mode="a")
+
+        if log.getEffectiveLevel() >= logging.INFO:
+            progress_bar.close()
+
+        if in_memory:
+            if self.merge_files:
+                entries = pd.concat(entries.values(), ignore_index=True)
+            return entries
+
+    def build_hit_entries(
+        self,
+        save_output_columns: bool = False,
+        in_memory: bool = True,
+        output_file: str = None,
+    ) -> dict[int, pd.DataFrame] | pd.DataFrame | None:
+        """Called by :meth:`.build_entry_list` to handle the case when
+        `tcm_level` is unspecified.
+
+        Ignores any cuts set on levels above lowest level.
+
+        Parameters
+        ----------
+        save_output_columns
+            If ``True``, saves any columns needed for both the cut and the
+            output to the entry list.
+        in_memory
+            If ``True``, returns the generated entry list in memory.
+        output_file
+            HDF5 file name to write the entry list to.
+
+        Returns
+        -------
+        entries
+            the entry list containing columns for ``{low_level}_idx``,
+            ``{low_level}_table``, and output columns if
+            applicable.  Only returned if `in_memory` is ``True``.
+        """
+        low_level = self.levels[0]
+        if in_memory:
+            entries = {}
+        entry_cols = [f"{low_level}_table", f"{low_level}_idx"]
+
+        log.debug(
+            f"generating (hit-oriented) entry list corresponding to cuts on the {low_level} level"
+        )
+
+        # find out which columns are needed for the cut
+        cut_cols = []
+        cut = ""
+        if self.cuts is not None and low_level in self.cuts.keys():
+            cut = self.cuts[low_level]
+            # do cut expression string parsing to determine which columns need to be loaded
+            # this matches any valid python variable name
+            terms = re.findall(r"[^\W0-9]\w*", cut)
+            for term in terms:
+                if not iskeyword(term):
+                    cut_cols.append(term)
+                    # Add column to entry_cols if they are needed for both the cut and the output
+                    if self.output_columns is not None:
+                        if (
+                            term in self.output_columns
+                            and term not in entry_cols
+                            and save_output_columns
+                        ):
+                            entry_cols.append(term)
+
+        log.debug(f"need to load {cut_cols} columns for applying cuts")
+        col_tiers = self.get_tiers_for_col(cut_cols, merge_files=False)
+
+        if log.getEffectiveLevel() >= logging.INFO:
+            progress_bar = tqdm(
+                desc="Building entry list",
+                total=len(self.file_list),
+                delay=2,
+                unit="keys",
+            )
+
+        # now we loop over the files in our list
+        for file in self.file_list:
+            if log.getEffectiveLevel() >= logging.INFO:
+                progress_bar.update()
+                progress_bar.set_postfix(
+                    key=self.filedb.df.iloc[file][self.filedb.sortby]
+                )
+
+            log.debug(
+                f"building entry list for cycle {self.filedb.df.iloc[file][self.filedb.sortby]}"
+            )
+
+            # this dataframe will be associated with the file and will contain
+            # the columns needed for the cut as well as the columns requested
+            # for the output
+            f_entries = pd.DataFrame(columns=entry_cols)
+
+            # check if we were asked to consider only certain data streams
+            if self.table_list is not None:
+                if low_level in self.table_list.keys():
+                    tables = self.table_list[low_level]
+            else:
+                tables = self.filedb.df.loc[file, f"{self.tiers[low_level][0]}_tables"]
+
+            # now loop over these data streams
+            for tb in tables:
+                tb_table = None
+
+                # no cut is set, let's include all indices for the data stream
+                if cut == "":
+                    tier = self.tiers[low_level][0]
+                    # reconstruct absolute path to tier file
+                    tier_path = os.path.join(
+                        self.data_dir,
+                        self.filedb.tier_dirs[tier].lstrip("/"),
+                        self.filedb.df.iloc[file][f"{tier}_file"].lstrip("/"),
+                    )
+                    # now read how many rows are there in the file
+                    table_name = self.filedb.get_table_name(tier, tb)
+                    try:
+                        n_rows = lh5.read_n_rows(table_name, tier_path)
+                    except KeyError:
+                        log.warning(f"Cannot find {table_name} in file {tier_path}")
+                        continue
+                    tb_df = pd.DataFrame(
+                        {
+                            f"{low_level}_idx": np.arange(n_rows),
+                            f"{low_level}_table": tb,
+                        }
+                    )
+                    if self.merge_files:
+                        tb_df["file"] = file
+                else:
+                    # loop over tiers in the lowest level
+                    for tier in self.tiers[low_level]:
+                        # is the tier involved, considered the columns on which cuts are applied?
+                        if (
+                            tier in col_tiers[file]["tables"].keys()
+                            and tb in col_tiers[file]["tables"][tier]
+                        ):
+                            # reconstruct absolute path to tier file
+                            tier_path = os.path.join(
+                                self.data_dir,
+                                self.filedb.tier_dirs[tier].lstrip("/"),
+                                self.filedb.df.iloc[file][f"{tier}_file"].lstrip("/"),
+                            )
+
+                            # load the data from the tier file, just the columns needed for the cut
+                            table_name = self.filedb.get_table_name(tier, tb)
+                            try:
+                                tier_tb = lh5.read(
+                                    table_name, tier_path, field_mask=cut_cols
+                                )
+                            except KeyError:
+                                log.warning(
+                                    f"Cannot find {table_name} in file {tier_path}"
+                                )
+                                continue
+                            # join everything in one table
+                            if tb_table is None:
+                                tb_table = tier_tb
+                            else:
+                                tb_table.join(tier_tb)
+
+                    if tb_table is None:
+                        continue
+
+                    # convert to DataFrame and apply cuts
+                    tb_df = tb_table.view_as("pd")
+                    tb_df.query(cut, inplace=True)
+                    tb_df[f"{low_level}_table"] = tb
+                    tb_df[f"{low_level}_idx"] = tb_df.index
+
+                # final DataFrame
+                if f_entries.empty:
+                    f_entries = tb_df
+                else:
+                    f_entries = pd.concat((f_entries, tb_df), ignore_index=True)[
+                        entry_cols
+                    ]
+
+            if self.merge_files:
+                f_entries["file"] = file
+            if in_memory:
+                entries[file] = f_entries
+            if output_file:
+                # Convert f_entries DataFrame to Struct
+                f_dict = f_entries.to_dict("list")
+                f_struct = Struct(f_dict)
+                if self.merge_files:
+                    lh5.write(f_struct, "entries", output_file, wo_mode="a")
+                else:
+                    lh5.write(f_struct, f"entries/{file}", output_file, wo_mode="a")
+
+        if log.getEffectiveLevel() >= logging.INFO:
+            progress_bar.close()
+
+        if in_memory:
+            if self.merge_files:
+                entries = pd.concat(entries.values(), ignore_index=True)
+            return entries
+
+    def next(
+        self, entry_list: pd.DataFrame = None, chunk_size: int = 10000, **kwargs
+    ) -> Iterator[Table | Struct | pd.DataFrame]:
+        """Loads the requested data from disk in chunks.
+
+        This method should be used instead of :meth:`.load` to handle large
+        data sets.
+
+        Note
+        ----
+        It is a user responsibility to optimize the chunk size in order to
+        achieve best performance.
+
+        Parameters
+        ----------
+        chunk_size
+            number of entries to load at each iteration. Adapt based on the
+            size of each entry and the amount of memory available on the
+            system.
+        entry_list, **kwargs
+            keyword argument forwarded to :meth:`.load`.
+
+        Returns
+        -------
+        data
+            see :meth:`.load`.
+
+        Examples
+        --------
+        >>> for chunk in dl.next():
+        >>>    # 'chunk' has the same type of the output of dl.load()
+
+        See Also
+        --------
+        .load
+        """
+        if entry_list is None:
+            entry_list = self.build_entry_list(
+                tcm_level=kwargs.get("tcm_level", None), save_output_columns=True
+            )
+
+        start = stop = 0
+        etot = len(entry_list)
+        while stop < etot:
+            start = stop
+
+            if stop + chunk_size > etot:
+                stop = etot
+            else:
+                stop += chunk_size
+
+            yield self.load(
+                entry_list=entry_list[start:stop].reset_index(drop=True), **kwargs
+            )
+
+    def load(
+        self,
+        entry_list: pd.DataFrame = None,
+        in_memory: bool = True,
+        output_file: str = None,
+        orientation: str = "hit",
+        tcm_level: str = None,
+    ) -> None | Table | Struct | pd.DataFrame:
+        """Loads the requested data from disk.
+
+        Loads the requested columns in `self.output_columns` for the entries in
+        the given `entry_list`.
+
+        Parameters
+        ----------
+        entry_list
+            the output of :meth:`.build_entry_list`. If ``None``, builds it
+            according to the current configuration.
+        in_memory
+            if ``True``, returns the loaded data in memory and stores in
+            `self.data`.
+        output_file
+            if not ``None``, writes the loaded data to the specified file.
+        orientation
+            specifies the orientation of the output table. Can be ``hit`` or
+            ``evt``.
+        tcm_level
+            which TCM was used to create the ``entry_list``.
+
+        Returns
+        -------
+        data
+            The data loaded from disk, as specified by `self.output_format`,
+            `self.output_columns`, and `self.merge_files`. Only returned if
+            `in_memory` is ``True``.
+        """
+        # set save_output_columns=True to avoid wasting time
+        if entry_list is None:
+            entry_list = self.build_entry_list(
+                tcm_level=tcm_level, save_output_columns=True
+            )
+
+        if not in_memory and output_file is None:
+            raise ValueError("if in_memory is False, need to specify an output file")
+
+        if self.output_columns is None or not self.output_columns:
+            raise ValueError("need to set output columns to load data")
+
+        if orientation == "hit":
+            self.data = self.load_hits(entry_list, in_memory, output_file, tcm_level)
+        elif orientation == "evt":
+            if tcm_level is None:
+                if len(self.tcms) == 1:
+                    tcm_level = list(self.tcms.keys())[0]
+                else:
+                    raise ValueError(
+                        "need to specify which coincidence map to use to return event-oriented data"
+                    )
+            self.data = self.load_evts(entry_list, in_memory, output_file, tcm_level)
+        else:
+            raise ValueError(
+                f"I don't understand what orientation={orientation} means!"
+            )
+
+        return self.data
+
+    def load_hits(
+        self,
+        entry_list: pd.DataFrame,
+        in_memory: bool = False,
+        output_file: str = None,
+        tcm_level: str = None,
+    ) -> None | Table | Struct | pd.DataFrame:
+        """Called by :meth:`.load` when orientation is ``hit``."""
+        if tcm_level is None:
+            parent = self.levels[0]
+            child = None
+            load_levels = [parent]
+        else:
+            parent = self.tcms[tcm_level]["parent"]
+            child = self.tcms[tcm_level]["child"]
+            load_levels = [parent, child]
+
+        def explode_evt_cols(el: pd.DataFrame, tier_table: Table):
+            # Explode columns from "evt"-style levels, untested
+            # Will only work if column has an "nda" attribute
+            cum_length = build_cl(el[f"{child}_idx"])
+            exp_cols = explode_arrays(
+                cum_length,
+                [a.nda for a in tier_table.values()],
+            )
+            tier_table.update(zip(tier_table.keys(), exp_cols))
+            return tier_table
+
+        if self.merge_files:
+            tables = entry_list[f"{parent}_table"].unique()
+            field_mask = []
+            for col in self.output_columns:
+                if col not in entry_list.columns:
+                    field_mask.append(col)
+
+            col_tiers = self.get_tiers_for_col(field_mask)
+            col_dict = entry_list.to_dict("list")
+            attr_dict = {}
+            for key in col_dict:
+                attr_dict[key] = None
+            table_length = len(entry_list)
+
+            tot_iter = 0
+            for _, level in product(tables, load_levels):
+                for _ in self.tiers[level]:
+                    tot_iter += 1
+
+            if log.getEffectiveLevel() >= logging.INFO:
+                progress_bar = tqdm(
+                    desc="Loading data",
+                    total=tot_iter,
+                    delay=2,
+                )
+
+            for tb, level in product(tables, load_levels):
+                gb = entry_list.query(f"{parent}_table == {tb}").groupby("file")
+                files = list(gb.groups.keys())
+                el_idx = list(gb.groups.values())
+                idx_mask = [list(entry_list.loc[i, f"{level}_idx"]) for i in el_idx]
+
+                for tier in self.tiers[level]:
+                    if log.getEffectiveLevel() >= logging.INFO:
+                        progress_bar.update()
+                        progress_bar.set_postfix(table=tb, tier=tier)
+
+                    if tb not in col_tiers[tier]:
+                        continue
+
+                    tb_name = self.filedb.get_table_name(tier, tb)
+                    tier_paths = [
+                        os.path.join(
+                            self.data_dir,
+                            self.filedb.tier_dirs[tier].lstrip("/"),
+                            self.filedb.df.iloc[file][f"{tier}_file"].lstrip("/"),
+                        )
+                        for file in files
+                    ]
+
+                    tier_table = lh5.read(
+                        name=tb_name,
+                        lh5_file=tier_paths,
+                        idx=idx_mask,
+                        field_mask=field_mask,
+                    )
+
+                    if level == child:
+                        explode_evt_cols(entry_list, tier_table)
+
+                    col_dict, attr_dict = utils.fill_col_dict(
+                        tier_table,
+                        col_dict,
+                        attr_dict,
+                        [idx for idx_list in el_idx for idx in idx_list],
+                        table_length,
+                        self.aoesa_to_vov,
+                    )
+
+            if log.getEffectiveLevel() >= logging.INFO:
+                progress_bar.close()
+
+            # Convert col_dict to lgdo.Table
+            f_table = utils.dict_to_table(col_dict=col_dict, attr_dict=attr_dict)
+
+            if output_file:
+                lh5.write(f_table, "merged_data", output_file, wo_mode="o")
+            if in_memory:
+                if self.output_format == "lgdo.Table":
+                    return f_table
+                elif self.output_format == "pd.DataFrame":
+                    return f_table.view_as("pd")
+                else:
+                    raise ValueError(
+                        f"'{self.output_format}' output format not supported"
+                    )
+        else:  # not merge_files
+            if in_memory:
+                load_out = Struct(attrs={"int_keys": True})
+
+            if log.getEffectiveLevel() >= logging.INFO:
+                progress_bar = tqdm(
+                    desc="Loading data",
+                    total=len(entry_list),
+                    delay=2,
+                    unit="keys",
+                )
+
+            # now loop over the output of build_entry_list()
+            for file, f_entries in entry_list.items():
+                if log.getEffectiveLevel() >= logging.INFO:
+                    progress_bar.update()
+                    progress_bar.set_postfix(
+                        key=self.filedb.df.iloc[file][self.filedb.sortby]
+                    )
+
+                log.debug(
+                    f"loading data for cycle key {self.filedb.df.iloc[file][self.filedb.sortby]}"
+                )
+
+                field_mask = []
+
+                for col in self.output_columns:
+                    if col not in f_entries.columns:
+                        field_mask.append(col)
+
+                col_tiers = self.get_tiers_for_col(field_mask)
+                col_dict = f_entries.to_dict("list")
+                attr_dict = {}
+                for key in col_dict:
+                    attr_dict[key] = None
+                table_length = len(f_entries)
+
+                log.debug(f"will load new columns {field_mask}")
+
+                # loop through each table in entry list and
+                # loop through each level we're asked to load from
+                for tb, level in product(
+                    f_entries[f"{parent}_table"].unique(), load_levels
+                ):
+                    tcm_idx = f_entries.query(f"{parent}_table == {tb}").index
+                    idx_mask = f_entries.loc[tcm_idx, f"{level}_idx"].tolist()
+
+                    # loop over tiers in the level
+                    for tier in self.tiers[level]:
+                        if tb not in col_tiers[file]["tables"][tier]:
+                            continue
+
+                        log.debug(
+                            f"...for stream '{self.filedb.get_table_name(tier, tb)}' (at {level} level)"
+                        )
+
+                        # path to tier file
+                        tier_path = os.path.join(
+                            self.data_dir,
+                            self.filedb.tier_dirs[tier].lstrip("/"),
+                            self.filedb.df.iloc[file][f"{tier}_file"].lstrip("/"),
+                        )
+                        # this should not happen
+                        if not os.path.exists(tier_path):
+                            raise FileNotFoundError(tier_path)
+
+                        table_name = self.filedb.get_table_name(tier, tb)
+                        tier_table = lh5.read(
+                            table_name,
+                            tier_path,
+                            idx=idx_mask,
+                            field_mask=field_mask,
+                        )
+
+                        if level == child:
+                            explode_evt_cols(f_entries, tier_table)
+
+                        col_dict, attr_dict = utils.fill_col_dict(
+                            tier_table,
+                            col_dict,
+                            attr_dict,
+                            tcm_idx,
+                            table_length,
+                            self.aoesa_to_vov,
+                        )
+                        # end tb loop
+
+                # Convert col_dict to lgdo.Table
+                f_table = utils.dict_to_table(col_dict, attr_dict)
+
+                if in_memory:
+                    load_out.add_field(name=str(file), obj=f_table)
+                if output_file:
+                    lh5.write(f_table, f"{file}", output_file, wo_mode="o")
+                # end file loop
+
+            if log.getEffectiveLevel() >= logging.INFO:
+                progress_bar.close()
+            if load_out:
+                load_out.update_datatype()
+
+            if in_memory:
+                if self.output_format == "lgdo.Table":
+                    return load_out
+                elif self.output_format == "pd.DataFrame":
+                    return [tb.view_as("pd") for tb in load_out.values()]
+                else:
+                    raise ValueError(
+                        f"'{self.output_format}' output format not supported"
+                    )
+
+    def load_evts(
+        self,
+        entry_list: pd.DataFrame = None,
+        in_memory: bool = False,
+        output_file: str = None,
+        tcm_level: str = None,
+    ) -> None | Table | Struct | pd.DataFrame:
+        """Called by :meth:`load` when orientation is ``evt``."""
+        raise NotImplementedError
+
+        parent = self.tcms[tcm_level]["parent"]
+        child = self.tcms[tcm_level]["child"]
+        load_levels = [parent, child]
+
+        if self.merge_files:  # Try to load all information at once
+            raise NotImplementedError
+        else:  # Not merge_files
+            if in_memory:
+                load_out = Struct(attrs={"int_keys": True})
+            for file, f_entries in entry_list.items():
+                field_mask = []
+                f_table = None
+                # Pre-allocate memory for output columns
+                for col in self.output_columns:
+                    if col not in f_entries.columns:
+                        f_entries[col] = None
+                        field_mask.append(col)
+                col_tiers = self.get_tiers_for_col(field_mask)
+                col_dict = f_entries.to_dict("list")
+                for col in col_dict.keys():
+                    nda = np.array(col_dict[col])
+                    col_dict[col] = Array(nda=nda)
+
+                # Loop through each table in entry list
+                for tb in f_entries[f"{parent}_table"].unique():
+                    tcm_idx = f_entries.query(f"{parent}_table == {tb}").index
+                    for level in load_levels:
+                        idx_mask = f_entries.loc[tcm_idx, f"{level}_idx"]
+
+                        for tier in self.tiers[level]:
+                            if tb in col_tiers["tables"][tier]:
+                                tier_path = os.path.join(
+                                    self.data_dir,
+                                    self.filedb.tier_dirs[tier].lstrip("/"),
+                                    self.filedb.df.iloc[file][f"{tier}_file"].lstrip(
+                                        "/"
+                                    ),
+                                )
+                                if os.path.exists(tier_path):
+                                    table_name = self.filedb.get_table_name(tier, tb)
+                                    tier_table = lh5.read(
+                                        table_name,
+                                        tier_path,
+                                        idx=idx_mask,
+                                        field_mask=field_mask,
+                                    )
+                                    for col in tier_table.keys():
+                                        f_table[col].nda[tcm_idx] = tier_table[
+                                            col
+                                        ].tolist()
+                    # end tb loop
+                if in_memory:
+                    load_out[file] = f_table
+                if output_file:
+                    lh5.write(f_table, f"file{file}", output_file, wo_mode="o")
+                # end file loop
+
+            if in_memory:
+                if self.output_format == "lgdo.Table":
+                    return load_out
+                elif self.output_format == "pd.DataFrame":
+                    for file in load_out.keys():
+                        load_out[file] = load_out[file].view_as("pd")
+                    return load_out
+                else:
+                    raise ValueError(
+                        f"'{self.output_format}' output format not supported"
+                    )
+
+    def load_iterator(
+        self,
+        entry_list: pd.DataFrame = None,
+        tcm_level: str = None,
+        buffer_len: int = 3200,
+    ) -> LH5Iterator:
+        """Creates an :class:LH5Iterator that will load the requested columns
+        in `self.output_columns` for the entries in the given `entry_list` in
+        chunks. This is more memory efficient than filling a whole table and
+        is recommended for use when loading waveforms.
+
+        Parameters
+        ----------
+        entry_list
+            the output of :meth:`.build_entry_list`. If ``None``, builds it
+            according to the current configuration.
+        tcm_level
+            which TCM was used to create the ``entry_list``.
+        buffer_len
+            how many entries to load in a single chunk
+
+        Returns
+        -------
+        data
+            LH5 Iterator, which yields (lh5 table, entry, n_entries) when
+            iterated over.
+        """
+        if entry_list is None:
+            entry_list = self.build_entry_list(
+                tcm_level=tcm_level, save_output_columns=True
+            )
+
+        if tcm_level is None:
+            parent = self.levels[0]
+            child = None
+            load_levels = [parent]
+        else:
+            parent = self.tcms[tcm_level]["parent"]
+            child = self.tcms[tcm_level]["child"]
+            load_levels = [parent, child]
+
+        if self.merge_files:
+            tables = entry_list[f"{parent}_table"].unique()
+            field_mask = []
+            for col in self.output_columns:
+                if col not in entry_list.columns:
+                    field_mask.append(col)
+
+            col_tiers = self.get_tiers_for_col(field_mask)
+
+            lh5_it = None
+            for level in load_levels:
+                for tier in self.tiers[level]:
+                    # Build list of files/tables/entries
+                    lh5_files = []
+                    tb_names = []
+                    idx_list = []
+                    for tb in tables:
+                        if tb not in col_tiers[tier]:
+                            continue
+                        gb = entry_list.query(f"{parent}_table == {tb}").groupby("file")
+                        lh5_files += [
+                            os.path.join(
+                                self.filedb.tier_dirs[tier].lstrip("/"),
+                                self.filedb.df.iloc[file][f"{tier}_file"].lstrip("/"),
+                            )
+                            for file in gb.groups.keys()
+                        ]
+                        tb_names += [[self.filedb.get_table_name(tier, tb)]] * len(gb)
+                        idx_list += [
+                            list(entry_list.loc[i, f"{level}_idx"])
+                            for i in gb.groups.values()
+                        ]
+
+                    # Create iterator for this tier and friend to other tiers
+                    if len(lh5_files) > 0:
+                        lh5_it = LH5Iterator(
+                            lh5_files=lh5_files,
+                            groups=tb_names,
+                            base_path=self.data_dir,
+                            entry_list=idx_list,
+                            field_mask=field_mask,
+                            buffer_len=buffer_len,
+                            friend=lh5_it,
+                            safe_mode=False,
+                        )
+
+            return lh5_it
+        else:  # not merge_files
+            raise NotImplementedError
+
+    def load_detector(self, det_id):
+        """
+        special version of `load` designed to retrieve all file files, tables,
+        column names, and potentially calibration/dsp parameters relevant to one
+        single detector.
+        """
+        raise NotImplementedError
+
+    def load_settings(self):
+        """
+        get metadata stored in raw files, usually from a DAQ machine.
+        """
+        raise NotImplementedError
+
+    def load_dsp_pars(self, query):
+        """
+        access the dsp_pars parameter database (probably JSON format) and do
+        some kind of query to retrieve parameters of interest for our file list,
+        and return some tables.
+        """
+        raise NotImplementedError
+
+    def load_cal_pars(self, query):
+        """
+        access the cal_pars parameter database, run a query, and return some tables.
+        """
+        raise NotImplementedError
+
+    def skim_waveforms(self, mode: str = "hit", hit_list=None, evt_list=None):
+        """
+        handle this one separately because waveforms can easily fill up memory.
+        """
+        raise NotImplementedError
+
+    # TODO: automatically get the dsp_config/par_database used for
+    #   processing when these are set to None
+    def browse(
+        self, entry_list: pd.DataFrame = None, buffer_len: int = 128, **kwargs
+    ) -> WaveformBrowser:
+        """Return a :class:`.WaveformBrowser` object for waveform inspection.
+
+        Parameters
+        ----------
+        entry_list
+            the output of :meth:`.build_entry_list`. If ``None``, builds it
+            according to the current configuration.
+        buffer_len
+            number of waveforms to keep in memory at a time.
+        **kwargs
+            keyword arguments forwarded to :class:`.WaveformBrowser`.
+
+        See Also
+        --------
+        .WaveformBrowser
+        """
+        if entry_list is None:
+            entry_list = self.build_entry_list()
+
+        parent = self.levels[0]
+        tables = entry_list[f"{parent}_table"].unique()
+
+        lh5_it = None
+        for tier in self.tiers[parent]:
+            # Build list of files/tables/entries
+            lh5_files = []
+            tb_names = []
+            idx_list = []
+            for tb in tables:
+                gb = entry_list.query(f"{parent}_table == {tb}").groupby("file")
+                lh5_files += [
+                    os.path.join(
+                        self.filedb.tier_dirs[tier].lstrip("/"),
+                        self.filedb.df.iloc[file][f"{tier}_file"].lstrip("/"),
+                    )
+                    for file in gb.groups.keys()
+                ]
+                tb_names += [[self.filedb.get_table_name(tier, tb)]] * len(gb)
+                idx_list += [
+                    list(entry_list.loc[i, f"{parent}_idx"]) for i in gb.groups.values()
+                ]
+
+            # Create iterator for this tier and friend to other tiers
+            lh5_it = LH5Iterator(
+                lh5_files=lh5_files,
+                groups=tb_names,
+                base_path=self.data_dir,
+                entry_list=idx_list,
+                buffer_len=buffer_len,
+                field_mask={"tracelist": False},
+                friend=lh5_it,
+                safe_mode=False,
+            )
+
+        return WaveformBrowser(lh5_it, buffer_len=buffer_len, **kwargs)
+
+    def get_tiers_for_col(
+        self, columns: list | np.ndarray, merge_files: bool = None
+    ) -> dict:
+        """For each column given, get the tiers and tables in that tier where
+        that column can be found.
+
+        Parameters
+        ----------
+        columns
+            the columns to look for.
+
+        Returns
+        -------
+        col_tiers
+            ``col_tiers[file]["tables"][tier]`` gives a list of tables in
+            ``tier`` that contain a column of interest.
+            ``col_tiers[file]["columns"][column]`` gives the tier that
+            ``column`` can be found in. If `self.merge_file`s then `
+            col_tiers[tier]`` is a list of tables in ``tier`` that contain a
+            column of interest.
+        """
+
+        col_tiers = {}
+
+        # filedb.columns is needed, generate it now if not available
+        if self.filedb.columns is None:
+            self.filedb.scan_tables_columns()
+
+        if merge_files is None:
+            merge_files = self.merge_files
+
+        if merge_files:
+            for file in self.file_list:
+                col_inds = set()
+                for i, col_list in enumerate(self.filedb.columns):
+                    if not set(col_list).isdisjoint(columns):
+                        col_inds.add(i)
+
+                for level in self.levels:
+                    for tier in self.tiers[level]:
+                        col_tiers[tier] = set()
+                        if self.filedb.df.loc[file, f"{tier}_col_idx"] is not None:
+                            for i in range(
+                                len(self.filedb.df.loc[file, f"{tier}_col_idx"])
+                            ):
+                                if (
+                                    self.filedb.df.loc[file, f"{tier}_col_idx"][i]
+                                    in col_inds
+                                ):
+                                    col_tiers[tier].add(
+                                        self.filedb.df.loc[file, f"{tier}_tables"][i]
+                                    )
+        else:
+            # loop over selected files (db entries)
+            for file in self.file_list:
+                # this is the output object
+                col_tiers[file] = {"tables": {}, "columns": {}}
+                # Rows of FileDB.columns that include columns that we are interested in
+                col_inds = set()
+                for i, col_list in enumerate(self.filedb.columns):
+                    if not set(list(col_list)).isdisjoint(columns):
+                        col_inds.add(i)
+
+                # Loop over tiers
+                for level in self.levels:
+                    for tier in self.tiers[level]:
+                        col_tiers[file]["tables"][tier] = []
+                        tier_col_idx = self.filedb.df.loc[file, f"{tier}_col_idx"]
+                        if tier_col_idx is not None:
+                            # Loop over tables
+                            for i in range(len(tier_col_idx)):
+                                col_idx = self.filedb.df.loc[file, f"{tier}_col_idx"][i]
+                                if col_idx in col_inds:
+                                    col_tiers[file]["tables"][tier].append(
+                                        self.filedb.df.loc[file, f"{tier}_tables"][i]
+                                    )
+                                    col_in_tier = set.intersection(
+                                        set(self.filedb.columns[col_idx]), set(columns)
+                                    )
+                                    for c in col_in_tier:
+                                        col_tiers[file]["columns"][c] = tier
+
+        return col_tiers
+
+    def __repr__(self) -> str:
+        return (
+            "DataLoader("
+            f"cuts={self.cuts}, "
+            f"merge_files={self.merge_files}, "
+            f'output_format="{self.output_format}", '
+            f"output_columns={self.output_columns}, "
+            f"aoesa_to_vov={self.aoesa_to_vov}"
+            ")"
+        )

--- a/src/pygama/flow/file_db.py
+++ b/src/pygama/flow/file_db.py
@@ -1,0 +1,735 @@
+"""Utilities for LH5 file inventory."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import string
+import warnings
+
+import h5py
+import lh5
+import numpy as np
+import pandas as pd
+from lh5 import ls
+from lh5.io.utils import expand_path, expand_vars
+from lgdo.types import Array, Scalar, VectorOfVectors
+from parse import parse
+
+from . import utils
+
+log = logging.getLogger(__name__)
+
+
+class FileDB:
+    """LH5 file database.
+
+    A class containing a :class:`pandas.DataFrame` that has additional
+    functions to scan the data directory, fill the dataframe's columns with
+    information about each file, and read or write to disk in an LGDO format.
+
+    The database contains the following columns:
+
+    - file keys: the fields specified in the configuration file's
+      ``file_format`` that are required to generate a file name e.g. ``run``,
+      ``type``, ``timestamp`` etc.
+    - ``{tier}_file``: generated file name for the tier.
+    - ``{tier}_size``: size of file on disk, if applicable.
+    - ``file_status``: contains a bit corresponding to whether or not a file
+      for each tier exists for a given cycle e.g. If we have tiers `raw`,
+      `dsp`, and `hit`, but only the `raw` file has been produced,
+      ``file_status`` would be ``0b100``.
+    - ``{tier}_tables``: available data streams (channels) in the tier.
+    - ``{tier}_col_idx``: ``file_db.columns[{tier}_col_idx]`` will return the
+      list of columns available in the tier's file.
+
+    The database must be configured by a JSON file (or corresponding
+    dictionary), which defines the data file names, paths and LH5 layout. For
+    example:
+
+    .. code-block:: json
+
+        {
+            "data_dir": "prod-ref-l200/generated/tier",
+            "tier_dirs": {
+                "raw": "/raw",
+                "dsp": "/dsp",
+                "hit": "/hit",
+                "tcm": "/tcm",
+                "evt": "/evt"
+            },
+            "file_format": {
+                "raw": "/{type}/{period}/{run}/{exp}-{period}-{run}-{type}-{timestamp}-tier_raw.lh5",
+                "dsp": "/{type}/{period}/{run}/{exp}-{period}-{run}-{type}-{timestamp}-tier_dsp.lh5",
+                "hit": "/{type}/{period}/{run}/{exp}-{period}-{run}-{type}-{timestamp}-tier_hit.lh5",
+                "evt": "/{type}/{period}/{run}/{exp}-{period}-{run}-{type}-{timestamp}-tier_evt.lh5",
+                "tcm": "/{type}/{period}/{run}/{exp}-{period}-{run}-{type}-{timestamp}-tier_tcm.lh5"
+            },
+            "table_format": {
+                "raw": "ch{ch:03d}/raw",
+                "dsp": "ch{ch:03d}/dsp",
+                "hit": "{ch}/hit",
+                "evt": "{grp}/evt",
+                "tcm": "hardware_tcm"
+            },
+            "tables": {
+                "raw": [0, 1, 2, 4, 5, 6, 7],
+                "dsp": [0, 1, 2, 4, 5, 6, 7],
+                "hit": [0, 1, 2, 4, 5, 6, 7],
+                "tcm": [""],
+                "evt": [""]
+            },
+            "columns": {
+                "raw": ["baseline", "waveform", "daqenergy"],
+                "dsp": ["trapEftp", "AoE", "trapEmax"],
+                "hit": ["trapEftp_cal", "trapEmax_cal"],
+                "tcm": ["table_key", "row_in_table"],
+                "evt": ["lar_veto", "muon_veto", "ge_mult"]
+            }
+        }
+
+    :class:`FileDB` objects can be also stored on disk and read-in at later
+    times.
+
+    Examples
+    --------
+    >>> from pygama.flow import FileDB
+    >>> db = FileDB("./filedb_config.json")
+    >>> db.scan_tables_columns()  # read in also table columns names
+    >>> print(db)
+    << Columns >>
+    [['baseline', 'card', 'ch_orca', 'channel', 'crate', 'daqenergy', 'deadtime', 'dr_maxticks', 'dr_start_pps', 'dr_start_ticks', 'dr_stop_pps', 'dr_stop_ticks', 'eventnumber', 'fcid', 'numtraces', 'packet_id', 'runtime', 'timestamp', 'to_abs_mu_usec', 'to_dt_mu_usec', 'to_master_sec', 'to_mu_sec', 'to_mu_usec', 'to_start_sec', 'to_start_usec', 'tracelist', 'ts_maxticks', 'ts_pps', 'ts_ticks', 'waveform'], ['bl_intercept', 'bl_mean', 'bl_slope', 'bl_std', 'tail_slope', 'tail_std', 'wf_blsub'], ['table_key', 'row_in_table', 'cumulative_length']]
+    << DataFrame >>
+       exp period   run         timestamp type  ... hit_col_idx tcm_tables tcm_col_idx evt_tables evt_col_idx
+    0  l60    p01  r014  20220716T105236Z  cal  ...        None         []         [2]       None        None
+    1  l60    p01  r014  20220716T104550Z  cal  ...        None         []         [2]       None        None
+    >>> db.to_disk("file_db.lh5")
+    """
+
+    def __init__(self, config: str | dict | list[str], scan: bool = True) -> None:
+        """
+        Parameters
+        ----------
+        config
+            dictionary or path to JSON file specifying data directories, tiers,
+            and file name templates. Can also be path (or list of paths or
+            regular expression) to existing LH5 file containing :class:`FileDB`
+            object serialized by :meth:`.to_disk()`.
+        scan
+            whether the file database should scan the directory containing
+            `raw` files to fill its rows with file keys.
+        """
+        self.df = None
+
+        config_path = None
+        if isinstance(config, str):
+            config_path = config
+            try:
+                with open(config) as f:
+                    config = json.load(f)
+            # can otherwise be (wildcard of) HDF5 file(s)
+            except (FileNotFoundError, json.JSONDecodeError, UnicodeDecodeError):
+                self.from_disk(config)
+                return
+
+        elif isinstance(config, list):
+            self.from_disk(config)
+            return
+
+        if not isinstance(config, dict):
+            raise ValueError("Bad FileDB configuration value")
+
+        self.set_config(config, config_path)
+
+        # Set up column names
+        fm = string.Formatter()
+        parse_arr = np.array(list(fm.parse(self.file_format[self.tiers[0]])))
+        names = list(parse_arr[:, 1])  # fields required to generate file name
+        names = [n for n in names if n]  # Remove none values
+        names = list(np.unique(names))
+        names += [f"{tier}_file" for tier in self.tiers]  # the generated file names
+        names += [f"{tier}_size" for tier in self.tiers]  # file sizes
+        names += ["file_status"]  # bonus columns
+
+        self.df = pd.DataFrame(columns=names)
+
+        self.columns = None
+
+        if scan:
+            self.scan_files()
+
+            # Use config columns and tables if provided
+            if "columns" in self.config.keys() and "tables" in self.config.keys():
+                log.debug("setting columns/tables from config")
+                self.columns = list(self.config["columns"].values())
+                for tier in self.tiers:
+                    self.df[f"{tier}_tables"] = [self.config["tables"][tier]] * len(
+                        self.df
+                    )
+                    self.df[f"{tier}_col_idx"] = [
+                        [self.columns.index(self.config["columns"][tier])]
+                        * len(self.df[f"{tier}_tables"].iloc[0])
+                    ] * len(self.df)
+
+    def set_config(self, config: dict, config_path: str = None) -> None:
+        """Read in the configuration dictionary."""
+        self.config = config
+        self.tiers = list(self.config["tier_dirs"].keys())
+        self.file_format = self.config["file_format"]
+        self.table_format = self.config["table_format"]
+        self.sortby = self.config.get("sortby", "timestamp")
+
+        # expand/substitute variables in data_dir and tier_dirs
+        # $_ expands to the location of the config file
+        subst_vars = {}
+        if config_path is not None:
+            subst_vars["_"] = os.path.dirname(str(config_path))
+
+        data_dir = expand_path(self.config["data_dir"], substitute=subst_vars)
+        self.data_dir = data_dir
+
+        tier_dirs = self.config["tier_dirs"]
+        for k, val in tier_dirs.items():
+            tier_dirs[k] = expand_vars(val, substitute=subst_vars)
+        self.tier_dirs = tier_dirs
+
+    def scan_files(self, dirs: list[str] = None) -> None:
+        """Scan the directory containing files from the lowest tier and fill the dataframe.
+
+        The lowest tier is defined as the first element of the `tiers` array.
+        Only fills columns that can be populated with just these files.
+
+        Parameters
+        ----------
+        dirs
+            restrict search to this list of directories. Specified paths can be
+            absolute, relative to `self.data_dir` or relative to the root
+            directory of the lowest-tier files. If ``None``, the whole root
+            lowest-tier directory is scanned. Useful to build a partial
+            database.
+        """
+        file_keys = []
+        n_files = 0
+        low_tier = self.tiers[0]
+        template = self.file_format[low_tier]
+        root_scan_dir = os.path.join(
+            self.data_dir, self.tier_dirs[low_tier].lstrip("/")
+        )
+
+        scan_dirs = dirs
+        if dirs is None:
+            scan_dirs = [root_scan_dir]
+        elif not isinstance(dirs, list):
+            scan_dirs = [dirs]
+
+        log.info(f"scanning {scan_dirs} with template {template}")
+
+        for scan_dir in scan_dirs:
+            # some logic to guess where the scan directory is
+            if not os.path.isabs(scan_dir):
+                # first check if it's relative to lowest tier directory
+                if os.path.isdir(os.path.join(root_scan_dir, scan_dir)):
+                    scan_dir = os.path.join(root_scan_dir, scan_dir)
+                # or maybe relative to the data dir?
+                elif os.path.isdir(os.path.join(self.data_dir, scan_dir)):
+                    scan_dir = os.path.join(self.data_dir, scan_dir)
+                else:
+                    scan_dir = os.path.join(os.getcwd(), scan_dir)
+
+            log.debug(f"scanning {scan_dir}")
+
+            for path, _, files in os.walk(scan_dir):
+                log.debug(f"scanning {path}")
+                n_files += len(files)
+
+                for f in files:
+                    # in some cases, we need information from the path name
+                    if "/" in template:
+                        f_tmp = path.replace(root_scan_dir, "") + "/" + f
+                    else:
+                        f_tmp = f
+
+                    finfo = parse(template, f_tmp)
+                    if finfo is not None:
+                        finfo = finfo.named
+                        for tier in self.tiers:
+                            finfo[f"{tier}_file"] = self.file_format[tier].format(
+                                **finfo
+                            )
+
+                        file_keys.append(finfo)
+
+        if n_files == 0:
+            raise FileNotFoundError(f"no {low_tier} files found")
+
+        if len(file_keys) == 0:
+            raise FileNotFoundError(f"no {low_tier} files matched pattern " + template)
+
+        temp_df = pd.DataFrame(file_keys)
+
+        # fill the main DataFrame
+        self.df = pd.concat([self.df, temp_df])
+
+        # convert cols to numeric dtypes where possible
+        for col in self.df.columns:
+            try:
+                self.df[col] = pd.to_numeric(self.df[col])
+            except ValueError:
+                continue
+
+        # sort rows according to timestamps
+        utils.inplace_sort(self.df, self.sortby)
+
+        # set file status and sizes
+        self.set_file_status()
+        self.set_file_sizes()
+
+    def set_file_status(self) -> None:
+        """Add a column with a bit corresponding to whether each tier's file exists.
+
+        For example, if we have tiers `raw`, `dsp`, and `hit`, but only the
+        `raw` file has been produced, ``file_status`` would be 4 (``0b100`` in
+        binary representation).
+        """
+
+        def check_status(row):
+            status = 0
+            for i, tier in enumerate(self.tiers):
+                path_name = os.path.join(
+                    self.data_dir,
+                    self.tier_dirs[tier].lstrip("/"),
+                    row[f"{tier}_file"].lstrip("/"),
+                )
+                if os.path.exists(path_name):
+                    status |= 1 << len(self.tiers) - i - 1
+
+            return status
+
+        self.df["file_status"] = self.df.apply(check_status, axis=1)
+
+    def set_file_sizes(self) -> None:
+        """Add columns for each tier containing the corresponding file size in bytes.
+
+        As reported by :func:`os.path.getsize`.
+        """
+
+        def get_size(row, tier):
+            size = 0
+            path_name = os.path.join(
+                self.data_dir,
+                self.tier_dirs[tier].lstrip("/"),
+                row[f"{tier}_file"].lstrip("/"),
+            )
+            if os.path.exists(path_name):
+                size = os.path.getsize(path_name)
+            return size
+
+        for tier in self.tiers:
+            self.df[f"{tier}_size"] = self.df.apply(get_size, axis=1, tier=tier)
+
+    def scan_tables_columns(
+        self,
+        to_file: str = None,
+        override: bool = False,
+        dir_files_conform: bool = False,
+    ) -> list[str]:
+        """Open files to read (and store) available tables (and columns therein) names.
+
+        Adds the available table names in each tier as a column in the
+        dataframe by searching for group names that match the configured
+        ``table_format`` and saving the associated keyword values.
+
+        Returns a list with each unique list of columns found in each table
+        and adds a column ``{tier}_col_idx`` to the dataframe that maps to the
+        column table.
+
+        Parameters
+        ----------
+        to_file
+            Optionally write the column table to an LH5 file (as a
+            :class:`~.lgdo.vectorofvectors.VectorOfVectors`).
+        override
+            If the :class:`FileDB` already has a `columns` field, the scan will
+            not run unless this parameter is set to ``True``.
+        dir_files_conform
+            if ``True``, assume that all files in a directory contain tables
+            with the same columns (i.e. all file contents conform to the same
+            format) and scan only the first file. Significantly reduces
+            processing time.
+        """
+        log.info("getting table column names")
+
+        if self.columns is not None:
+            if not override:
+                log.warning(
+                    "LH5 tables/columns names already set, if you want to perform the scan anyway, set override=True"
+                )
+                return
+            else:
+                log.warning("overwriting existing LH5 tables/columns names")
+
+        def update_tables_cols(row, tier: str, utc_cache: dict = None) -> pd.Series:
+            fpath = os.path.join(
+                self.data_dir,
+                self.tier_dirs[tier].lstrip("/"),
+                row[f"{tier}_file"].lstrip("/"),
+            )
+            this_dir = fpath[: fpath.rfind("/")]
+            if utc_cache is not None and this_dir in utc_cache:
+                return utc_cache[this_dir]
+
+            log.debug(f"reading column names for tier '{tier}' from {fpath}")
+
+            if os.path.exists(fpath):
+                f = h5py.File(fpath)
+            else:
+                log.debug(f"{fpath} doesn't exist")
+                return pd.Series({f"{tier}_tables": None, f"{tier}_col_idx": None})
+
+            # Get tables in each tier
+            tier_tables = []
+            template = self.table_format[tier]
+            if template[-1] == "/":
+                template = template[:-1]
+
+            braces = list(re.finditer("{|}", template))
+
+            if len(braces) > 2:
+                raise ValueError("tables can only have one identifier")
+            if len(braces) % 2 != 0:
+                raise ValueError("braces mismatch in table format")
+            if len(braces) == 0:
+                tier_tables.append(0)
+            else:
+                wildcard = (
+                    template[: braces[0].span()[0]]
+                    + "*"
+                    + template[braces[1].span()[1] :]
+                )
+
+                # TODO this call here is really expensive!
+                groups = ls(f, wildcard)
+                if len(groups) > 0 and parse(template, groups[0]) is None:
+                    log.warning(f"groups in {fpath} don't match template")
+                else:
+                    tier_tables = [
+                        list(parse(template, g).named.values())[0] for g in groups
+                    ]
+
+            # Get columns
+            col_idx = []
+            template = self.table_format[tier]
+            fm = string.Formatter()
+
+            for tb in tier_tables:
+                parse_arr = np.array(list(fm.parse(template)))
+                names = list(parse_arr[:, 1])
+                if len(names) > 0:
+                    keyword = names[0]
+                    args = {keyword: tb}
+                    table_name = template.format(**args)
+                else:
+                    table_name = template
+
+                try:
+                    col = ls(f[table_name])
+                except KeyError:
+                    log.warning(f"cannot find '{table_name}' in {fpath}")
+                    continue
+                if col not in columns:
+                    columns.append(col)
+                    col_idx.append(len(columns) - 1)
+                else:
+                    col_idx.append(columns.index(col))
+
+            series = pd.Series(
+                {f"{tier}_tables": tier_tables, f"{tier}_col_idx": col_idx}
+            )
+            if utc_cache is not None:
+                utc_cache[this_dir] = series
+            return series
+
+        columns = []
+
+        # set up a cache to provide a fast option if all files in each directory
+        # are expected to all have the same cols
+        utc_cache = None
+        if dir_files_conform:
+            utc_cache = {}
+
+        for tier in self.tiers:
+            self.df[[f"{tier}_tables", f"{tier}_col_idx"]] = self.df.apply(
+                update_tables_cols, axis=1, tier=tier, utc_cache=utc_cache
+            )
+
+        self.columns = columns
+
+        if to_file is not None:
+            log.debug(f"writing column names to '{to_file}'")
+            flattened = []
+            length = []
+            for i, col in enumerate(columns):
+                if i == 0:
+                    length.append(len(col))
+                else:
+                    length.append(length[i - 1] + len(col))
+                for c in col:
+                    flattened.append(c)
+            columns_vov = VectorOfVectors(
+                flattened_data=flattened, cumulative_length=length
+            )
+            lh5.write(columns_vov, "unique_columns", to_file)
+
+        return self.columns
+
+    def from_disk(self, path: str | list[str]) -> None:
+        """Read FileDBs from disk.
+
+        Overrides the dataframe, configuration dictionary and columns with the
+        information from a file created by :meth:`to_disk`.
+
+        Parameters
+        ----------
+        path
+            file or file pattern (or list of the latter).
+        """
+        log.debug(f"reading FileDB from disk at {path}")
+
+        if not isinstance(path, list):
+            path = [path]
+
+        # expand wildcards
+        paths = []
+        for p in path:
+            paths += expand_path(p, list=True)
+
+        if not paths:
+            raise FileNotFoundError(path)
+
+        # objects/accumulators that will be used to configure the FileDB at the end
+        _cfg = None
+        _df = None
+        _columns = None
+
+        # function needed later in the loop
+        def _replace_idx(row, trans, tier):
+            col = row[f"{tier}_col_idx"]
+            if col is None:
+                return None
+
+            col = np.array(col)
+            new_col = np.copy(col)
+
+            for idx, new_idx in trans.items():
+                new_col[np.where(col == idx)] = new_idx
+
+            return new_col.tolist()
+
+        # loop over the files
+        for p in paths:
+            cfg = lh5.read("config", p)
+            cfg = json.loads(cfg.value.decode())
+
+            # make sure configurations are all the same
+            if _cfg is None:
+                _cfg = cfg
+            elif cfg != _cfg:
+                raise RuntimeError(
+                    "cannot merge FileDBs created with different configuration files"
+                )
+
+            # read in unique columns
+            vov = lh5.read("columns", p)
+            # Convert back from VoV of UTF-8 bytestrings to a list of lists of strings
+            columns = [[v.decode("utf-8") for v in ov] for ov in list(vov)]
+
+            # read in dataframe
+            df = pd.read_hdf(p, key="dataframe")
+
+            # first iteration
+            if _columns is None:
+                _columns = columns
+                _df = df
+                continue
+
+            elif _columns != columns:
+                log.debug("found inconsistent FileDB, trying to merge")
+                # if columns are not the same, need to merge the two dataframes
+                # in the right way. loop over new columns
+                idx_trans = {}
+                for idx, cols in enumerate(columns):
+                    new_idx = None
+
+                    # the columns might be a new entry...
+                    if cols not in _columns:
+                        # add the new column at the end and save its index
+                        _columns += [cols]
+                        new_idx = len(_columns) - 1
+                    # ...or just located (at a different index?) in the
+                    # existing column list
+                    else:
+                        new_idx = _columns.index(cols)
+
+                    idx_trans[idx] = new_idx
+
+                # now go through the new dataframe and update the old index
+                # everywhere in the {tier}_col_idx columns
+                for tier in list(_cfg["tier_dirs"].keys()):
+                    df[f"{tier}_col_idx"] = df.apply(
+                        _replace_idx,
+                        args=(idx_trans, tier),
+                        axis=1,
+                    )
+
+            # now we can safely concat the dataframes
+            _df = pd.concat([_df, df], ignore_index=True)
+
+        self.set_config(_cfg)
+        self.df = _df
+        self.columns = _columns
+
+        utils.inplace_sort(self.df, self.sortby)
+
+    def to_disk(self, filename: str, wo_mode="write_safe") -> None:
+        """Serializes database to disk.
+
+        Parameters
+        -----------
+        filename
+            output LH5 file name.
+        wo_mode
+            passed to :func:`~lh5.io.core.write`.
+        """
+        log.debug(f"writing database to {filename}")
+
+        lh5.write(Scalar(json.dumps(self.config)), "config", filename, wo_mode=wo_mode)
+
+        if wo_mode in ["write_safe", "w", "overwrite_file", "of"]:
+            wo_mode = "a"
+
+        if self.columns is not None:
+            flat = []
+            cum_l = [0]
+            for i in range(len(self.columns)):
+                flat += self.columns[i]
+                cum_l.append(cum_l[i] + len(self.columns[i]))
+            cum_l = cum_l[1:]
+            # Must use type 'S' to play nice with HDF
+            col_vov = VectorOfVectors(
+                flattened_data=Array(nda=np.array(flat).astype("S")),
+                cumulative_length=Array(nda=np.array(cum_l)),
+            )
+            lh5.write(col_vov, "columns", filename, wo_mode=wo_mode)
+
+        # FIXME: to_hdf() throws this:
+        #
+        #     pandas.errors.PerformanceWarning: your performance may suffer as
+        #     PyTables will pickle object types that it cannot map directly to c-types
+        #
+        # not sure how to fix this so we ignore the warning for the moment
+        warnings.simplefilter(action="ignore", category=pd.errors.PerformanceWarning)
+        self.df.to_hdf(filename, key="dataframe", format="fixed", mode="r+")
+
+    def scan_daq_files(self, daq_dir: str, daq_template: str) -> None:
+        """
+        Does the exact same thing as :meth:`.scan_files` but with extra
+        configuration arguments for a DAQ directory and template instead of
+        using the lowest tier.
+        """
+        file_keys = []
+        n_files = 0
+
+        for path, _folders, files in os.walk(daq_dir):
+            n_files += len(files)
+
+            for f in files:
+                # in some cases, we need information from the path name
+                if "/" in daq_template:
+                    f_tmp = path.replace(daq_dir, "") + "/" + f
+                else:
+                    f_tmp = f
+
+                finfo = parse(daq_template, f_tmp)
+                if finfo is not None:
+                    finfo = finfo.named
+                    file_keys.append(finfo)
+                for tier in self.tiers:
+                    finfo[f"{tier}_file"] = self.file_format[tier].format(**finfo)
+
+        if n_files == 0:
+            raise FileNotFoundError("No DAQ files found")
+
+        if len(file_keys) == 0:
+            raise FileNotFoundError("No DAQ files matched pattern ", daq_template)
+
+        temp_df = pd.DataFrame(file_keys)
+
+        # fill the main DataFrame
+        self.df = pd.concat([self.df, temp_df])
+
+        # convert cols to numeric dtypes where possible
+        for col in self.df.columns:
+            try:
+                self.df[col] = pd.to_numeric(self.df[col])
+            except ValueError:
+                continue
+
+    def get_table_name(self, tier: str, tb: str) -> str:
+        """Get the table name for a tier given its table identifier.
+
+        Parameters
+        ----------
+        tier
+            specify the tier whose table format will be used.
+        tb
+            the table identifier that will be passed to the table format.
+
+        Returns
+        -------
+        table_name
+            the name of the table in `tier` with table identifier `tb`
+        """
+        template = self.table_format[tier]
+        fm = string.Formatter()
+        parse_arr = np.array(list(fm.parse(template)))
+        names = list(parse_arr[:, 1])
+        if len(names) > 0:
+            keyword = names[0]
+            args = {keyword: tb}
+            table_name = template.format(**args)
+        else:
+            table_name = template
+        return table_name
+
+    def get_table_columns(
+        self, table: str | int, tier: str, ifile: int = 0
+    ) -> list[str]:
+        """Return list of columns in table `table`, tier `tier`.
+
+        Assumes that the table contents do not change across data files. If
+        desired, `ifile` (default is 0) can be used to select a different file.
+        """
+        tables = self.df.iloc[ifile][f"{tier}_tables"]
+        if tables is None:
+            return []
+
+        table_idx = tables.index(table)
+        col_idx = self.df.iloc[ifile][f"{tier}_col_idx"][table_idx]
+        return self.columns[col_idx]
+
+    def __repr__(self) -> str:
+        string = f"FileDB(data_dir={self.data_dir}, tiers={self.tier_dirs}, "
+
+        if self.df is not None:
+            string += "df=DataFrame(...), "
+        else:
+            string += "df=None, "
+
+        if self.columns is not None:
+            string += "columns=[...]"
+        else:
+            string += "columns=None"
+
+        return string + ")"

--- a/src/pygama/flow/query_meta.py
+++ b/src/pygama/flow/query_meta.py
@@ -444,11 +444,17 @@ def query_meta(
             raise ValueError(msg)
 
         # Format and return results
-        result = ak.Array(records)
         if library == "ak":
-            pass
+            result = ak.Array(records)
         elif library == "pd":
-            result = ak.to_dataframe(result)
+            result = pd.json_normalize(records, sep='/')
+            cols = result.columns.str.split('/', expand=True)
+            # if columns are nested, they will be tuples; if nesting is uneven,
+            # some tuples may have NaN; replace with '' to get better behavior
+            if isinstance(cols[0], tuple):
+                result.columns = pd.MultiIndex.from_tuples(
+                    [[name if not pd.isna(name) else '' for name in c] for c in cols]
+                )
         elif library == "np":
             if group_chans:
                 msg = "library 'np' is not compatible with group_chans=True"

--- a/src/pygama/flow/utils.py
+++ b/src/pygama/flow/utils.py
@@ -1,9 +1,164 @@
+from __future__ import annotations
+
 from dbetto import TextDB
 import keyword
+import logging
 import re
 import string
+from datetime import datetime, timezone
 
 import awkward as ak
+import numpy as np
+import pandas as pd
+from lgdo import Array, ArrayOfEqualSizedArrays, Table, VectorOfVectors, WaveformTable
+
+log = logging.getLogger(__name__)
+
+# Util functions associated with dataloader
+
+def to_datetime(key: str) -> datetime:
+    """Convert LEGEND cycle key to :class:`~datetime.datetime`.
+
+    Assumes `key` is formatted as ``YYYYMMDDTHHMMSSZ`` (UTC).
+    """
+    m = re.match(r"^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})Z$", key)
+    if m is None:
+        raise ValueError(f"Could not parse '{key}' as a datetime object")
+    else:
+        g = [int(el) for el in m.groups()]
+        return datetime(*g, tzinfo=timezone.utc)
+
+
+def to_unixtime(key: str) -> int:
+    """Convert LEGEND cycle key to `POSIX timestamp <https://en.wikipedia.org/wiki/Unix_time>`_."""
+    return int(to_datetime(key).timestamp())
+
+
+def inplace_sort(df: pd.DataFrame, by: str) -> None:
+    # sort rows according to timestamps
+    log.debug(f"sorting database entries according to {by}")
+    if by == "timestamp":
+        df["_datetime"] = df["timestamp"].apply(to_datetime)
+        df.sort_values("_datetime", ignore_index=True, inplace=True)
+        df.drop("_datetime", axis=1, inplace=True)
+    else:
+        df.sort_values(by, ignore_index=True, inplace=True)
+
+
+def dict_to_table(col_dict: dict, attr_dict: dict):
+    for col in col_dict.keys():
+        if isinstance(col_dict[col], list):
+            if isinstance(col_dict[col][0], (list, np.ndarray, Array)):
+                # Convert to VectorOfVectors if there is array-like in a list
+                col_dict[col] = VectorOfVectors(
+                    listoflists=col_dict[col], attrs=attr_dict[col]
+                )
+            else:
+                # Elements are scalars, convert to Array
+                nda = np.array(col_dict[col])
+                col_dict[col] = Array(nda=nda, attrs=attr_dict[col])
+        elif isinstance(col_dict[col], dict):
+            # Dicts are Tables
+            col_dict[col] = dict_to_table(
+                col_dict=col_dict[col], attr_dict=attr_dict[col]
+            )
+        else:
+            # ndas are Arrays or AOESA
+            nda = np.array(col_dict[col])
+            if len(nda.shape) == 2:
+                dt = attr_dict[col]["datatype"]
+                g = re.match(r"\w+<(\d+),(\d+)>{\w+}", dt).groups()
+                dims = [int(e) for e in g]
+                col_dict[col] = ArrayOfEqualSizedArrays(
+                    dims=dims, nda=nda, attrs=attr_dict[col]
+                )
+            else:
+                col_dict[col] = Array(nda=nda, attrs=attr_dict[col])
+        attr_dict.pop(col)
+    if set(col_dict.keys()) == {"t0", "dt", "values"}:
+        return WaveformTable(
+            t0=col_dict["t0"],
+            dt=col_dict["dt"],
+            values=col_dict["values"],
+            attrs=attr_dict,
+        )
+    else:
+        return Table(col_dict=col_dict)
+
+
+def fill_col_dict(
+    tier_table: Table,
+    col_dict: dict,
+    attr_dict: dict,
+    tcm_idx: list | pd.RangeIndex,
+    table_length: int,
+    aoesa_to_vov: bool,
+):
+    # Put the information from the tier_table (after the columns have been exploded)
+    # into col_dict, which will be turned into the final Table
+    for col in tier_table.keys():
+        if col not in attr_dict.keys():
+            attr_dict[col] = tier_table[col].attrs
+        else:
+            if attr_dict[col] != tier_table[col].attrs:
+                if isinstance(tier_table[col], Table):
+                    temp_attr = {
+                        k: attr_dict[col][k]
+                        for k in attr_dict[col].keys() - tier_table[col].keys()
+                    }
+                    if temp_attr != tier_table[col].attrs:
+                        raise ValueError(
+                            f"{col} attributes are inconsistent across data"
+                        )
+                else:
+                    raise ValueError(f"{col} attributes are inconsistent across data")
+        if isinstance(tier_table[col], ArrayOfEqualSizedArrays):
+            # Allocate memory for column for all channels
+            if aoesa_to_vov:  # convert to VectorOfVectors
+                if col not in col_dict.keys():
+                    col_dict[col] = [[]] * table_length
+                for i, idx in enumerate(tcm_idx):
+                    col_dict[col][idx] = tier_table[col].nda[i]
+            else:  # Try to make AoESA, raise error otherwise
+                if col not in col_dict.keys():
+                    col_dict[col] = np.empty(
+                        (table_length, len(tier_table[col].nda[0])),
+                        dtype=tier_table[col].dtype,
+                    )
+                col_dict[col][tcm_idx] = tier_table[col].nda
+        elif isinstance(tier_table[col], VectorOfVectors):
+            # Allocate memory for column for all channels
+            if col not in col_dict.keys():
+                col_dict[col] = [[]] * table_length
+            for i, idx in enumerate(tcm_idx):
+                col_dict[col][idx] = tier_table[col][i]
+        elif isinstance(tier_table[col], Array):
+            # Allocate memory for column for all channels
+            if col not in col_dict.keys():
+                col_dict[col] = np.empty(
+                    table_length,
+                    dtype=tier_table[col].dtype,
+                )
+            col_dict[col][tcm_idx] = tier_table[col].nda
+        elif isinstance(tier_table[col], Table):
+            if col not in col_dict.keys():
+                col_dict[col] = {}
+            col_dict[col], attr_dict[col] = fill_col_dict(
+                tier_table[col],
+                col_dict[col],
+                attr_dict[col],
+                tcm_idx,
+                table_length,
+                aoesa_to_vov,
+            )
+        else:
+            log.warning(
+                f"not sure how to handle column {col} "
+                f"of type {type(tier_table[col])} yet"
+            )
+    return col_dict, attr_dict
+
+# Util functions associated with queries
 
 def get_recursive(db: TextDB, path: str):
     """Helper to recursively access values from nested dict-likes"""

--- a/tests/flow/configs/config.json
+++ b/tests/flow/configs/config.json
@@ -1,0 +1,1 @@
+data-loader-config.json

--- a/tests/flow/configs/data-loader-config.json
+++ b/tests/flow/configs/data-loader-config.json
@@ -1,0 +1,22 @@
+{
+  "filedb": "$_/filedb-config.json",
+  "levels": {
+    "hit": {
+      "tiers": ["raw", "dsp", "hit"]
+    },
+    "tcm": {
+      "tiers": ["tcm"],
+      "parent": "hit",
+      "child": "evt",
+      "tcm_cols": {
+        "child_idx": "coin_idx",
+        "parent_tb": "table_key",
+        "parent_idx": "row_in_table"
+      }
+    },
+    "evt": {
+      "tiers": ["evt"]
+    }
+  },
+  "channel_map": {}
+}

--- a/tests/flow/configs/filedb-config.json
+++ b/tests/flow/configs/filedb-config.json
@@ -1,0 +1,24 @@
+{
+  "data_dir": "lh5/prod-ref-l200/generated/tier",
+  "tier_dirs": {
+    "raw": "/raw",
+    "dsp": "/dsp",
+    "hit": "/hit",
+    "tcm": "/tcm",
+    "evt": "/evt"
+  },
+  "file_format": {
+    "raw": "/{type}/{period}/{run}/{exp}-{period}-{run}-{type}-{timestamp}-tier_raw.lh5",
+    "dsp": "/{type}/{period}/{run}/{exp}-{period}-{run}-{type}-{timestamp}-tier_dsp.lh5",
+    "hit": "/{type}/{period}/{run}/{exp}-{period}-{run}-{type}-{timestamp}-tier_hit.lh5",
+    "evt": "/{type}/{period}/{run}/{exp}-{period}-{run}-{type}-{timestamp}-tier_evt.lh5",
+    "tcm": "/{type}/{period}/{run}/{exp}-{period}-{run}-{type}-{timestamp}-tier_tcm.lh5"
+  },
+  "table_format": {
+    "raw": "ch{ch:07d}/raw",
+    "dsp": "ch{ch:07d}/dsp",
+    "hit": "ch{ch:07d}/hit",
+    "evt": "{grp}/evt",
+    "tcm": "hardware_tcm_1"
+  }
+}

--- a/tests/flow/configs/nested/config.json
+++ b/tests/flow/configs/nested/config.json
@@ -1,0 +1,1 @@
+data-loader-config-nested.json

--- a/tests/flow/configs/nested/data-loader-config-nested.json
+++ b/tests/flow/configs/nested/data-loader-config-nested.json
@@ -1,0 +1,25 @@
+{
+  "nest1": {
+    "nest2": {
+      "filedb": "$_/filedb-config.json",
+      "levels": {
+        "hit": {
+          "tiers": ["raw", "dsp", "hit"]
+        },
+        "tcm": {
+          "tiers": ["tcm"],
+          "parent": "hit",
+          "child": "evt",
+          "tcm_cols": {
+            "child_idx": "coin_idx",
+            "parent_tb": "table_key",
+            "parent_idx": "row_in_table"
+          }
+        },
+        "evt": {
+          "tiers": ["evt"]
+        }
+      }
+    }
+  }
+}

--- a/tests/flow/conftest.py
+++ b/tests/flow/conftest.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from pygama.flow import FileDB
+
+config_dir = Path(__file__).parent / "configs"
+
+
+@pytest.fixture(scope="module")
+def test_filedb(lgnd_test_data):
+    with (config_dir / "filedb-config.json").open() as f:
+        config = json.load(f)
+
+    config["data_dir"] = lgnd_test_data.get_path("lh5/prod-ref-l200/generated/tier")
+    db = FileDB(config, scan=False)
+    db.scan_files(["cal/p03/r001", "phy/p03/r001"])
+    return db
+
+
+@pytest.fixture(scope="module")
+def test_filedb_full(lgnd_test_data):
+    with (config_dir / "filedb-config.json").open() as f:
+        config = json.load(f)
+
+    config["data_dir"] = lgnd_test_data.get_path("lh5/prod-ref-l200/generated/tier")
+    db = FileDB(config, scan=False)
+    db.scan_files(["cal/p03/r001", "phy/p03/r001"])
+    db.scan_tables_columns()
+    return db

--- a/tests/flow/test_data_loader.py
+++ b/tests/flow/test_data_loader.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import lgdo
+import numpy as np
+import pandas as pd
+import pytest
+
+from pygama.flow import DataLoader
+
+config_dir = Path(__file__).parent / "configs"
+
+
+@pytest.fixture
+def test_dl(test_filedb):
+    return DataLoader(f"{config_dir}/data-loader-config.json", test_filedb)
+
+
+def test_init(test_dl):
+    pass
+
+
+def test_init_variants(test_filedb):
+    assert DataLoader(str(config_dir), test_filedb).config is not None
+    assert (
+        DataLoader(
+            f"{config_dir}/nested/data-loader-config-nested.json[nest1/nest2]",
+            test_filedb,
+        ).config
+        is not None
+    )
+    assert (
+        DataLoader(f"{config_dir}/nested[nest1/nest2]", test_filedb).config is not None
+    )
+
+
+def test_simple_load(test_dl):
+    test_dl.set_files("all")
+    test_dl.set_output(columns=["timestamp"])
+    data = test_dl.load()
+
+    assert isinstance(data, lgdo.Table)
+    assert list(data.keys()) == ["hit_table", "hit_idx", "file", "timestamp"]
+
+
+def test_simple_chunked_load(test_dl):
+    test_dl.set_files("all")
+    test_dl.set_output(columns=["timestamp"])
+    for data in test_dl.next(chunk_size=2):
+        assert len(data) == 2
+        assert isinstance(data, lgdo.Table)
+        assert list(data.keys()) == ["hit_table", "hit_idx", "file", "timestamp"]
+
+
+def test_load_wfs(test_dl):
+    test_dl.set_files("all")
+    test_dl.set_output(columns=["waveform"], fmt="lgdo.Table")
+    data = test_dl.load()
+    assert isinstance(data, lgdo.Table)
+    assert list(data.keys()) == ["hit_table", "hit_idx", "file", "waveform"]
+
+    test_dl.set_output(columns=["waveform"], fmt="pd.DataFrame")
+    data = test_dl.load()
+    assert isinstance(data, pd.DataFrame)
+    assert list(data.keys()) == [
+        "hit_table",
+        "hit_idx",
+        "file",
+        "waveform_t0",
+        "waveform_dt",
+        "waveform_values",
+    ]
+
+
+def test_no_merge(test_dl):
+    test_dl.set_files("all")
+    test_dl.set_output(columns=["timestamp"], merge_files=False)
+    data = test_dl.load()
+
+    assert isinstance(data, lgdo.Struct)
+    assert isinstance(data["0"], lgdo.Table)
+    assert len(data) == 4  # 4 files
+    assert list(data["0"].keys()) == ["hit_table", "hit_idx", "timestamp"]
+
+
+def test_outputs(test_dl):
+    test_dl.set_files("type == 'phy'")
+    test_dl.set_datastreams([1057600, 1059201], "ch")
+    test_dl.set_output(
+        fmt="pd.DataFrame", columns=["timestamp", "channel", "energies", "energy_in_pe"]
+    )
+    data = test_dl.load()
+
+    assert isinstance(data, pd.DataFrame)
+    assert list(data.keys()) == [
+        "hit_table",
+        "hit_idx",
+        "file",
+        "timestamp",
+        "channel",
+        "energies",
+        "energy_in_pe",
+    ]
+
+
+def test_any_mode(test_dl):
+    test_dl.filedb.scan_tables_columns()
+    test_dl.set_files("type == 'phy'")
+    test_dl.set_cuts({"hit": "daqenergy == 10221"})
+    el = test_dl.build_entry_list(tcm_level="tcm", mode="any")
+
+    assert len(el) == 6
+
+
+def test_set_files(test_dl):
+    test_dl.set_files("timestamp == '20230318T012144Z'")
+    test_dl.set_output(columns=["timestamp"], merge_files=False)
+    data = test_dl.load()
+
+    assert len(data) == 1
+
+
+def test_set_keylist(test_dl):
+    test_dl.set_files(["20230318T012144Z", "20230318T012228Z"])
+    test_dl.set_output(columns=["timestamp"], merge_files=False)
+    data = test_dl.load()
+
+    assert len(data) == 2
+
+
+def test_set_datastreams(test_dl):
+    channels = [1084803, 1084804, 1121600]
+    test_dl.set_files("timestamp == '20230318T012144Z'")
+    test_dl.set_datastreams(channels, "ch")
+    test_dl.set_output(columns=["eventnumber"], fmt="pd.DataFrame", merge_files=False)
+    data = test_dl.load()
+
+    assert np.array_equal(data[0]["hit_table"].unique(), channels)
+
+
+def test_set_cuts(test_dl):
+    test_dl.set_files("type == 'cal'")
+    test_dl.set_cuts({"hit": "is_valid_cal == False"})
+    test_dl.set_datastreams([1084803], "ch")
+    test_dl.set_output(columns=["is_valid_cal"], fmt="pd.DataFrame")
+    data = test_dl.load()
+
+    assert (data.is_valid_cal == False).all()  # noqa: E712
+
+
+def test_setter_overwrite(test_dl):
+    test_dl.set_files("all")
+    test_dl.set_datastreams([1084803, 1084804, 1121600], "ch")
+    test_dl.set_cuts({"hit": "trapEmax > 5000"})
+    test_dl.set_output(columns=["trapEmax"])
+
+    data = test_dl.load().view_as("pd")
+
+    test_dl.set_files("timestamp == '20230318T012144Z'")
+    test_dl.set_datastreams([1084803, 1121600], "ch")
+    test_dl.set_cuts({"hit": "trapEmax > 0"})
+
+    data2 = test_dl.load().view_as("pd")
+
+    assert 1084804 not in data2["hit_table"]
+    assert len(pd.unique(data2["file"])) == 1
+    assert len(data2.query("hit_table == 1084803")) > len(
+        data.query("hit_table == 1084803")
+    )
+
+
+def test_browse(test_dl):
+    test_dl.set_files("type == 'phy'")
+    test_dl.set_datastreams([1057600, 1059201], "ch")
+    test_dl.set_output(
+        fmt="pd.DataFrame", columns=["timestamp", "channel", "energies", "energy_in_pe"]
+    )
+    wb = test_dl.browse()
+
+    wb.draw_next()

--- a/tests/flow/test_filedb.py
+++ b/tests/flow/test_filedb.py
@@ -1,0 +1,366 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from lh5.io.exceptions import LH5EncodeError
+from pandas.testing import assert_frame_equal
+
+from pygama.flow import FileDB
+
+config_dir = Path(__file__).parent / "configs"
+
+
+def test_chain_filedbs(lgnd_test_data, test_filedb_full, tmp_dir):  # noqa: ARG001
+    with (config_dir / "filedb-config.json").open() as f:
+        config = json.load(f)
+
+    config["data_dir"] = lgnd_test_data.get_path("lh5/prod-ref-l200/generated/tier")
+
+    fdb1 = FileDB(config, scan=False)
+    fdb1.scan_files("cal/p03/r001")
+    fdb1.scan_tables_columns()
+    fdb1.to_disk(f"{tmp_dir}/fdb1.h5")
+
+    fdb2 = FileDB(config, scan=False)
+    fdb2.scan_files("phy/p03/r001")
+    fdb2.scan_tables_columns()
+    fdb2.to_disk(f"{tmp_dir}/fdb2.h5")
+
+    # columns from cal and phy data should be different
+    assert fdb1.columns
+    assert fdb2.columns
+    assert fdb1.columns != fdb2.columns
+
+    # test invariance to merge direction
+    for fdb in [
+        FileDB([f"{tmp_dir}/fdb1.h5", f"{tmp_dir}/fdb2.h5"]),
+        FileDB([f"{tmp_dir}/fdb2.h5", f"{tmp_dir}/fdb1.h5"]),
+    ]:
+        # check that merging columns works
+        merged_columns = []
+        for it in fdb1.columns + fdb2.columns:
+            if it not in merged_columns:
+                merged_columns += [it]
+
+        assert sorted(fdb.columns, key=lambda item: item[0]) == sorted(
+            merged_columns, key=lambda item: item[0]
+        )
+
+        assert len(fdb.df) == len(fdb1.df) + len(fdb2.df)
+
+        # cal comes first in time, then phy
+
+        # hpge channel
+        tbl = 1084804
+        assert fdb.get_table_columns(tbl, "raw", ifile=0) == fdb1.get_table_columns(
+            tbl, "raw", ifile=0
+        )
+        assert fdb.get_table_columns(tbl, "dsp", ifile=0) == fdb1.get_table_columns(
+            tbl, "dsp", ifile=0
+        )
+
+        # at a later timestamp (phy), columns in dsp should be the same as in fdb2
+        assert fdb.get_table_columns(tbl, "dsp", ifile=2) == fdb2.get_table_columns(
+            tbl, "dsp", ifile=0
+        )
+
+        # sipm channel, not in cal
+        tbl = 1057600
+        assert fdb.get_table_columns(tbl, "raw", ifile=2) == fdb2.get_table_columns(
+            tbl, "raw", ifile=0
+        )
+        assert fdb.get_table_columns(tbl, "hit", ifile=2) == fdb2.get_table_columns(
+            tbl, "hit", ifile=0
+        )
+
+
+def test_filedb_basics(test_filedb):
+    db = test_filedb
+
+    assert list(db.df.keys()) == [
+        "exp",
+        "period",
+        "run",
+        "timestamp",
+        "type",
+        "raw_file",
+        "dsp_file",
+        "hit_file",
+        "tcm_file",
+        "evt_file",
+        "raw_size",
+        "dsp_size",
+        "hit_size",
+        "tcm_size",
+        "evt_size",
+        "file_status",
+    ]
+
+    assert db.df.to_numpy().tolist() == [
+        [
+            "l200",
+            "p03",
+            "r001",
+            "20230318T012144Z",
+            "cal",
+            "/cal/p03/r001/l200-p03-r001-cal-20230318T012144Z-tier_raw.lh5",
+            "/cal/p03/r001/l200-p03-r001-cal-20230318T012144Z-tier_dsp.lh5",
+            "/cal/p03/r001/l200-p03-r001-cal-20230318T012144Z-tier_hit.lh5",
+            "/cal/p03/r001/l200-p03-r001-cal-20230318T012144Z-tier_tcm.lh5",
+            "/cal/p03/r001/l200-p03-r001-cal-20230318T012144Z-tier_evt.lh5",
+            874456,
+            484864,
+            224776,
+            28672,
+            0,
+            30,
+        ],
+        [
+            "l200",
+            "p03",
+            "r001",
+            "20230318T012228Z",
+            "cal",
+            "/cal/p03/r001/l200-p03-r001-cal-20230318T012228Z-tier_raw.lh5",
+            "/cal/p03/r001/l200-p03-r001-cal-20230318T012228Z-tier_dsp.lh5",
+            "/cal/p03/r001/l200-p03-r001-cal-20230318T012228Z-tier_hit.lh5",
+            "/cal/p03/r001/l200-p03-r001-cal-20230318T012228Z-tier_tcm.lh5",
+            "/cal/p03/r001/l200-p03-r001-cal-20230318T012228Z-tier_evt.lh5",
+            874456,
+            484864,
+            224776,
+            28672,
+            0,
+            30,
+        ],
+        [
+            "l200",
+            "p03",
+            "r001",
+            "20230322T160139Z",
+            "phy",
+            "/phy/p03/r001/l200-p03-r001-phy-20230322T160139Z-tier_raw.lh5",
+            "/phy/p03/r001/l200-p03-r001-phy-20230322T160139Z-tier_dsp.lh5",
+            "/phy/p03/r001/l200-p03-r001-phy-20230322T160139Z-tier_hit.lh5",
+            "/phy/p03/r001/l200-p03-r001-phy-20230322T160139Z-tier_tcm.lh5",
+            "/phy/p03/r001/l200-p03-r001-phy-20230322T160139Z-tier_evt.lh5",
+            1747968,
+            601440,
+            388368,
+            28672,
+            0,
+            30,
+        ],
+        [
+            "l200",
+            "p03",
+            "r001",
+            "20230322T170202Z",
+            "phy",
+            "/phy/p03/r001/l200-p03-r001-phy-20230322T170202Z-tier_raw.lh5",
+            "/phy/p03/r001/l200-p03-r001-phy-20230322T170202Z-tier_dsp.lh5",
+            "/phy/p03/r001/l200-p03-r001-phy-20230322T170202Z-tier_hit.lh5",
+            "/phy/p03/r001/l200-p03-r001-phy-20230322T170202Z-tier_tcm.lh5",
+            "/phy/p03/r001/l200-p03-r001-phy-20230322T170202Z-tier_evt.lh5",
+            1747968,
+            601440,
+            388368,
+            28672,
+            0,
+            30,
+        ],
+    ]
+
+
+def test_scan_tables_columns(test_filedb_full):
+    db = test_filedb_full
+
+    assert set(db.df.keys()) == {
+        "exp",
+        "period",
+        "run",
+        "timestamp",
+        "type",
+        "raw_file",
+        "dsp_file",
+        "hit_file",
+        "tcm_file",
+        "evt_file",
+        "raw_size",
+        "dsp_size",
+        "hit_size",
+        "tcm_size",
+        "evt_size",
+        "file_status",
+        "raw_tables",
+        "raw_col_idx",
+        "dsp_tables",
+        "dsp_col_idx",
+        "hit_tables",
+        "hit_col_idx",
+        "tcm_tables",
+        "tcm_col_idx",
+        "evt_tables",
+        "evt_col_idx",
+    }
+
+    assert db.columns == [
+        [
+            "abs_delta_mu_usec",
+            "baseline",
+            "board_id",
+            "channel",
+            "crate",
+            "daqenergy",
+            "deadtime",
+            "delta_mu_usec",
+            "dr_maxticks",
+            "dr_start_pps",
+            "dr_start_ticks",
+            "dr_stop_pps",
+            "dr_stop_ticks",
+            "event_type",
+            "eventnumber",
+            "fc_input",
+            "fcid",
+            "mu_offset_sec",
+            "mu_offset_usec",
+            "numtraces",
+            "packet_id",
+            "runtime",
+            "slot",
+            "timestamp",
+            "to_master_sec",
+            "to_start_sec",
+            "to_start_usec",
+            "tracelist",
+            "ts_maxticks",
+            "ts_pps",
+            "ts_ticks",
+            "waveform",
+        ],
+        [
+            "A_max",
+            "QDrift",
+            "baseline",
+            "bl_intercept",
+            "bl_mean",
+            "bl_slope",
+            "bl_slope_diff",
+            "bl_slope_rms",
+            "bl_std",
+            "cuspEftp",
+            "cuspEmax",
+            "dt_eff",
+            "dt_eff_invert",
+            "lq80",
+            "pz_mean",
+            "pz_slope",
+            "pz_slope_diff",
+            "pz_slope_rms",
+            "pz_std",
+            "t_discharge",
+            "t_sat_hi",
+            "t_sat_lo",
+            "timestamp",
+            "tp_01",
+            "tp_0_atrap",
+            "tp_0_est",
+            "tp_0_invert",
+            "tp_10",
+            "tp_100",
+            "tp_100_invert",
+            "tp_10_invert",
+            "tp_20",
+            "tp_20_invert",
+            "tp_50",
+            "tp_50_invert",
+            "tp_80",
+            "tp_80_invert",
+            "tp_90",
+            "tp_90_invert",
+            "tp_95",
+            "tp_99",
+            "tp_99_invert",
+            "tp_aoe_max",
+            "tp_max",
+            "tp_max_win",
+            "tp_min",
+            "tp_min_win",
+            "trapEftp",
+            "trapEmax",
+            "trapSmax",
+            "trapTftp_invert",
+            "trapTmax",
+            "trapTmax_invert",
+            "wf_max",
+            "wf_max_win",
+            "wf_min",
+            "wf_min_win",
+            "zacEftp",
+            "zacEmax",
+        ],
+        ["energies", "energies_dplms", "timestamp", "trigger_pos", "trigger_pos_dplms"],
+        [
+            "AoE_Classifier",
+            "AoE_Corrected",
+            "AoE_Double_Sided_Cut",
+            "AoE_Low_Cut",
+            "cuspEmax_ctc_cal",
+            "is_discharge",
+            "is_downgoing_baseline",
+            "is_neg_energy",
+            "is_negative",
+            "is_negative_crosstalk",
+            "is_noise_burst",
+            "is_saturated",
+            "is_upgoing_baseline",
+            "is_valid_0vbb",
+            "is_valid_baseline",
+            "is_valid_cal",
+            "is_valid_dteff",
+            "is_valid_ediff",
+            "is_valid_efrac",
+            "is_valid_rt",
+            "is_valid_t0",
+            "is_valid_tail",
+            "is_valid_tmax",
+            "timestamp",
+            "trapEmax_ctc_cal",
+            "trapTmax_cal",
+            "zacEmax_ctc_cal",
+        ],
+        [
+            "energy_in_pe",
+            "energy_in_pe_dplms",
+            "is_valid_hit",
+            "is_valid_hit_dplms",
+            "timestamp",
+            "trigger_pos",
+            "trigger_pos_dplms",
+        ],
+        ["row_in_table", "table_key"],
+    ]
+
+
+def test_serialization(test_filedb_full, tmp_dir):
+    db = test_filedb_full
+    db.to_disk(f"{tmp_dir}/filedb.lh5", wo_mode="of")
+
+    with pytest.raises(LH5EncodeError):
+        db.to_disk(f"{tmp_dir}/filedb.lh5")
+
+    db2 = FileDB(f"{tmp_dir}/filedb.lh5")
+    assert_frame_equal(db.df, db2.df, check_dtype=False)
+
+
+def test_get_table_columns(test_filedb_full):
+    db = test_filedb_full
+    cols = db.get_table_columns(1084803, "dsp")
+    assert cols == db.columns[1]
+    with pytest.raises(KeyError):
+        db.get_table_columns(1084803, "blah")
+    with pytest.raises(ValueError):
+        db.get_table_columns(9999, "raw")

--- a/tests/flow/test_flow_utils.py
+++ b/tests/flow/test_flow_utils.py
@@ -1,8 +1,20 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
+
 import pytest
 
-from pygama.flow.utils import parse_query_paths
+from pygama.flow.utils import parse_query_paths, to_datetime, to_unixtime
+
+
+def test_key_to_datetime():
+    assert to_datetime("20220716T105236Z") == datetime(
+        2022, 7, 16, 10, 52, 36, tzinfo=timezone.utc
+    )
+
+
+def test_key_to_unixtime():
+    assert to_unixtime("20220716T105236Z") == 1657968756
 
 
 def test_parse_query_paths():


### PR DESCRIPTION
The old data loader and filedb code was added back into `pygama.flow` as it is a dependency for the data monitoring.

Query_meta with `library='pd'` no longer uses `ak` as an intermediary; this enables it to read some of the values with numeric keys.