### PR TITLE
Improve error handling and error messages in pargen

### DIFF
--- a/src/pygama/pargen/AoE_cal.py
+++ b/src/pygama/pargen/AoE_cal.py
@@ -881,15 +881,18 @@ def bimodal_dt_fit(
                     (mus[0] * aoe_pars["mu"]) - (mus[1] * aoe_pars2["mu"])
                 )
             except ZeroDivisionError:
+                log.debug(
+                    "bimodal_dt_fit: alpha denominator is zero, falling back to alpha = 0"
+                )
                 alpha = 0
 
             dt_res_dict["alpha"] = alpha
             log.info("dtcorr successful alpha: %s", alpha)
 
-    except BaseException as e:
-        if isinstance(e, KeyboardInterrupt) or debug_mode:
-            raise e
-        log.error("Drift time correction (bimodal_dt_fit) failed")
+    except Exception as e:
+        if debug_mode:
+            raise
+        log.error("Drift time correction (bimodal_dt_fit) failed: %s", e)
 
     return alpha, dt_res_dict
 
@@ -937,7 +940,7 @@ def mcdrift(
         )
     except Exception as e:
         if debug_mode:
-            raise e
+            raise
         log.error("MCD drift: event selection query failed: %s", e)
         return 0, {}
 
@@ -1003,7 +1006,7 @@ def mcdrift(
         mcd = MinCovDet().fit(subset)
     except Exception as e:
         if debug_mode:
-            raise e
+            raise
         log.error("MCD drift: MCD fit failed: %s", e)
         return 0, {}
 
@@ -1215,9 +1218,15 @@ class CalAoE:
                                 ),
                             ]
                         )
-                    except BaseException as e:
-                        if isinstance(e, KeyboardInterrupt) or self.debug_mode:
-                            raise (e)
+                    except Exception as e:
+                        if self.debug_mode:
+                            raise
+                        log.debug(
+                            "A/E time correction: fit failed for run_timestamp %s, filling nan: %s",
+                            tstamp,
+                            e,
+                            exc_info=True,
+                        )
                         self.timecorr_df = pd.concat(
                             [
                                 self.timecorr_df,
@@ -1332,12 +1341,21 @@ class CalAoE:
                             raise ValueError(msg)
 
                     else:
-                        msg = "unknown mode"
+                        msg = (
+                            f"unknown mode {mode!r}, expected 'full', 'partial', 'none', "
+                            "'average_consecutive' or 'interpolate_consecutive'"
+                        )
                         raise ValueError(msg)
 
-                    df[output_name] = df[aoe_param] / np.array(
-                        [time_dict[tstamp] for tstamp in df["run_timestamp"]]
-                    )
+                    try:
+                        df[output_name] = df[aoe_param] / np.array(
+                            [time_dict[tstamp] for tstamp in df["run_timestamp"]]
+                        )
+                    except KeyError as e:
+                        msg = (
+                            f"no time-correction entry for run_timestamp {e.args[0]!r}"
+                        )
+                        raise KeyError(msg) from e
                     self.update_cal_dicts(final_time_dict)
                 else:
                     df[output_name] = (
@@ -1385,10 +1403,14 @@ class CalAoE:
                             ),
                         ]
                     )
-                except BaseException as e:
-                    if isinstance(e, KeyboardInterrupt) or self.debug_mode:
-                        raise (e)
-
+                except Exception as e:
+                    if self.debug_mode:
+                        raise
+                    log.debug(
+                        "A/E time correction: single-run fit failed, filling nan: %s",
+                        e,
+                        exc_info=True,
+                    )
                     self.timecorr_df = pd.concat(
                         [
                             self.timecorr_df,
@@ -1417,10 +1439,10 @@ class CalAoE:
                     }
                 )
                 log.info("Finished A/E time correction")
-        except BaseException as e:
-            if isinstance(e, KeyboardInterrupt) or self.debug_mode:
-                raise (e)
-            log.error("A/E time correction failed")
+        except Exception as e:
+            if self.debug_mode:
+                raise
+            log.error("A/E time correction failed: %s", e)
             df[output_name] = df[aoe_param] / np.nan
             self.update_cal_dicts(
                 {
@@ -1609,9 +1631,15 @@ class CalAoE:
                         ]
                     )
 
-                except BaseException as e:
-                    if isinstance(e, KeyboardInterrupt) or self.debug_mode:
-                        raise (e)
+                except Exception as e:
+                    if self.debug_mode:
+                        raise
+                    log.debug(
+                        "A/E energy correction: fit failed for compton band %s, filling nan: %s",
+                        band,
+                        e,
+                        exc_info=True,
+                    )
                     self.energy_corr_fits = pd.concat(
                         [
                             self.energy_corr_fits,
@@ -1717,10 +1745,14 @@ class CalAoE:
                     pdf=self.pdf,
                     display=display,
                 )
-            except BaseException as e:
-                if isinstance(e, KeyboardInterrupt) or self.debug_mode:
-                    raise (e)
-
+            except Exception as e:
+                if self.debug_mode:
+                    raise
+                log.debug(
+                    "A/E energy correction: DEP fit failed, filling nan: %s",
+                    e,
+                    exc_info=True,
+                )
                 dep_pars, dep_err, _ = return_nans(self.pdf)
 
             data[corrected_param] = data[aoe_param] / self.mean_func.func(
@@ -1733,10 +1765,10 @@ class CalAoE:
             log.info("mean pars are %s", mu_pars.to_dict())
             log.info("sigma pars are %s", sig_pars.to_dict())
 
-        except BaseException as e:
-            if isinstance(e, KeyboardInterrupt) or self.debug_mode:
-                raise (e)
-            log.error("A/E energy correction failed")
+        except Exception as e:
+            if self.debug_mode:
+                raise
+            log.error("A/E energy correction failed: %s", e)
             mu_pars, mu_errs, _mu_cov = return_nans(self.mean_func.func)
             csqr_mu, dof_mu, p_val_mu = (np.nan, np.nan, np.nan)
             csqr_sig, dof_sig, p_val_sig = (np.nan, np.nan, np.nan)
@@ -1889,10 +1921,10 @@ class CalAoE:
                 data[output_cut_param] = (
                     data[output_cut_param] & (data[self.dt_cut_param])
                 )
-        except BaseException as e:
-            if isinstance(e, KeyboardInterrupt) or self.debug_mode:
-                raise (e)
-            log.error("A/E cut determination failed")
+        except Exception as e:
+            if self.debug_mode:
+                raise
+            log.error("A/E cut determination failed: %s", e)
             self.low_cut_val = np.nan
             data[output_cut_param] = False
 
@@ -2010,9 +2042,9 @@ class CalAoE:
                     )
                     peak_dfs[peak] = cut_df
                 log.info("%skeV: %.1f +/- %.1f %%", peak, sf, sf_err)
-            except BaseException as e:
-                if isinstance(e, KeyboardInterrupt) or self.debug_mode:
-                    raise (e)
+            except Exception as e:
+                if self.debug_mode:
+                    raise
                 sfs = pd.concat(
                     [
                         sfs,
@@ -2020,8 +2052,9 @@ class CalAoE:
                     ]
                 )
                 log.error(
-                    "A/E Survival fraction sweep determination failed for %s peak",
+                    "A/E survival fraction sweep determination failed for %s peak: %s",
                     peak,
+                    e,
                 )
         sfs = sfs.set_index("peak")
         return sfs, peak_dfs
@@ -2112,9 +2145,9 @@ class CalAoE:
                     )
                 log.info("%skeV: %.1f +/- %.1f %%", peak, sf, sf_err)
 
-            except BaseException as e:
-                if isinstance(e, KeyboardInterrupt) or self.debug_mode:
-                    raise (e)
+            except Exception as e:
+                if self.debug_mode:
+                    raise
                 sfs = pd.concat(
                     [
                         sfs,
@@ -2122,7 +2155,9 @@ class CalAoE:
                     ]
                 )
                 log.error(
-                    "A/E survival fraction determination failed for %s peak", peak
+                    "A/E survival fraction determination failed for %s peak: %s",
+                    peak,
+                    e,
                 )
         return sfs.set_index("peak")
 
@@ -2757,7 +2792,7 @@ def plot_sigma_fit(aoe_class, _data, figsize=(12, 8), fontsize=12) -> plt.figure
         if aoe_class.sigma_func == SigmaFit:
             label = f"sqrt model: \nsqrt({sig_pars['a']:1.4f}+({sig_pars['b']:1.1f}/E)^{sig_pars['c']:1.1f})"
         else:
-            msg = "unknown sigma function"
+            msg = f"unknown sigma function {aoe_class.sigma_func!r}, expected SigmaFit"
             raise ValueError(msg)
         ax1.plot(
             aoe_class.energy_corr_fits.index.to_numpy(),

--- a/src/pygama/pargen/data_cleaning.py
+++ b/src/pygama/pargen/data_cleaning.py
@@ -95,6 +95,9 @@ def get_keys(in_data, cut_dict):
         possible_keys = in_data.keys()
     elif isinstance(in_data, Collection):
         possible_keys = in_data
+    else:
+        msg = f"in_data must be a Mapping or Collection, got {type(in_data).__name__}"
+        raise TypeError(msg)
     for param in parameters:
         for key in possible_keys:
             if key in param:
@@ -146,7 +149,11 @@ def get_mode_stdev(par_array) -> tuple:
 
         upper_bound = mu + 10 * guess_sig
 
-    except Exception:
+    except Exception as e:
+        log.debug(
+            "get_mode_stdev: fwhm estimate failed, falling back to percentile bounds: %s",
+            e,
+        )
         lower_bound = np.nanpercentile(par_array, 5)
         upper_bound = np.nanpercentile(par_array, 95)
 
@@ -187,13 +194,18 @@ def get_mode_stdev(par_array) -> tuple:
             or (mean + std) < mu
             or (mean - std) > mu
         ):
-            raise IndexError
+            msg = "gaussian mode estimate fell outside histogram range"
+            raise IndexError(msg)
     except IndexError:
         try:
             fwhm = pgh.get_fwhm(counts, bins)[0]
             mean = float(bin_centres[np.argmax(counts)])
             std = fwhm / 2.355
-        except Exception:
+        except Exception as e:
+            log.debug(
+                "get_mode_stdev: fwhm estimate failed, retrying with percentile bounds: %s",
+                e,
+            )
             lower_bound = np.nanpercentile(par_array, 5)
             upper_bound = np.nanpercentile(par_array, 95)
 
@@ -214,7 +226,11 @@ def get_mode_stdev(par_array) -> tuple:
                 fwhm = pgh.get_fwhm(counts, bins)[0]
                 mean = float(bin_centres[np.argmax(counts)])
                 std = fwhm / 2.355
-            except Exception:
+            except Exception as e:
+                log.debug(
+                    "get_mode_stdev: fwhm estimate failed, falling back to nanstd: %s",
+                    e,
+                )
                 mean = float(bin_centres[np.argmax(counts)])
                 std = np.nanstd(par_array)
     return mean, std
@@ -518,6 +534,12 @@ def generate_cuts(
         data = pd.DataFrame.from_dict(data)
     elif isinstance(data, dict):
         data = pd.DataFrame.from_dict(data)
+    else:
+        msg = (
+            "data must be a pandas DataFrame, lgdo Table or dict, "
+            f"got {type(data).__name__}"
+        )
+        raise ValueError(msg)
     for out_par, cut in cut_dict.items():
         if "expression" in cut:
             output_dict[out_par] = {"expression": cut["expression"]}
@@ -530,7 +552,11 @@ def generate_cuts(
             try:
                 all_par_array = data[par].to_numpy()
             except KeyError:
-                all_par_array = data.eval(par).to_numpy()
+                try:
+                    all_par_array = data.eval(par).to_numpy()
+                except Exception as e:
+                    msg = f"unable to find or evaluate cut parameter {par!r} in data"
+                    raise ValueError(msg) from e
 
             bad_entries = (~np.isnan(all_par_array)) & (~np.isinf(all_par_array))
 
@@ -546,16 +572,24 @@ def generate_cuts(
                 num_sigmas_left = num_sigmas
                 num_sigmas_right = num_sigmas
             elif isinstance(num_sigmas, dict):
-                if "low_side" in num_sigmas:
-                    num_sigmas_left = num_sigmas["low_side"]
-                else:
-                    num_sigmas_left = None
-                if "high_side" in num_sigmas:
-                    num_sigmas_right = num_sigmas["high_side"]
-                else:
-                    num_sigmas_right = None
-            upper = round(float((num_sigmas_right * std) + mean), rounding)
-            lower = round(float((-num_sigmas_left * std) + mean), rounding)
+                num_sigmas_left = num_sigmas.get("low_side")
+                num_sigmas_right = num_sigmas.get("high_side")
+            else:
+                msg = (
+                    f"cut_level for {par!r} must be a number or dict, "
+                    f"got {type(num_sigmas).__name__}"
+                )
+                raise TypeError(msg)
+            upper = (
+                round(float((num_sigmas_right * std) + mean), rounding)
+                if num_sigmas_right is not None
+                else None
+            )
+            lower = (
+                round(float((-num_sigmas_left * std) + mean), rounding)
+                if num_sigmas_left is not None
+                else None
+            )
             if mode == "inclusive":
                 if upper is not None and lower is not None:
                     cut_string = f"({par}>a) & ({par}<b)"
@@ -576,6 +610,9 @@ def generate_cuts(
                 elif lower is None:
                     cut_string = f"{par}>a"
                     par_dict = {"a": upper}
+            else:
+                msg = f"unknown mode {mode!r}, expected 'inclusive' or 'exclusive'"
+                raise ValueError(msg)
 
             output_dict[out_par] = {"expression": cut_string, "parameters": par_dict}
 
@@ -652,7 +689,9 @@ def get_cut_indexes(data, cut_parameters):
             data[outname] = data.eval(exp, local_dict=info.get("parameters", None))
             ct_mask = ct_mask & data[outname]
     else:
-        msg = "Data must be a Table or DataFrame"
+        msg = (
+            f"data must be an lgdo Table or pandas DataFrame, got {type(data).__name__}"
+        )
         raise ValueError(msg)
 
     return ct_mask
@@ -743,6 +782,12 @@ def generate_cut_classifiers(
         data = pd.DataFrame.from_dict(data)
     elif isinstance(data, dict):
         data = pd.DataFrame.from_dict(data)
+    else:
+        msg = (
+            "data must be a pandas DataFrame, lgdo Table or dict, "
+            f"got {type(data).__name__}"
+        )
+        raise ValueError(msg)
     for out_par, cut in cut_dict.items():
         if "expression" in cut:
             output_dict[out_par] = {"expression": cut["expression"]}
@@ -758,7 +803,11 @@ def generate_cut_classifiers(
             try:
                 all_par_array = data[par].to_numpy()
             except KeyError:
-                all_par_array = data.eval(par).to_numpy()
+                try:
+                    all_par_array = data.eval(par).to_numpy()
+                except Exception as e:
+                    msg = f"unable to find or evaluate cut parameter {par!r} in data"
+                    raise ValueError(msg) from e
 
             mean, std = get_mode_stdev(all_par_array)
 
@@ -769,14 +818,14 @@ def generate_cut_classifiers(
                     cut_left = -num_sigmas
                     cut_right = num_sigmas
                 elif isinstance(num_sigmas, dict):
-                    if "low_side" in num_sigmas:
-                        cut_left = num_sigmas["low_side"]
-                    else:
-                        cut_left = None
-                    if "high_side" in num_sigmas:
-                        cut_right = num_sigmas["high_side"]
-                    else:
-                        cut_right = None
+                    cut_left = num_sigmas.get("low_side")
+                    cut_right = num_sigmas.get("high_side")
+                else:
+                    msg = (
+                        f"cut_level for {par!r} must be a number or dict, "
+                        f"got {type(num_sigmas).__name__}"
+                    )
+                    raise TypeError(msg)
 
             elif percentile is not None:
                 if method == "fit":
@@ -814,7 +863,10 @@ def generate_cut_classifiers(
                     elif func == skewed_fit:
                         cdf = skewnorm.cdf(xs, pars["alpha"], pars["mu"], pars["sigma"])
                     else:
-                        msg = "unknown func"
+                        msg = (
+                            f"unknown func {getattr(func, '__name__', func)!r}, expected "
+                            "exgauss, gaussian, gauss_on_exgauss_areas, double_exgauss or skewed_fit"
+                        )
                         raise ValueError(msg)
 
                     if isinstance(percentile, int | float):
@@ -824,14 +876,24 @@ def generate_cut_classifiers(
                     elif isinstance(percentile, dict):
                         if "low_side" in percentile:
                             cut_left = xs[
-                                np.argmin(np.abs(cdf - (1 - (percentile / 100))))
+                                np.argmin(
+                                    np.abs(cdf - (1 - (percentile["low_side"] / 100)))
+                                )
                             ]
                         else:
                             cut_left = None
                         if "high_side" in percentile:
-                            cut_right = xs[np.argmin(np.abs(cdf - (percentile / 100)))]
+                            cut_right = xs[
+                                np.argmin(np.abs(cdf - (percentile["high_side"] / 100)))
+                            ]
                         else:
                             cut_right = None
+                    else:
+                        msg = (
+                            f"cut_percentile for {par!r} must be a number or dict, "
+                            f"got {type(percentile).__name__}"
+                        )
+                        raise TypeError(msg)
 
                 elif isinstance(percentile, int | float):
                     cut_left = np.nanpercentile(norm_par_array, 100 - percentile)
@@ -839,13 +901,29 @@ def generate_cut_classifiers(
 
                 elif isinstance(percentile, dict):
                     if "low_side" in percentile:
-                        cut_left = np.nanpercentile(norm_par_array, percentile)
+                        cut_left = np.nanpercentile(
+                            norm_par_array, 100 - percentile["low_side"]
+                        )
                     else:
                         cut_left = None
                     if "high_side" in percentile:
-                        cut_right = np.nanpercentile(norm_par_array, percentile)
+                        cut_right = np.nanpercentile(
+                            norm_par_array, percentile["high_side"]
+                        )
                     else:
                         cut_right = None
+                else:
+                    msg = (
+                        f"cut_percentile for {par!r} must be a number or dict, "
+                        f"got {type(percentile).__name__}"
+                    )
+                    raise TypeError(msg)
+            else:
+                msg = (
+                    f"cut definition for {par!r} must provide either "
+                    "'cut_level' or 'cut_percentile'"
+                )
+                raise ValueError(msg)
 
             if default is not None:
                 value = default["value"]
@@ -874,7 +952,10 @@ def generate_cut_classifiers(
                     if cut_right is not None:
                         cut_right = max(cut_right, default_cut_right)
                 else:
-                    msg = "unknown mode"
+                    msg = (
+                        f"unknown default mode {default_mode!r}, "
+                        "expected 'higher_limit' or 'lower_limit'"
+                    )
                     raise ValueError(msg)
 
             if mode == "inclusive":
@@ -897,6 +978,9 @@ def generate_cut_classifiers(
                 elif cut_left is None:
                     cut_string = f"{out_par}_classifier>a"
                     par_dict = {"a": cut_right}
+            else:
+                msg = f"unknown mode {mode!r}, expected 'inclusive' or 'exclusive'"
+                raise ValueError(msg)
 
             output_dict[f"{out_par}_classifier"] = {
                 "expression": f"(({par})-a)/b",
@@ -978,7 +1062,6 @@ def find_pulser_properties(df, energy="daqenergy"):
     )
     peak_e_err = pt_pars[:, 1] * 4
 
-    allowed_mask = np.ones(len(peak_energies), dtype=bool)
     for j, e in enumerate(peak_energies[1:-1]):
         i = j + 1
         if peak_e_err[i] > allowed_err:
@@ -1009,8 +1092,15 @@ def find_pulser_properties(df, energy="daqenergy"):
             peak_e_err[i + 1] -= (overlap) * (peak_e_err[i + 1] / total)
 
     out_pulsers = []
-    for i, e in enumerate(peak_energies[allowed_mask]):
-        if peak_e_err[i] > allowed_err:
+    for i, e in enumerate(peak_energies):
+        if np.isnan(peak_e_err[i]) or peak_e_err[i] > allowed_err:
+            log.debug(
+                "find_pulser_properties: skipping peak at %s, "
+                "half-width %s is nan or above %s",
+                e,
+                peak_e_err[i],
+                allowed_err,
+            )
             continue
 
         try:
@@ -1051,7 +1141,10 @@ def find_pulser_properties(df, energy="daqenergy"):
 
             else:
                 continue
-        except Exception:
+        except Exception as ex:
+            log.debug(
+                "find_pulser_properties: skipping candidate peak at %s: %s", e, ex
+            )
             continue
     return out_pulsers
 

--- a/src/pygama/pargen/dplms_ge_dict.py
+++ b/src/pygama/pargen/dplms_ge_dict.py
@@ -16,6 +16,7 @@ from scipy.stats import chi2
 
 from pygama.pargen.dsp_optimize import run_one_dsp
 from pygama.pargen.energy_optimisation import fom_fwhm_with_alpha_fit
+from pygama.pargen.utils import require_config_keys
 
 log = logging.getLogger(__name__)
 
@@ -57,6 +58,29 @@ def dplms_ge_dict(
     """
 
     t0 = time.time()
+
+    require_config_keys(
+        dplms_dict,
+        [
+            "bl_field",
+            "bsize",
+            "length",
+            "wsize",
+            "wf_field",
+            "peaks_kev",
+            "kev_widths",
+            "dp_coeffs",
+            "dp_def",
+            "fwhm_limit",
+            "err_limit",
+            "p_val_lim",
+            "rt_low",
+            "peak_lim",
+            "centroid_lim",
+        ],
+        name="dplms_dict",
+    )
+
     log.info("Using baseline-selected FFT events")
 
     dsp_fft = run_one_dsp(raw_fft, dsp_config, db_dict=par_dsp)
@@ -165,8 +189,16 @@ def dplms_ge_dict(
                 idxs=np.where(~np.isnan(dsp_opt[ctc_par].nda))[0],
                 frac_max=0.5,
             )
-        except Exception:
-            log.debug("FWHM not calculated")
+        except Exception as e:
+            log.debug(
+                "FWHM not calculated for grid point %s (nm=%s, za=%s, pl=%s, ft=%s): %s",
+                i,
+                nm_coeff,
+                za_coeff,
+                pl_coeff,
+                ft_coeff,
+                e,
+            )
             continue
 
         fwhm, fwhm_err, alpha, chisquare = (
@@ -223,9 +255,31 @@ def dplms_ge_dict(
         ):
             log.info("\nBest case: %s", best_case_values)
         else:
-            log.debug("Some values are missing in the best case results")
+            missing = [
+                k
+                for k, v in zip(
+                    ["fwhm", "fwhm_err", "alpha", "nm", "za", "pl", "ft", "rt", "pt"],
+                    [
+                        fwhm,
+                        fwhm_err,
+                        alpha,
+                        nm_coeff,
+                        za_coeff,
+                        pl_coeff,
+                        ft_coeff,
+                        rt_coeff,
+                        pt_coeff,
+                    ],
+                    strict=True,
+                )
+                if v is None
+            ]
+            log.warning("missing values in the best case results: %s", missing)
     else:
-        log.debug("Filter synthesis failed")
+        log.warning(
+            "no grid point passed the fwhm/err/p-value limits, "
+            "falling back to default coefficients"
+        )
         nm_coeff = dplms_dict["dp_def"]["nm"]
         za_coeff = dplms_dict["dp_def"]["za"]
         pl_coeff = dplms_dict["dp_def"]["pl"]

--- a/src/pygama/pargen/dplms_ge_dict.py
+++ b/src/pygama/pargen/dplms_ge_dict.py
@@ -80,7 +80,11 @@ def dplms_ge_dict(
         ],
         name="dplms_dict",
     )
-
+    require_config_keys(
+        dplms_dict["dp_def"],
+        ["nm", "za", "pl", "ft", "rt", "pt"],
+        name="dplms_dict['dp_def']",
+    )
     log.info("Using baseline-selected FFT events")
 
     dsp_fft = run_one_dsp(raw_fft, dsp_config, db_dict=par_dsp)

--- a/src/pygama/pargen/dsp_optimize.py
+++ b/src/pygama/pargen/dsp_optimize.py
@@ -127,7 +127,7 @@ class ParGrid:
         """
         axes = []
         for i in range(self.get_n_dimensions()):
-            axes.append(self.dims[i].values_strs)
+            axes.append(self.dims[i].value_strs)
         return np.meshgrid(*axes, copy, sparse, indexing="ij")
 
     def get_zero_indices(self):
@@ -519,7 +519,10 @@ class BayesianOptimizer:
             self.sampling_rate = sampling_rate
         else:
             if sampling_rate is not None:
-                msg = "Unknown type for sampling rate"
+                msg = (
+                    "sampling_rate must be a str or pint.Quantity, "
+                    f"got {type(sampling_rate).__name__}"
+                )
                 raise TypeError(msg)
 
             self.sampling_rate = None
@@ -942,8 +945,11 @@ class BayesianOptimizer:
         fail_idxs = np.isnan(self.yerr_init)
         self.gauss_pr.fit(self.x_init[~nan_idxs], np.array(self.y_init)[~nan_idxs])
         if (len(self.dims) != 2) and (len(self.dims) != 1):
-            msg = "Acquisition Function Plotting not implemented for dim!=2"
-            raise Exception(msg)
+            msg = (
+                "acquisition function plotting is only implemented for "
+                f"1 or 2 dimensions, got {len(self.dims)}"
+            )
+            raise NotImplementedError(msg)
         if len(self.dims) == 1:
             points = np.arange(self.dims[0].min_val, self.dims[0].max_val, 0.1)
 
@@ -1046,8 +1052,11 @@ class BayesianOptimizer:
         nan_idxs = np.isnan(self.y_init)
         self.gauss_pr.fit(self.x_init[~nan_idxs], np.array(self.y_init)[~nan_idxs])
         if (len(self.dims) != 2) and (len(self.dims) != 1):
-            msg = "Acquisition Function Plotting not implemented for dim!=2"
-            raise Exception(msg)
+            msg = (
+                "acquisition function plotting is only implemented for "
+                f"1 or 2 dimensions, got {len(self.dims)}"
+            )
+            raise NotImplementedError(msg)
         if len(self.dims) == 1:
             points = np.arange(self.dims[0].min_val, self.dims[0].max_val, 0.1)
             ys = np.zeros_like(points)

--- a/src/pygama/pargen/energy_cal.py
+++ b/src/pygama/pargen/energy_cal.py
@@ -2445,7 +2445,10 @@ def get_hpge_energy_fixed(func):
         fixed = ["x_lo", "x_hi"]
 
     else:
-        msg = f"get_hpge_energy_fixed not implemented for {func.__name__}"
+        msg = (
+            "get_hpge_energy_fixed not implemented for "
+            f"{getattr(func, '__name__', func)}"
+        )
         raise NotImplementedError(msg)
     mask = ~np.isin(func.required_args(), fixed)
     return fixed, mask

--- a/src/pygama/pargen/energy_cal.py
+++ b/src/pygama/pargen/energy_cal.py
@@ -75,15 +75,16 @@ class HPGeCalibration:
         self.energy_param = energy_param
 
         if deg < -1:
-            log.error("hpge_E_cal warning: invalid deg = %s", deg)
-            return
+            msg = f"invalid deg = {deg}, must be >= -1"
+            raise ValueError(msg)
         self.deg = int(deg)
 
         self.peaks_kev = np.asarray(sorted(glines))
         self.peak_locs = []
 
-        if guess_kev <= 0:
-            log.error("hpge_E_cal warning: invalid guess_kev = %s", guess_kev)
+        if np.isscalar(guess_kev) and guess_kev <= 0:
+            msg = f"invalid guess_kev = {guess_kev}, must be positive"
+            raise ValueError(msg)
         if deg == -1:
             self.pars = np.zeros(2, dtype=float)
             self.pars[0] = guess_kev
@@ -633,13 +634,8 @@ class HPGeCalibration:
                 csqr = (csqr[0], csqr[1] + len(np.where(mask)[0]))
 
                 if np.isnan(pars_i).any():
-                    log.debug(
-                        "hpge_cal_energy_peak_tops: fit failed for i_peak=%s at loc %g, par is nan : %s",
-                        i_peak,
-                        mode_guess,
-                        pars_i,
-                    )
-                    raise RuntimeError
+                    msg = f"fit at loc {mode_guess:g} returned nan parameters: {pars_i}"
+                    raise RuntimeError(msg)
 
                 p_val = scipy.stats.chi2.sf(csqr[0], csqr[1])
 
@@ -689,12 +685,14 @@ class HPGeCalibration:
 
                 mu, mu_err = func_i.get_mu(pars_i, errors=errs_i)
 
-            except BaseException as e:
-                if isinstance(e, KeyboardInterrupt) or self.debug_mode:
-                    raise (e)
+            except Exception as e:
+                if self.debug_mode:
+                    raise
                 log.debug(
-                    "hpge_cal_energy_peak_tops: fit failed for i_peak=%s, unknown error",
+                    "hpge_cal_energy_peak_tops: fit failed for i_peak=%s: %s",
                     i_peak,
+                    e,
+                    exc_info=True,
                 )
                 valid_pk = False
                 pars_i, errs_i, cov_i = return_nans(func_i)
@@ -787,8 +785,12 @@ class HPGeCalibration:
             results_dict["calibration_uncertainties"] = errs
             results_dict["calibration_covariance"] = cov
 
-        except ValueError:
-            log.error("Failed to fit enough peaks to get accurate calibration")
+        except ValueError as e:
+            log.error(
+                "failed to fit enough peaks to get accurate calibration for %s: %s",
+                self.energy_param,
+                e,
+            )
 
         self.update_results_dict(results_dict)
 
@@ -1005,13 +1007,8 @@ class HPGeCalibration:
                     csqr = (csqr[0], csqr[1] + len(np.where(mask)[0]))
 
                 if np.isnan(pars_i).any():
-                    log.debug(
-                        "hpge_fit_energy_peaks: fit failed for i_peak=%s at loc %g, par is nan : %s",
-                        i_peak,
-                        mode_guess,
-                        pars_i,
-                    )
-                    raise RuntimeError
+                    msg = f"fit at loc {mode_guess:g} returned nan parameters: {pars_i}"
+                    raise RuntimeError(msg)
 
                 p_val = scipy.stats.chi2.sf(csqr[0], csqr[1])
 
@@ -1076,18 +1073,17 @@ class HPGeCalibration:
                 elif peak_param == "mode":
                     mu, mu_err = func_i.get_mode(pars_i, cov=cov_i)
                 else:
-                    log.error(
-                        "hpge_fit_energy_peaks: mode %s not recognized",
-                        self.peak_param,
-                    )
-                    raise RuntimeError
+                    msg = f"unknown peak_param {peak_param!r}, expected 'mu' or 'mode'"
+                    raise ValueError(msg)
 
-            except BaseException as e:
-                if isinstance(e, KeyboardInterrupt) or self.debug_mode:
-                    raise (e)
+            except Exception as e:
+                if self.debug_mode:
+                    raise
                 log.debug(
-                    "hpge_fit_energy_peaks: fit failed for i_peak=%s, unknown error",
+                    "hpge_fit_energy_peaks: fit failed for i_peak=%s: %s",
                     i_peak,
+                    e,
+                    exc_info=True,
                 )
                 valid_pk = False
                 pars_i, errs_i, cov_i = return_nans(func_i)
@@ -1183,8 +1179,12 @@ class HPGeCalibration:
             results_dict["calibration_uncertainties"] = errs
             results_dict["calibration_covariance"] = cov
 
-        except ValueError:
-            log.error("Failed to fit enough peaks to get accurate calibration")
+        except ValueError as e:
+            log.error(
+                "failed to fit enough peaks to get accurate calibration for %s: %s",
+                self.energy_param,
+                e,
+            )
 
         self.update_results_dict(results_dict)
 
@@ -1285,7 +1285,8 @@ class HPGeCalibration:
         """
         try:
             if len(fwhm_peaks) == 0:
-                raise RuntimeError
+                msg = "no valid peaks available to fit the energy resolution curve"
+                raise RuntimeError(msg)
             c_lin = cost.LeastSquares(fwhm_peaks, fwhms, dfwhms, fwhm_func.func)
             # c_lin.loss = "soft_l1"
             m = Minuit(c_lin, *fwhm_func.guess(fwhm_peaks, fwhms, dfwhms))
@@ -1323,7 +1324,7 @@ class HPGeCalibration:
                     fwhme,
                     fwhm_func.func(peak, *results["parameters"]),
                 )
-        except RuntimeError:
+        except RuntimeError as e:
             pars, errs, cov = return_nans(fwhm_func.func)
             results = {
                 "function": fwhm_func,
@@ -1335,7 +1336,7 @@ class HPGeCalibration:
                 "csqr": (np.nan, np.nan),
                 "p_val": 0,
             }
-            log.error("FWHM fit failed to converge")
+            log.error("FWHM fit failed: %s", e)
         return results
 
     @staticmethod
@@ -1385,9 +1386,15 @@ class HPGeCalibration:
                     )
                     interp_err = np.nanstd(interp_vals)
                     interp_fwhm = fwhm_func.func(energy, *fwhm_results["parameters"])
-                except BaseException as e:
+                except Exception as e:
                     if debug_mode:
-                        raise (e)
+                        raise
+                    log.debug(
+                        "FWHM interpolation at %s keV failed, filling nan: %s",
+                        energy,
+                        e,
+                        exc_info=True,
+                    )
                     interp_fwhm = np.nan
                     interp_err = np.nan
                 fwhm_results.update(
@@ -1552,9 +1559,14 @@ class HPGeCalibration:
                                     peak_par[1][1] - 5,
                                 )
                                 peak_pars[j] = (peak, new_kev_ranges, peak_par[2])
-                except BaseException as e:
+                except Exception as e:
                     if self.debug_mode:
-                        raise (e)
+                        raise
+                    log.debug(
+                        "FWHM-based refit range adjustment failed, keeping original ranges: %s",
+                        e,
+                        exc_info=True,
+                    )
 
             self.hpge_fit_energy_peaks(
                 e_uncal,
@@ -1653,7 +1665,9 @@ class HPGeCalibration:
         log.debug("Find peaks and compute calibration curve for %s", self.energy_param)
         log.debug("Guess is %.3f", self.pars[1])
         if self.deg != 0:
-            log.error("deg must be 0 for calibrate_prominent_peak")
+            log.error(
+                "calibrate_prominent_peak requires deg = 0, got deg = %s", self.deg
+            )
             return
         self.hpge_find_energy_peaks(e_uncal)
         self.hpge_get_energy_peaks(e_uncal)
@@ -1929,9 +1943,12 @@ class HPGeCalibration:
                     new_locs, new_labels = get_peak_labels(locs, self.pars)
                     plt.xticks(ticks=new_locs, labels=new_labels)
 
-            except BaseException as e:
+            except Exception as e:
                 if self.debug_mode:
-                    raise (e)
+                    raise
+                log.debug(
+                    "calibration plot: peak labelling failed: %s", e, exc_info=True
+                )
 
         plt.tight_layout()
         plt.close()
@@ -2169,9 +2186,15 @@ def hpge_fit_energy_peak_tops(
                 inflate_errors=inflate_errors,
                 gof_method=gof_method,
             )
-        except BaseException as e:
-            if isinstance(e, KeyboardInterrupt) or debug_mode:
-                raise (e)
+        except Exception as e:
+            if debug_mode:
+                raise
+            log.debug(
+                "hpge_fit_energy_peak_tops: fit failed for peak at %s, filling None: %s",
+                e_peak,
+                e,
+                exc_info=True,
+            )
             pars, cov = None, None
 
         pars_list.append(pars)
@@ -2307,7 +2330,8 @@ def get_hpge_energy_peak_par_guess(
                 or abs(sigma / sigma_guess) > 5
                 or sigma > (fit_range[1] - fit_range[0]) / 2
             ):
-                raise ValueError
+                msg = f"interpolated sigma estimate {sigma} failed sanity checks"
+                raise ValueError(msg)
         except ValueError:
             try:
                 sigma = pgh.get_fwfm(
@@ -2421,8 +2445,8 @@ def get_hpge_energy_fixed(func):
         fixed = ["x_lo", "x_hi"]
 
     else:
-        log.error("get_hpge_energy_fixed not implemented for %s", func.__name__)
-        return None
+        msg = f"get_hpge_energy_fixed not implemented for {func.__name__}"
+        raise NotImplementedError(msg)
     mask = ~np.isin(func.required_args(), fixed)
     return fixed, mask
 
@@ -2846,7 +2870,8 @@ def unbinned_staged_energy_fit(
                     & (~(np.array(m.errors)[mask] == 0).all())
                 )
             except Exception as e:
-                raise RuntimeError from e
+                msg = "minos error estimation failed after tail-drop refit"
+                raise RuntimeError(msg) from e
 
         fit = (m.values, m.errors, m.covariance, cs, func, mask, valid3, m)
 
@@ -2869,7 +2894,12 @@ def unbinned_staged_energy_fit(
         fit = fit2
 
     else:
-        raise RuntimeError
+        msg = (
+            "unable to choose between tail and no-tail fits: "
+            f"p-values ({cs[0]}, {cs2[0]}) and fractional errors "
+            f"({frac_errors1}, {frac_errors2}) are indistinguishable"
+        )
+        raise RuntimeError(msg)
 
     if (func == pgf.hpge_peak) and allow_tail_drop is True:
         p_val = chi2.sf(fit[3][0], fit[3][1])

--- a/src/pygama/pargen/energy_optimisation.py
+++ b/src/pygama/pargen/energy_optimisation.py
@@ -15,7 +15,7 @@ import numpy as np
 import pygama.math.distributions as pgd
 import pygama.math.histogram as pgh
 import pygama.pargen.energy_cal as pgc
-from pygama.pargen.utils import convert_to_minuit, return_nans
+from pygama.pargen.utils import convert_to_minuit, require_config_keys, return_nans
 
 log = logging.getLogger(__name__)
 
@@ -259,7 +259,12 @@ def get_peak_fwhm_with_dt_corr(
         for i, p in enumerate(par_b):
             try:
                 y_b[i] = func.get_fwfm(p, frac_max=frac_max)
-            except Exception:
+            except Exception as e:
+                log.debug(
+                    "bootstrap fwfm evaluation failed for sample %s, filling nan: %s",
+                    i,
+                    e,
+                )
                 y_b[i] = np.nan
         fwhm_err = np.nanstd(y_b, axis=0)
         fwhm_o_max_err = np.nanstd(y_b / maxs, axis=0)
@@ -284,7 +289,12 @@ def get_peak_fwhm_with_dt_corr(
             )
             plt.show()
 
-    except Exception:
+    except Exception as e:
+        log.warning(
+            "get_peak_fwhm_with_dt_corr: fit failed for peak %s, returning nan: %s",
+            peak,
+            e,
+        )
         return (
             np.nan,
             np.nan,
@@ -358,6 +368,9 @@ def fom_fwhm_with_alpha_fit(
         ``alpha_err``, ``chisquare``, ``n_sig``, and ``n_sig_err``.
         All values are ``np.nan`` (and ``alpha`` is 0) on failure.
     """
+    require_config_keys(
+        kwarg_dict, ["parameter", "func", "peak", "kev_width"], name="kwarg_dict"
+    )
     parameter = kwarg_dict["parameter"]
     func = kwarg_dict["func"]
     energies = tb_in[parameter].nda
@@ -377,11 +390,11 @@ def fom_fwhm_with_alpha_fit(
         dt = dt[idxs]
     try:
         if np.isnan(energies).any():
-            log.debug("nan in energies")
-            raise RuntimeError
+            msg = f"nan in energies for {parameter}"
+            raise RuntimeError(msg)
         if np.isnan(dt).any():
-            log.debug("nan in dts")
-            raise RuntimeError
+            msg = f"nan in drift times for {ctc_parameter}"
+            raise RuntimeError(msg)
         fwhms = np.array([])
         final_alphas = np.array([])
         fwhm_errs = np.array([])
@@ -428,8 +441,11 @@ def fom_fwhm_with_alpha_fit(
 
         # Make sure fit isn't based on only a few points
         if len(fwhms) < nsteps * 0.2 and early_break is False:
-            log.debug("less than 20% fits successful")
-            raise RuntimeError
+            msg = (
+                f"less than 20% of alpha-sweep fits successful "
+                f"({len(fwhms)} of {nsteps})"
+            )
+            raise RuntimeError(msg)
 
         ids = (fwhm_errs < 2 * np.nanpercentile(fwhm_errs, 50)) & (fwhm_errs > 1e-10)
         # Fit alpha curve to get best alpha
@@ -471,12 +487,13 @@ def fom_fwhm_with_alpha_fit(
                 )
                 plt.show()
 
-        except Exception:
-            log.debug("alpha fit failed")
+        except Exception as e:
+            msg = "alpha polynomial fit failed"
+            raise RuntimeError(msg) from e
 
         if np.isnan(fit_vals).all():
-            log.debug("alpha fit all nan")
-            raise RuntimeError
+            msg = "alpha polynomial fit returned all nan"
+            raise RuntimeError(msg)
         (
             final_fwhm,
             _,
@@ -503,8 +520,8 @@ def fom_fwhm_with_alpha_fit(
             display=display,
         )
         if np.isnan(final_fwhm) or np.isnan(final_err):
-            log.debug("final fit failed, alpha was %s", alpha)
-            raise RuntimeError
+            msg = f"final dt-corrected fit failed, alpha was {alpha}"
+            raise RuntimeError(msg)
         return {
             "fwhm": final_fwhm,
             "fwhm_err": final_err,
@@ -514,7 +531,13 @@ def fom_fwhm_with_alpha_fit(
             "n_sig": n_sig,
             "n_sig_err": n_sig_err,
         }
-    except Exception:
+    except Exception as e:
+        log.warning(
+            "fom_fwhm_with_alpha_fit failed for peak %s (%s), returning nan: %s",
+            peak,
+            parameter,
+            e,
+        )
         return {
             "fwhm": np.nan,
             "fwhm_err": np.nan,
@@ -577,6 +600,9 @@ def fom_fwhm_no_alpha_sweep(
         ``mu``, ``mu_err``, and ``fit_pars``.  All values are ``np.nan``
         if the input energies contain NaNs.
     """
+    require_config_keys(
+        kwarg_dict, ["parameter", "func", "peak", "kev_width"], name="kwarg_dict"
+    )
     parameter = kwarg_dict["parameter"]
     func = kwarg_dict["func"]
     energies = tb_in[parameter].nda
@@ -592,7 +618,6 @@ def fom_fwhm_no_alpha_sweep(
             dt = tb_in[ctc_param].nda
         except KeyError:
             dt = tb_in.eval(ctc_param)
-            dt = tb_in[ctc_param].nda
     else:
         dt = 0
 
@@ -683,6 +708,9 @@ def fom_single_peak_alpha_sweep(data, kwarg_dict, display=0) -> dict:
         at minimum ``fwhm``, ``fwhm_err``, ``alpha``, ``n_sig``, and
         ``n_sig_err``.
     """
+    require_config_keys(
+        kwarg_dict, ["idx_list", "ctc_param", "peak_dicts"], name="kwarg_dict"
+    )
     idx_list = kwarg_dict["idx_list"]
     ctc_param = kwarg_dict["ctc_param"]
     peak_dicts = kwarg_dict["peak_dicts"]
@@ -741,6 +769,11 @@ def fom_interpolate_energy_res_with_single_peak_alpha_sweep(
         Returns ``(nan, nan, nan)`` if fewer than two valid FWHM values are
         available.
     """
+    require_config_keys(
+        kwarg_dict,
+        ["peaks_kev", "idx_list", "ctc_param", "peak_dicts"],
+        name="kwarg_dict",
+    )
     peaks = kwarg_dict["peaks_kev"]
     idx_list = kwarg_dict["idx_list"]
     ctc_param = kwarg_dict["ctc_param"]
@@ -801,7 +834,7 @@ def fom_interpolate_energy_res_with_single_peak_alpha_sweep(
     interp_res = results[f"{next(iter(interp_energy))}_fwhm_in_kev"]
     interp_res_err = results[f"{next(iter(interp_energy))}_fwhm_err_in_kev"]
 
-    if nan_mask[-1] is True or nan_mask[-2] is True:
+    if nan_mask[-1] or nan_mask[-2]:
         interp_res_err = np.nan
     if interp_res_err / interp_res > 0.1:
         interp_res_err = np.nan

--- a/src/pygama/pargen/lq_cal.py
+++ b/src/pygama/pargen/lq_cal.py
@@ -436,10 +436,15 @@ class LQCal:
                                 ),
                             ]
                         )
-                    except BaseException as e:
-                        if isinstance(e, KeyboardInterrupt) or self.debug_mode:
-                            raise (e)
-
+                    except Exception as e:
+                        if self.debug_mode:
+                            raise
+                        log.debug(
+                            "LQ time correction: fit failed for run_timestamp %s, filling nan: %s",
+                            tstamp,
+                            e,
+                            exc_info=True,
+                        )
                         self.timecorr_df = pd.concat(
                             [
                                 self.timecorr_df,
@@ -464,9 +469,13 @@ class LQCal:
                     np.array(self.timecorr_df["res"]),
                 )
 
-                df[output_name] = df[lq_param] / np.array(
-                    [time_dict[tstamp] for tstamp in df["run_timestamp"]]
-                )
+                try:
+                    df[output_name] = df[lq_param] / np.array(
+                        [time_dict[tstamp] for tstamp in df["run_timestamp"]]
+                    )
+                except KeyError as e:
+                    msg = f"no time-correction entry for run_timestamp {e.args[0]!r}"
+                    raise KeyError(msg) from e
                 self.update_cal_dicts(
                     {
                         tstamp: {
@@ -507,9 +516,14 @@ class LQCal:
                             ),
                         ]
                     )
-                except BaseException as e:
-                    if isinstance(e, KeyboardInterrupt) or self.debug_mode:
-                        raise (e)
+                except Exception as e:
+                    if self.debug_mode:
+                        raise
+                    log.debug(
+                        "LQ time correction: single-run fit failed, filling nan: %s",
+                        e,
+                        exc_info=True,
+                    )
                     self.timecorr_df = pd.concat(
                         [
                             self.timecorr_df,
@@ -536,10 +550,10 @@ class LQCal:
                     }
                 )
                 log.info("LQ time correction finished")
-        except BaseException as e:
-            if isinstance(e, KeyboardInterrupt) or self.debug_mode:
-                raise (e)
-            log.error("LQ time correction failed")
+        except Exception as e:
+            if self.debug_mode:
+                raise
+            log.error("LQ time correction failed: %s", e)
             self.update_cal_dicts(
                 {
                     output_name: {
@@ -614,10 +628,10 @@ class LQCal:
                 - self.dt_fit_pars[1]
             )
 
-        except BaseException as e:
-            if isinstance(e, KeyboardInterrupt) or self.debug_mode:
-                raise (e)
-            log.error("LQ drift time correction failed")
+        except Exception as e:
+            if self.debug_mode:
+                raise
+            log.error("LQ drift time correction failed: %s", e)
             self.dt_fit_pars = (np.nan, np.nan)
 
         self.update_cal_dicts(
@@ -664,10 +678,10 @@ class LQCal:
             df["LQ_Classifier"] = np.divide(df[lq_param].to_numpy(), pars[1])
             df["LQ_Cut"] = df["LQ_Classifier"] < self.cut_val
 
-        except BaseException as e:
-            if isinstance(e, KeyboardInterrupt) or self.debug_mode:
-                raise (e)
-            log.error("LQ cut determination failed")
+        except Exception as e:
+            if self.debug_mode:
+                raise
+            log.error("LQ cut determination failed: %s", e)
             self.cut_val = np.nan
             c = cost.UnbinnedNLL(np.array([0]), gaussian.pdf)
             m = Minuit(c, np.full(2, np.nan))
@@ -783,16 +797,20 @@ class LQCal:
                     )
                     self.low_side_peak_dfs[peak] = cut_df
                 log.info("%skeV: %2.1f +/- %2.1f %%", peak, sf, sf_err)
-            except BaseException as e:
-                if isinstance(e, KeyboardInterrupt) or self.debug_mode:
-                    raise (e)
+            except Exception as e:
+                if self.debug_mode:
+                    raise
                 self.low_side_sf = pd.concat(
                     [
                         self.low_side_sf,
                         pd.DataFrame([{"peak": peak, "sf": np.nan, "sf_err": np.nan}]),
                     ]
                 )
-                log.error("LQ Survival fraction determination failed for %s peak", peak)
+                log.error(
+                    "LQ survival fraction determination failed for %s peak: %s",
+                    peak,
+                    e,
+                )
         self.low_side_sf = self.low_side_sf.set_index("peak")
 
 

--- a/src/pygama/pargen/noise_optimization.py
+++ b/src/pygama/pargen/noise_optimization.py
@@ -20,6 +20,7 @@ from pygama.math.distributions import gauss_on_uniform
 from pygama.math.histogram import get_hist
 from pygama.math.unbinned_fitting import fit_unbinned
 from pygama.pargen.dsp_optimize import run_one_dsp
+from pygama.pargen.utils import require_config_keys
 
 log = logging.getLogger(__name__)
 
@@ -57,6 +58,26 @@ def noise_optimization(
     """
 
     t0 = time.time()
+
+    require_config_keys(
+        opt_dict,
+        [
+            "start",
+            "stop",
+            "step",
+            "step_val",
+            "optimization",
+            "perform_fit",
+            "fit_deg",
+        ],
+        name="opt_dict",
+    )
+    for ene_par, par_config in opt_dict["optimization"].items():
+        require_config_keys(
+            par_config,
+            ["dict_str", "filter_par", "ene_str"],
+            name=f"opt_dict['optimization'][{ene_par!r}]",
+        )
 
     samples = np.arange(opt_dict["start"], opt_dict["stop"], opt_dict["step"])
     samples_val = np.arange(opt_dict["start"], opt_dict["stop"], opt_dict["step_val"])
@@ -436,7 +457,7 @@ def simple_gaussian_guess(hist, bins, func, toll=0.2) -> tuple:
     bounds = {
         "mu": (mu - sigma, mu + sigma),
         "sigma": (sigma - sigma * toll, sigma + sigma * toll),
-        "n_sig": (n_sig + n_sig * toll, n_sig + n_sig * toll),
+        "n_sig": (n_sig - n_sig * toll, n_sig + n_sig * toll),
     }
 
     for par in func.required_args():

--- a/src/pygama/pargen/pz_correct.py
+++ b/src/pygama/pargen/pz_correct.py
@@ -121,6 +121,11 @@ def linear_dpz_fit(
     slope_1, intercept_1, *_ = linregress(ts[:tau1_idx], np.log(sub_pulse[:tau1_idx]))
     # If the fit fails, just return an arbitrary good-enough guess. All detectors have a roughly ~130 sample short time constant for presumming of 8.
     if slope_1 > 0:
+        log.warning(
+            "short time-constant fit failed (positive slope %s), "
+            "falling back to default 130-sample tau",
+            slope_1,
+        )
         slope_1 = -1 / 130
         intercept_1 = np.log(1 - np.exp(intercept_2))
 
@@ -275,9 +280,6 @@ def tp100_align(wfs: np.array, tp100_window_width: int, tp100s: np.array) -> np.
     time_aligned_wfs
         An array of waveforms that are all aligned at their maximal values
     """
-    tp100_window_width = (
-        13  # If tp100 isn't in +/- this window of the median, forget about it
-    )
     median_tp100 = int(np.nanmedian(tp100s))  # in samples
     wf_len = len(wfs[0])
     time_aligned_wfs = []
@@ -295,6 +297,20 @@ def tp100_align(wfs: np.array, tp100_window_width: int, tp100s: np.array) -> np.
                 - (-1 * tp100s[i] + median_tp100 + tp100_window_width)
             ]
             time_aligned_wfs.append(wf_win)
+
+    if len(time_aligned_wfs) < len(wfs):
+        log.debug(
+            "tp100_align: kept %s of %s waveforms within +/- %s samples of the median tp100",
+            len(time_aligned_wfs),
+            len(wfs),
+            tp100_window_width,
+        )
+    if len(time_aligned_wfs) == 0:
+        msg = (
+            f"no waveforms had a tp100 within +/- {tp100_window_width} samples "
+            "of the median, cannot build superpulse"
+        )
+        raise RuntimeError(msg)
 
     return time_aligned_wfs
 

--- a/src/pygama/pargen/pz_correct.py
+++ b/src/pygama/pargen/pz_correct.py
@@ -312,7 +312,7 @@ def tp100_align(wfs: np.array, tp100_window_width: int, tp100s: np.array) -> np.
         )
         raise RuntimeError(msg)
 
-    return time_aligned_wfs
+    return np.asarray(time_aligned_wfs)
 
 
 class PZCorrect:

--- a/src/pygama/pargen/survival_fractions.py
+++ b/src/pygama/pargen/survival_fractions.py
@@ -48,8 +48,12 @@ def energy_guess(energy, func_i, fit_range=None, bin_width=1, peak=None, eres=No
     Returns
     -------
     parguess
-        :class:`iminuit.Values` of initial parameter values for *func_i*, or
-        ``None`` if *func_i* is not supported.
+        :class:`iminuit.Values` of initial parameter values for *func_i*.
+
+    Raises
+    ------
+    NotImplementedError
+        If *func_i* is not supported.
     """
     if fit_range is None:
         fit_range = (np.nanmin(energy), np.nanmax(energy))
@@ -69,8 +73,8 @@ def energy_guess(energy, func_i, fit_range=None, bin_width=1, peak=None, eres=No
                 parguess[i] = 0
 
     else:
-        log.error("energy_guess not implemented for %s", func_i)
-        return None
+        msg = f"energy_guess not implemented for {getattr(func_i, '__name__', func_i)}"
+        raise NotImplementedError(msg)
     return parguess
 
 
@@ -92,11 +96,15 @@ def fix_all_but_nevents(func) -> tuple:
     Returns
     -------
     fixed
-        List of parameter names to be held fixed during the fit, or ``None``
-        if *func* is not supported.
+        List of parameter names to be held fixed during the fit.
     mask
         Boolean array of length ``len(func.required_args())``, where ``True``
         indicates a free (floating) parameter.
+
+    Raises
+    ------
+    NotImplementedError
+        If *func* is not supported.
     """
 
     if func == gauss_on_step:
@@ -108,8 +116,10 @@ def fix_all_but_nevents(func) -> tuple:
         fixed = ["x_lo", "x_hi", "mu", "sigma", "htail", "tau", "hstep"]
 
     else:
-        log.error("get_hpge_E_fixed not implemented for %s", func)
-        return None, None
+        msg = (
+            f"fix_all_but_nevents not implemented for {getattr(func, '__name__', func)}"
+        )
+        raise NotImplementedError(msg)
     mask = ~np.isin(func.required_args(), fixed)
     return fixed, mask
 
@@ -133,8 +143,12 @@ def get_bounds(func, parguess) -> dict:
     Returns
     -------
     bounds
-        Dictionary mapping parameter names to ``(low, high)`` bound tuples,
-        or ``None`` if *func* is not supported.
+        Dictionary mapping parameter names to ``(low, high)`` bound tuples.
+
+    Raises
+    ------
+    NotImplementedError
+        If *func* is not supported.
     """
     if func in (hpge_peak, gauss_on_step):
         bounds = pgc.get_hpge_energy_bounds(func, parguess)
@@ -144,8 +158,8 @@ def get_bounds(func, parguess) -> dict:
         bounds["n_bkg"] = (0, 2 * (parguess["n_sig"] + parguess["n_bkg"]))
 
     else:
-        log.error("get_bounds not implemented for %s", func)
-        return None
+        msg = f"get_bounds not implemented for {getattr(func, '__name__', func)}"
+        raise NotImplementedError(msg)
     return bounds
 
 
@@ -441,7 +455,10 @@ def update_guess(func, parguess, energies):
         parguess["n_bkg"] = total_events - parguess["n_sig"]
         return parguess
 
-    log.error("update_guess not implemented for %s", func)
+    log.warning(
+        "update_guess not implemented for %s, returning original guess",
+        getattr(func, "__name__", func),
+    )
     return parguess
 
 
@@ -532,7 +549,7 @@ def get_survival_fraction(
     elif mode == "less":
         idxs = (cut_param < cut_val) & data_mask
     else:
-        msg = "mode not recognised"
+        msg = f"unknown mode {mode!r}, expected 'greater' or 'less'"
         raise ValueError(msg)
 
     if pars is None:
@@ -585,7 +602,10 @@ def get_survival_fraction(
         ) + cost.ExtendedUnbinnedNLL(energy[(~nan_idxs) & (~idxs)], fail_pdf_gos)
 
     else:
-        msg = "Unknown func"
+        msg = (
+            f"unknown func {getattr(func, '__name__', func)!r}, "
+            "expected hpge_peak or gauss_on_step"
+        )
         raise ValueError(msg)
 
     m = Minuit(lh, **parguess)
@@ -636,7 +656,7 @@ def get_sf_sweep(
     mode="greater",
     fit_range=None,
     debug_mode=False,
-) -> tuple(pd.DataFrame, float, float):
+) -> tuple[pd.DataFrame, float, float]:
     """
     Function sweeping through cut values and calculating the survival fraction for each value
     using a fit to the surviving and failing enegry distributions.
@@ -718,9 +738,15 @@ def get_sf_sweep(
             out_df = pd.concat(
                 [out_df, pd.DataFrame([{"cut_val": cut_val, "sf": sf, "sf_err": err}])]
             )
-        except BaseException as e:
-            if isinstance(e, KeyboardInterrupt) or debug_mode:
-                raise (e)
+        except Exception as e:
+            if debug_mode:
+                raise
+            log.debug(
+                "survival fraction sweep: fit failed for cut_val %s, skipping: %s",
+                cut_val,
+                e,
+                exc_info=True,
+            )
     out_df = out_df.set_index("cut_val")
     if final_cut_value is not None:
         sf, sf_err, _, _ = get_survival_fraction(
@@ -788,7 +814,7 @@ def compton_sf(
     elif mode == "less":
         mask = (cut_param < low_cut_val) & data_mask
     else:
-        msg = "mode not recognised"
+        msg = f"unknown mode {mode!r}, expected 'greater' or 'less'"
         raise ValueError(msg)
 
     sf = len(cut_param[mask]) / len(cut_param)
@@ -811,7 +837,7 @@ def compton_sf_sweep(
     cut_range=(-5, 5),
     n_samples=51,
     mode="greater",
-) -> tuple(pd.DataFrame, float, float):
+) -> tuple[pd.DataFrame, float, float]:
     """
     Function sweeping through cut values and calculating the survival fraction for each value
     using a simple counting analysis.

--- a/src/pygama/pargen/utils.py
+++ b/src/pygama/pargen/utils.py
@@ -6,6 +6,7 @@ used across the pargen calibration and optimisation modules.
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterable, Mapping
 from types import FunctionType
 
 import lh5
@@ -14,6 +15,32 @@ import pandas as pd
 from iminuit import Minuit, cost
 
 log = logging.getLogger(__name__)
+
+
+def require_config_keys(
+    config: Mapping, keys: Iterable[str], name: str = "config"
+) -> None:
+    """
+    Check that *config* contains every key in *keys*.
+
+    Parameters
+    ----------
+    config
+        Mapping to validate.
+    keys
+        Required key names.
+    name
+        Name of the mapping used in the error message.
+
+    Raises
+    ------
+    KeyError
+        If any of *keys* is missing from *config*, listing all missing keys.
+    """
+    missing = sorted(k for k in keys if k not in config)
+    if missing:
+        msg = f"{name} is missing required key(s): {', '.join(missing)}"
+        raise KeyError(msg)
 
 
 def convert_to_minuit(pars, func) -> Minuit:
@@ -82,7 +109,7 @@ def load_data(
     cal_energy_param: str = "cuspEmax_ctc_cal",
     threshold=None,
     return_selection_mask=False,
-) -> pd.DataFrame | tuple(pd.DataFrame, np.array):
+) -> pd.DataFrame | tuple[pd.DataFrame, np.ndarray]:
     """
     Load parameters from LH5 files and apply calibration expressions.
 
@@ -126,6 +153,13 @@ def load_data(
     if isinstance(files, str):
         files = [files]
 
+    if not isinstance(files, dict | list):
+        msg = (
+            "files must be a str, list of paths or dict of "
+            f"timestamp -> paths, got {type(files).__name__}"
+        )
+        raise TypeError(msg)
+
     if isinstance(files, dict):
         # Go through each tstamp and recursively load_data on file lists
         data_df = []
@@ -156,6 +190,14 @@ def load_data(
             masks = np.concatenate(masks)
 
     elif isinstance(files, list):
+        if len(files) == 0:
+            msg = "files list is empty, no data to load"
+            raise ValueError(msg)
+        for outname, info in cal_dict.items():
+            if "expression" not in info:
+                msg = f"cal_dict entry {outname!r} has no 'expression' key"
+                raise KeyError(msg)
+
         # Get set of available fields between input table and cal_dict
         file_keys = lh5.ls(
             files[0], lh5_path if lh5_path[-1] == "/" else lh5_path + "/"

--- a/tests/pargen/test_error_handling.py
+++ b/tests/pargen/test_error_handling.py
@@ -1,0 +1,190 @@
+"""Tests for the error paths of the pargen modules."""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import pygama.pargen.data_cleaning as dc
+import pygama.pargen.survival_fractions as sf
+from pygama.pargen import dsp_optimize, energy_cal
+from pygama.pargen.utils import load_data, require_config_keys
+
+
+def unsupported_func(x):
+    return x
+
+
+class TestRequireConfigKeys:
+    def test_passes_when_complete(self):
+        require_config_keys({"a": 1, "b": 2}, ["a", "b"])
+
+    def test_raises_listing_missing_keys(self):
+        with pytest.raises(
+            KeyError, match=r"my_dict is missing required key\(s\): a, c"
+        ):
+            require_config_keys({"b": 2}, ["a", "b", "c"], name="my_dict")
+
+
+class TestHPGeCalibration:
+    def test_invalid_deg_raises(self):
+        with pytest.raises(ValueError, match="invalid deg = -2"):
+            energy_cal.HPGeCalibration("energy", [2614.5], 0.5, deg=-2)
+
+    def test_invalid_guess_kev_raises(self):
+        with pytest.raises(ValueError, match="invalid guess_kev = 0"):
+            energy_cal.HPGeCalibration("energy", [2614.5], 0, deg=0)
+
+    def test_get_hpge_energy_fixed_unsupported_func(self):
+        with pytest.raises(NotImplementedError, match="unsupported_func"):
+            energy_cal.get_hpge_energy_fixed(unsupported_func)
+
+    def test_fwhm_fit_with_no_peaks_falls_back_to_nan(self, caplog):
+        with caplog.at_level(logging.ERROR, logger="pygama.pargen.energy_cal"):
+            results = energy_cal.HPGeCalibration.fit_energy_res_curve(
+                energy_cal.FWHMLinear, np.array([]), np.array([]), np.array([])
+            )
+        assert np.isnan(np.array(results["parameters"])).all()
+        assert "no valid peaks" in caplog.text
+
+
+class TestDataCleaning:
+    def test_get_keys_wrong_type(self):
+        with pytest.raises(TypeError, match="got int"):
+            dc.get_keys(42, {"cut": {"cut_parameter": "bl_std"}})
+
+    def test_generate_cuts_wrong_data_type(self):
+        with pytest.raises(ValueError, match="got list"):
+            dc.generate_cuts(
+                [1, 2, 3],
+                {
+                    "cut": {
+                        "cut_parameter": "bl_std",
+                        "cut_level": 4,
+                        "mode": "inclusive",
+                    }
+                },
+            )
+
+    def test_generate_cuts_unknown_mode(self):
+        rng = np.random.default_rng(42)
+        data = pd.DataFrame({"bl_std": rng.normal(10, 1, 1000)})
+        with pytest.raises(ValueError, match="banana"):
+            dc.generate_cuts(
+                data,
+                {"cut": {"cut_parameter": "bl_std", "cut_level": 4, "mode": "banana"}},
+            )
+
+    def test_generate_cuts_bad_cut_level_type(self):
+        rng = np.random.default_rng(42)
+        data = pd.DataFrame({"bl_std": rng.normal(10, 1, 1000)})
+        with pytest.raises(TypeError, match="got str"):
+            dc.generate_cuts(
+                data,
+                {
+                    "cut": {
+                        "cut_parameter": "bl_std",
+                        "cut_level": "4",
+                        "mode": "inclusive",
+                    }
+                },
+            )
+
+    def test_generate_cuts_one_sided_cut_level(self):
+        rng = np.random.default_rng(42)
+        data = pd.DataFrame({"bl_std": rng.normal(10, 1, 1000)})
+        cut_dict = dc.generate_cuts(
+            data,
+            {
+                "cut": {
+                    "cut_parameter": "bl_std",
+                    "cut_level": {"high_side": 4},
+                    "mode": "inclusive",
+                }
+            },
+        )
+        assert cut_dict["cut"]["expression"] == "bl_std<a"
+        assert cut_dict["cut"]["parameters"]["a"] == pytest.approx(14, abs=1)
+
+    def test_generate_cut_classifiers_one_sided_percentile(self):
+        rng = np.random.default_rng(42)
+        data = pd.DataFrame({"bl_std": rng.normal(10, 1, 1000)})
+        cut_dict = dc.generate_cut_classifiers(
+            data,
+            {
+                "cut": {
+                    "cut_parameter": "bl_std",
+                    "cut_percentile": {"high_side": 97.5},
+                    "mode": "inclusive",
+                    "method": "percentile",
+                }
+            },
+        )
+        assert cut_dict["cut"]["expression"] == "cut_classifier<a"
+        # 97.5th percentile of a standard normal is ~1.96 sigma; the classifier
+        # std comes from an fwhm-based mode estimate, so allow a loose window
+        assert 1.5 < cut_dict["cut"]["parameters"]["a"] < 3.5
+
+    def test_generate_cuts_unknown_parameter(self):
+        rng = np.random.default_rng(42)
+        data = pd.DataFrame({"bl_std": rng.normal(10, 1, 1000)})
+        with pytest.raises(ValueError, match="not_a_column"):
+            dc.generate_cuts(
+                data,
+                {
+                    "cut": {
+                        "cut_parameter": "not_a_column",
+                        "cut_level": 4,
+                        "mode": "inclusive",
+                    }
+                },
+            )
+
+
+class TestSurvivalFractions:
+    def test_compton_sf_unknown_mode(self):
+        with pytest.raises(ValueError, match="banana"):
+            sf.compton_sf(np.array([1.0, 2.0, 3.0]), 1.5, mode="banana")
+
+    def test_energy_guess_unsupported_func(self):
+        with pytest.raises(NotImplementedError, match="unsupported_func"):
+            sf.energy_guess(np.array([1.0, 2.0, 3.0]), unsupported_func)
+
+    def test_fix_all_but_nevents_unsupported_func(self):
+        with pytest.raises(NotImplementedError, match="unsupported_func"):
+            sf.fix_all_but_nevents(unsupported_func)
+
+    def test_get_bounds_unsupported_func(self):
+        with pytest.raises(NotImplementedError, match="unsupported_func"):
+            sf.get_bounds(unsupported_func, {})
+
+
+class TestDspOptimize:
+    def test_bad_sampling_rate_type(self):
+        with pytest.raises(TypeError, match="got float"):
+            dsp_optimize.BayesianOptimizer(
+                acq_func="ei", batch_size=1, sampling_rate=3.0
+            )
+
+    def test_bad_acq_func(self):
+        with pytest.raises(ValueError, match="banana"):
+            dsp_optimize.BayesianOptimizer(acq_func="banana", batch_size=1)
+
+
+class TestLoadData:
+    def test_wrong_files_type(self):
+        with pytest.raises(TypeError, match="got int"):
+            load_data(42, "dsp", {}, {"energy"})
+
+    def test_empty_files_list(self):
+        with pytest.raises(ValueError, match="empty"):
+            load_data([], "dsp", {}, {"energy"})
+
+    def test_cal_dict_missing_expression(self):
+        with pytest.raises(KeyError, match="'expression'"):
+            load_data(
+                ["dummy.lh5"], "dsp", {"energy_cal": {"parameters": {}}}, {"energy"}
+            )


### PR DESCRIPTION
## Summary

Systematic overhaul of error handling and error messages across `pygama.pargen` (~550 insertions over 11 files). The goal: every failure either raises with a useful, value-bearing message, or falls back deliberately with context-rich logging. The intentional *fit-fails → NaN-and-continue* design used by production calibration pipelines is preserved everywhere — one failed peak still never aborts a calibration, but it is no longer invisible.

### Exception handling made visible (behavior-preserving)

- All 23 `except BaseException` catches narrowed to `except Exception`, so `KeyboardInterrupt`/`SystemExit` propagate naturally; the `raise (e)` idiom replaced with bare `raise`.
- Every NaN-fallback handler that was previously silent (per-timestamp A/E and LQ fits, per-compton-band fits, DEP fits, survival-fraction sweeps, whole-stage NaN returns in `energy_optimisation`) now logs the exception plus identifying context — which timestamp, band, peak, or cut value failed. Per-item scan failures log at `debug` (with `exc_info`), whole-stage fallbacks at `warning`, stage-level failures at `error` with the exception appended.
- ~15 message-less `raise RuntimeError`/`ValueError` control-flow raises got messages with the offending values; vague messages like `"unknown mode"` now report the value and the valid options; `raise Exception` in `dsp_optimize` became `NotImplementedError`.

### New raises (behavior changes, please review)

- `HPGeCalibration.__init__`: invalid `deg` previously logged and returned a **half-built object** (later `AttributeError` far from the cause); invalid `guess_kev` previously logged and **kept executing with the bad value**. Both now raise `ValueError`.
- `get_hpge_energy_fixed` (energy_cal) and `energy_guess` / `fix_all_but_nevents` / `get_bounds` (survival_fractions) returned `None` into tuple-unpacks → now raise `NotImplementedError` naming the unsupported function (also fixes `fix_all_but_nevents` logging the wrong function name).
- Missing `else` branches that died with `UnboundLocalError` in `get_keys`, `generate_cuts`, `generate_cut_classifiers` and `load_data` now raise `TypeError`/`ValueError` naming the offending type/value.
- New `require_config_keys()` helper in `pargen.utils` reports **all** missing config keys at once; wired into `dplms_ge_dict`, `noise_optimization` and the `energy_optimisation` FOM functions, replacing bare `KeyError: 'bl_field'` deep inside a run. Data-dependent `time_dict[tstamp]` lookups and `cal_dict` entries missing `"expression"` also raise contextual `KeyError`s.

### Latent bug fixes adjacent to error handling

- `nan_mask[-1] is True` never fired (`np.bool_ is True` is always `False`), defeating the resolution quality check in `fom_interpolate_energy_res_with_single_peak_alpha_sweep`.
- One-sided `cut_level` dicts in `generate_cuts` crashed with `TypeError: NoneType * float` because the `None` checks were unreachable — they now work.
- Dict-valued `cut_percentile` branches in `generate_cut_classifiers` did arithmetic on the dict itself (`percentile / 100`); they now use the `low_side`/`high_side` values with the same semantics as the scalar case.
- `dt = tb_in[ctc_param].nda` re-raised `KeyError` uncaught after the `tb_in.eval` fallback in `fom_fwhm_no_alpha_sweep`.
- `ParGrid.get_par_meshgrid` crashed on the `values_strs` attribute typo (field is `value_strs`).
- Degenerate `n_sig` bounds in `noise_optimization` (`(n_sig + tol, n_sig + tol)` → `(n_sig - tol, n_sig + tol)`).
- `tp100_align` unconditionally overwrote its `tp100_window_width` parameter with 13; the caller's default is unchanged but explicit values are now honored, and an empty alignment result raises instead of averaging an empty list into a NaN superpulse.
- Dead all-True `allowed_mask` in `find_pulser_properties` removed; peaks with NaN fit widths (which slipped past `> allowed_err` since NaN comparisons are `False`) are now skipped explicitly.
- `tuple(...)` return annotations fixed to `tuple[...]` in `utils` and `survival_fractions`.

### Tests

New `tests/pargen/test_error_handling.py` — the first `pytest.raises` coverage in pargen (22 tests): the new constructor/type/mode/config raises with `match=` assertions, regression tests for the one-sided `cut_level` and dict `cut_percentile` fixes, and a `caplog` guard pinning the NaN-fallback-with-logging contract for `fit_energy_res_curve`.

## Test plan

- `ruff check` / `ruff format --check` clean on all changed files
- Full test suite passes locally (181 passed). Note: the 3 `test_ecal.py` failures observed locally also fail on a clean checkout (numpy divide-by-zero warning inside `pygama.math.hpge_peak_fitting` under `filterwarnings = "error"`) and are unrelated to this change.
- Grep audits return empty: `except BaseException`, `raise (e)`, and message-less `raise <Error>$` no longer occur in pargen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
