### PR TITLE
perf: cache SumDists dispatch and add opt-in log-density mode for unbinned energy fits

### DIFF
--- a/src/pygama/math/functions/sum_dists.py
+++ b/src/pygama/math/functions/sum_dists.py
@@ -17,6 +17,7 @@ A class that creates the sum of distributions, with methods for scipy computed :
 from __future__ import annotations
 
 import inspect
+from weakref import WeakKeyDictionary
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -169,6 +170,19 @@ def copy_signature(signature_to_copy, obj_to_copy_to):
 
     wrapper.__signature__ = signature_to_copy
     return wrapper
+
+
+# methods that get a signature built from x_shapes / extended_shapes on access
+_X_SHAPE_METHODS = frozenset(("get_pdf", "get_cdf", "cdf_ext"))
+_EXTENDED_SHAPE_METHODS = frozenset(("pdf_norm", "pdf_ext", "log_pdf_ext", "cdf_norm"))
+
+# smallest positive normal float: the zero-protection iminuit itself adds
+# before taking logarithms in its NLL cost functions
+_TINY_FLOAT = np.finfo(float).tiny
+
+# per-instance cache of the signature-carrying wrappers; keyed weakly so
+# instances stay picklable/deepcopy-able and can be garbage collected
+_signature_wrapper_cache: WeakKeyDictionary = WeakKeyDictionary()
 
 
 class SumDists(rv_continuous):
@@ -465,7 +479,8 @@ class SumDists(rv_continuous):
                 2:
             ]  # chop off x_lo, x_hi from the shapes to actually pass to get_cdf
 
-        norm = np.diff(self.get_cdf(np.array([x_lo, x_hi]), *params))
+        cdf = self.get_cdf(np.array([x_lo, x_hi]), *params)
+        norm = cdf[1] - cdf[0]
 
         if norm == 0:
             return np.full_like(x, np.inf)
@@ -489,7 +504,8 @@ class SumDists(rv_continuous):
                 2:
             ]  # chop off x_lo, x_hi from the shapes to actually pass to get_cdf
 
-        norm = np.diff(self.get_cdf(np.array([x_lo, x_hi]), *params))
+        cdf = self.get_cdf(np.array([x_lo, x_hi]), *params)
+        norm = cdf[1] - cdf[0]
 
         if norm == 0:
             return np.full_like(x, np.inf)
@@ -525,17 +541,10 @@ class SumDists(rv_continuous):
         )
 
         # sig = areas[0] + areas[1] # this is a hack, it performs faster but may not *always* be true
-        sig = (
-            areas[0]
-            * fracs[0]
-            * np.diff(
-                pdf_exts[0].get_cdf(np.array([x_lo, x_hi]), *params[self.par_idxs[0]])
-            )[0]
-            + areas[1]
-            * fracs[1]
-            * np.diff(
-                pdf_exts[1].get_cdf(np.array([x_lo, x_hi]), *params[self.par_idxs[1]])
-            )[0]
+        cdf_0 = pdf_exts[0].get_cdf(np.array([x_lo, x_hi]), *params[self.par_idxs[0]])
+        cdf_1 = pdf_exts[1].get_cdf(np.array([x_lo, x_hi]), *params[self.par_idxs[1]])
+        sig = areas[0] * fracs[0] * (cdf_0[1] - cdf_0[0]) + areas[1] * fracs[1] * (
+            cdf_1[1] - cdf_1[0]
         )
 
         if self.components:
@@ -549,6 +558,22 @@ class SumDists(rv_continuous):
         ) + areas[1] * fracs[1] * pdf_exts[1].get_pdf(x, *params[self.par_idxs[1]])
 
         return sig, probs
+
+    def log_pdf_ext(self, x, *params):
+        """
+        Log-density counterpart of :func:`pdf_ext` for extended unbinned NLL
+        fits with ``iminuit.cost.ExtendedUnbinnedNLL(..., log=True)``.
+
+        Returns the integral of the density over the fit range together with
+        ``log(density + tiny)``, where ``tiny`` is the smallest positive
+        normal float — the same zero-protection ``iminuit`` applies
+        internally when it takes the logarithm itself.  Letting ``iminuit``
+        sum the log-density directly skips its accuracy-motivated sort of the
+        per-event log values, which dominates the cost of each NLL evaluation
+        for large samples.
+        """
+        sig, probs = self.pdf_ext(x, *params)
+        return sig, np.log(probs + _TINY_FLOAT)
 
     def cdf_ext(self, x, *params):
         """
@@ -752,26 +777,35 @@ class SumDists(rv_continuous):
     def __getattribute__(self, attr):
         """
         Necessary to overload this so that Iminuit can use inspect.signature to get the correct parameter names
-        """
-        value = object.__getattribute__(self, attr)
 
-        if attr in ["get_pdf", "get_cdf", "cdf_ext"]:
-            params = [
-                inspect.Parameter(param, inspect.Parameter.POSITIONAL_OR_KEYWORD)
-                for param in self.x_shapes
-            ]
-            value = copy_signature(inspect.Signature(params), value)
-        if (
-            attr
-            in [
-                "pdf_norm",
-                "pdf_ext",
-                "cdf_norm",
-            ]
-        ):  # Set these to include the x_lo, x_hi at the correct positions since these always need those params
-            params = [
-                inspect.Parameter(param, inspect.Parameter.POSITIONAL_OR_KEYWORD)
-                for param in self.extended_shapes
-            ]
-            value = copy_signature(inspect.Signature(params), value)
-        return value
+        The signature-carrying wrappers are built once per instance and cached:
+        constructing :class:`inspect.Signature` objects on every attribute
+        access dominates the runtime of scalar-heavy code paths (unbinned NLL
+        fits, FWHM root-finding).  The wrapper closes over the bound method, so
+        runtime state such as ``self.components`` is still honoured at call
+        time.  ``x_shapes``/``extended_shapes`` are fixed after ``__init__``,
+        so the cache never needs invalidating.
+        """
+        if attr in _X_SHAPE_METHODS or attr in _EXTENDED_SHAPE_METHODS:
+            cache = _signature_wrapper_cache.get(self)
+            if cache is None:
+                cache = {}
+                _signature_wrapper_cache[self] = cache
+            wrapper = cache.get(attr)
+            if wrapper is None:
+                value = object.__getattribute__(self, attr)
+                shapes = (
+                    self.x_shapes
+                    if attr in _X_SHAPE_METHODS
+                    # extended shapes include x_lo, x_hi at the correct
+                    # positions since these methods always need those params
+                    else self.extended_shapes
+                )
+                params = [
+                    inspect.Parameter(param, inspect.Parameter.POSITIONAL_OR_KEYWORD)
+                    for param in shapes
+                ]
+                wrapper = copy_signature(inspect.Signature(params), value)
+                cache[attr] = wrapper
+            return wrapper
+        return object.__getattribute__(self, attr)

--- a/src/pygama/pargen/AoE_cal.py
+++ b/src/pygama/pargen/AoE_cal.py
@@ -352,6 +352,7 @@ def unbinned_aoe_fit(
     aoe: np.array,
     pdf=aoe_peak,
     display: int = 0,
+    use_log_pdf: bool = False,
 ) -> tuple(np.array, np.array):
     """
     Fitting function for A/E, first fits just a Gaussian before using the full pdf to fit
@@ -365,6 +366,12 @@ def unbinned_aoe_fit(
         PDF to fit to.
     display
         Verbosity level; 0 = silent, >1 = diagnostic plots.
+    use_log_pdf
+        Build the full-pdf extended unbinned NLL from the model's
+        ``log_pdf_ext`` (``iminuit`` ``log=True`` mode) — faster on large
+        samples, results differ at machine-precision level.  Ignored when
+        *pdf* has no ``log_pdf_ext``; the Gaussian/exgauss prefits (a
+        negligible share of the fit time) always use the standard mode.
 
     Returns
     -------
@@ -478,7 +485,12 @@ def unbinned_aoe_fit(
     )
 
     # Full fit using Gaussian signal with Gaussian tail background
-    c = cost.ExtendedUnbinnedNLL(aoe[(aoe < fmax) & (aoe > fmin)], pdf.pdf_ext)
+    if use_log_pdf and hasattr(pdf, "log_pdf_ext"):
+        c = cost.ExtendedUnbinnedNLL(
+            aoe[(aoe < fmax) & (aoe > fmin)], pdf.log_pdf_ext, log=True
+        )
+    else:
+        c = cost.ExtendedUnbinnedNLL(aoe[(aoe < fmax) & (aoe > fmin)], pdf.pdf_ext)
     m = Minuit(c, *x0)
     for arg, val in bounds.items():
         m.limits[arg] = val
@@ -753,6 +765,7 @@ def bimodal_dt_fit(
     pdf,
     debug_mode: bool = False,
     display: int = 0,
+    use_log_pdf: bool = False,
     **_kwargs,
 ) -> tuple[float, dict]:
     """
@@ -861,7 +874,10 @@ def bimodal_dt_fit(
             )
 
             aoe_pars, aoe_errs, _, _ = unbinned_aoe_fit(
-                final_df.query(aoe_grp1)[aoe_param], pdf=pdf, display=display
+                final_df.query(aoe_grp1)[aoe_param],
+                pdf=pdf,
+                display=display,
+                use_log_pdf=use_log_pdf,
             )
             dt_res_dict["aoe_fit1"] = {
                 "pars": aoe_pars.to_dict(),
@@ -869,7 +885,10 @@ def bimodal_dt_fit(
             }
 
             aoe_pars2, aoe_errs2, _, _ = unbinned_aoe_fit(
-                final_df.query(aoe_grp2)[aoe_param], pdf=pdf, display=display
+                final_df.query(aoe_grp2)[aoe_param],
+                pdf=pdf,
+                display=display,
+                use_log_pdf=use_log_pdf,
             )
             dt_res_dict["aoe_fit2"] = {
                 "pars": aoe_pars2.to_dict(),
@@ -1055,6 +1074,7 @@ class CalAoE:
         sigma_func: Callable = SigmaFit,
         compt_bands_width: float = 20,
         debug_mode: bool = False,
+        use_log_pdf: bool = False,
     ):
         """
         Parameters
@@ -1095,6 +1115,11 @@ class CalAoE:
             Width of the Compton bands in keV used for the energy correction.
         debug_mode
             If ``True``, re-raise exceptions from the A/E calibration steps instead of returning NaN.
+        use_log_pdf
+            Build the unbinned fits (A/E peak fits and survival-fraction
+            energy fits) from the models' log-densities (``iminuit``
+            ``log=True`` mode) — faster on large samples, results differ at
+            machine-precision level.
 
         """
         self.cal_dicts = cal_dicts if cal_dicts is not None else {}
@@ -1119,6 +1144,7 @@ class CalAoE:
         self.sigma_func = sigma_func
         self.compt_bands_width = compt_bands_width
         self.debug_mode = debug_mode
+        self.use_log_pdf = use_log_pdf
 
     def update_cal_dicts(self, update_dict):
         """
@@ -1195,6 +1221,7 @@ class CalAoE:
                             )[aoe_param],
                             pdf=self.pdf,
                             display=display,
+                            use_log_pdf=self.use_log_pdf,
                         )
                         self.timecorr_df = pd.concat(
                             [
@@ -1380,6 +1407,7 @@ class CalAoE:
                         )[aoe_param],
                         pdf=self.pdf,
                         display=display,
+                        use_log_pdf=self.use_log_pdf,
                     )
                     self.timecorr_df = pd.concat(
                         [
@@ -1513,6 +1541,7 @@ class CalAoE:
             pdf=self.pdf,
             debug_mode=self.debug_mode,
             display=display,
+            use_log_pdf=self.use_log_pdf,
         )
 
         data[out_param] = data[aoe_param] * (1 + self.alpha * data[self.dt_param])
@@ -1600,6 +1629,7 @@ class CalAoE:
                         )[aoe_param],
                         pdf=self.pdf,
                         display=display,
+                        use_log_pdf=self.use_log_pdf,
                     )
 
                     mean, mean_err = self.pdf.get_mu(pars, cov)
@@ -1744,6 +1774,7 @@ class CalAoE:
                     )[aoe_param],
                     pdf=self.pdf,
                     display=display,
+                    use_log_pdf=self.use_log_pdf,
                 )
             except Exception as e:
                 if self.debug_mode:
@@ -1884,6 +1915,7 @@ class CalAoE:
                 n_samples=40,
                 mode="greater",
                 debug_mode=self.debug_mode,
+                use_log_pdf=self.use_log_pdf,
             )
 
             valid_fits = self.cut_fits.query(
@@ -2028,6 +2060,7 @@ class CalAoE:
                             else None
                         ),
                         debug_mode=self.debug_mode,
+                        use_log_pdf=self.use_log_pdf,
                     )
 
                     cut_df = cut_df.query(
@@ -2136,6 +2169,7 @@ class CalAoE:
                             if self.dt_cut_param is not None
                             else None
                         ),
+                        use_log_pdf=self.use_log_pdf,
                     )
                     sfs = pd.concat(
                         [

--- a/src/pygama/pargen/dplms_ge_dict.py
+++ b/src/pygama/pargen/dplms_ge_dict.py
@@ -48,7 +48,10 @@ def dplms_ge_dict(
     par_dsp
         Dictionary with db parameters for dsp processing
     dplms_dict
-        Dictionary with various parameters
+        Dictionary with various parameters.  Optional key ``use_log_pdf``
+        (default False): build the FOM's unbinned fits from the model's
+        log-density (``iminuit`` ``log=True`` mode) — faster on large
+        samples, results differ at machine-precision level.
     fom_func
         Function for peak fits
 
@@ -140,10 +143,29 @@ def dplms_ge_dict(
     coeff_keys = list(dp_coeffs.keys())
     lists = [dp_coeffs[key] for key in dp_coeffs]
 
+    use_log_pdf = dplms_dict.get("use_log_pdf", False)
+
     prod = list(itertools.product(*lists))
     grid_dict = {}
     min_fom = float("inf")
     min_idx = None
+
+    # signal selection and the signal-shape matrices depend only on the rt
+    # (risetime percentile) and pt (pile-up threshold) coefficients, so cache
+    # them: for grids that only vary nm/za/pl/ft they are computed once
+    sel_matrix_cache = {}
+
+    def selection_and_matrices(coeff_values):
+        key = (
+            coeff_values.get("rt", dplms_dict["dp_def"]["rt"]),
+            coeff_values.get("pt", dplms_dict["dp_def"]["pt"]),
+        )
+        if key not in sel_matrix_cache:
+            sel_dict = signal_selection(dsp_cal, dplms_dict, coeff_values)
+            wfs = dsp_cal[wf_field].nda[sel_dict["idxs"], :]
+            matrices = signal_matrices(wfs, dplms_dict["length"], decay_const)
+            sel_matrix_cache[key] = (sel_dict, matrices, len(wfs))
+        return sel_matrix_cache[key]
 
     for i, values in enumerate(prod):
         coeff_values = dict(zip(coeff_keys, values, strict=False))
@@ -154,11 +176,10 @@ def dplms_ge_dict(
 
         grid_dict[i] = coeff_values
 
-        sel_dict = signal_selection(dsp_cal, dplms_dict, coeff_values)
-        wfs = dsp_cal[wf_field].nda[sel_dict["idxs"], :]
-        log.info("... %s signals after signal selection", len(wfs))
+        sel_dict, matrices, n_wfs = selection_and_matrices(coeff_values)
+        log.info("... %s signals after signal selection", n_wfs)
 
-        ref, rmat, pmat, fmat = signal_matrices(wfs, dplms_dict["length"], decay_const)
+        ref, rmat, pmat, fmat = matrices
 
         t_tmp = time.time()
         nm_coeff = coeff_values["nm"]
@@ -192,6 +213,7 @@ def dplms_ge_dict(
                 ctc_par,
                 idxs=np.where(~np.isnan(dsp_opt[ctc_par].nda))[0],
                 frac_max=0.5,
+                use_log_pdf=use_log_pdf,
             )
         except Exception as e:
             log.debug(
@@ -294,10 +316,10 @@ def dplms_ge_dict(
         alpha = 0
 
     # filter synthesis
-    sel_dict = signal_selection(dsp_cal, dplms_dict, best_case_values)
+    sel_dict, matrices, _ = selection_and_matrices(best_case_values)
     idxs = sel_dict["idxs"]
     wfs = dsp_cal[wf_field].nda[idxs, :]
-    ref, rmat, pmat, fmat = signal_matrices(wfs, dplms_dict["length"], decay_const)
+    ref, rmat, pmat, fmat = matrices
 
     x, _y, _refy = filter_synthesis(
         ref,
@@ -496,7 +518,7 @@ def is_not_pile_up(
     Returns
     -------
     idxs
-        Per-event mask; True means the event is pile-up free.
+        Per-event boolean mask; True means the event is pile-up free.
     llow
         Lower boundary of the accepted peak band (samples).
     lupp
@@ -516,14 +538,16 @@ def is_not_pile_up(
 
     llow, lupp = bin_edges[idx_low], bin_edges[idx_upp]
 
-    idxs = []
-    for n, nn in zip(peak_pos, peak_pos_neg, strict=False):
-        condition1 = np.count_nonzero(n > 0) == 1
-        condition2 = (
-            np.count_nonzero((n > 0) & ((n < llow) | (n > lupp) & (n < size))) == 0
+    pos = peak_pos > 0
+    condition1 = np.count_nonzero(pos, axis=1) == 1
+    condition2 = (
+        np.count_nonzero(
+            pos & ((peak_pos < llow) | (peak_pos > lupp) & (peak_pos < size)), axis=1
         )
-        condition3 = np.count_nonzero(nn > 0) == 0
-        idxs.append(condition1 and condition2 and condition3)
+        == 0
+    )
+    condition3 = np.count_nonzero(peak_pos_neg > 0, axis=1) == 0
+    idxs = condition1 & condition2 & condition3
     return idxs, llow, lupp
 
 

--- a/src/pygama/pargen/energy_cal.py
+++ b/src/pygama/pargen/energy_cal.py
@@ -2639,8 +2639,8 @@ def unbinned_staged_energy_fit(
     bin_width=None,
     lock_guess=False,
     p_val_threshold=10e-20,
-    use_log_pdf=False,
     display=0,
+    use_log_pdf=False,
 ):
     """
     Unbinned fit to energy. This is different to the default fitting as

--- a/src/pygama/pargen/energy_cal.py
+++ b/src/pygama/pargen/energy_cal.py
@@ -2609,11 +2609,18 @@ def unbinned_staged_energy_fit(
     bin_width=None,
     lock_guess=False,
     p_val_threshold=10e-20,
+    use_log_pdf=False,
     display=0,
 ):
     """
     Unbinned fit to energy. This is different to the default fitting as
     it will try different fitting methods and choose the best. This is necessary for the lower statistics.
+
+    When ``use_log_pdf`` is true the extended unbinned NLL is built from the
+    model's ``log_pdf_ext`` with ``iminuit``'s ``log=True`` mode, which sums
+    the log-density directly instead of sorting per-event log values — much
+    faster on large samples, at the price of a slightly different floating
+    point summation (results can differ at machine-precision level).
     """
 
     if fit_range is None:
@@ -2698,7 +2705,12 @@ def unbinned_staged_energy_fit(
             bin_width=bin_width,
             **guess_kwargs if guess_kwargs is not None else {},
         )
-        c = cost.ExtendedUnbinnedNLL(energy, pgf.gauss_on_step.pdf_ext)
+        if use_log_pdf:
+            c = cost.ExtendedUnbinnedNLL(
+                energy, pgf.gauss_on_step.log_pdf_ext, log=True
+            )
+        else:
+            c = cost.ExtendedUnbinnedNLL(energy, pgf.gauss_on_step.pdf_ext)
         m = Minuit(c, *x0_notail)
         bounds = bounds_func(
             pgf.gauss_on_step,
@@ -2762,11 +2774,16 @@ def unbinned_staged_energy_fit(
             tail_weight=None,
             allow_tail_drop=False,
             bin_width=bin_width,
+            use_log_pdf=use_log_pdf,
         )
 
-        c = cost.ExtendedUnbinnedNLL(energy, func.pdf_ext) + TailPrior(
-            energy, func, tail_weight=tail_weight
-        )
+        if use_log_pdf:
+            c = cost.ExtendedUnbinnedNLL(energy, func.log_pdf_ext, log=True)
+        else:
+            c = cost.ExtendedUnbinnedNLL(energy, func.pdf_ext)
+        c = c + TailPrior(energy, func, tail_weight=tail_weight)
+    elif use_log_pdf:
+        c = cost.ExtendedUnbinnedNLL(energy, func.log_pdf_ext, log=True)
     else:
         c = cost.ExtendedUnbinnedNLL(energy, func.pdf_ext)
 

--- a/src/pygama/pargen/energy_cal.py
+++ b/src/pygama/pargen/energy_cal.py
@@ -2616,11 +2616,16 @@ def unbinned_staged_energy_fit(
     Unbinned fit to energy. This is different to the default fitting as
     it will try different fitting methods and choose the best. This is necessary for the lower statistics.
 
-    When ``use_log_pdf`` is true the extended unbinned NLL is built from the
-    model's ``log_pdf_ext`` with ``iminuit``'s ``log=True`` mode, which sums
-    the log-density directly instead of sorting per-event log values — much
-    faster on large samples, at the price of a slightly different floating
-    point summation (results can differ at machine-precision level).
+    """
+
+    if use_log_pdf and not hasattr(func, "log_pdf_ext"):
+        raise ValueError(
+            "use_log_pdf=True requires the model to implement log_pdf_ext(x, *pars)"
+        )
+
+    if fit_range is None:
+        fit_range = (np.nanmin(energy), np.nanmax(energy))
+
     """
 
     if fit_range is None:

--- a/src/pygama/pargen/energy_cal.py
+++ b/src/pygama/pargen/energy_cal.py
@@ -807,6 +807,7 @@ class HPGeCalibration:
         tail_weight=0,
         update_cal_pars=True,
         use_bin_width_in_fit=True,
+        use_log_pdf=False,
     ):
         """
         Fit the energy peaks specified using the given function.
@@ -834,6 +835,11 @@ class HPGeCalibration:
             Weight applied to the tail of the fit.
         update_cal_pars
             Whether to update the calibration parameters. Default is ``True``.
+        use_log_pdf
+            Build the unbinned fits from the model's log-density
+            (``iminuit`` ``log=True`` mode). Faster on large samples;
+            results can differ from the standard mode at machine-precision
+            level. Only used when *method* is ``"unbinned"``.
 
         Returns
         -------
@@ -960,6 +966,7 @@ class HPGeCalibration:
                         bin_width=binw_1 if use_bin_width_in_fit is True else None,
                         guess_kwargs={"mode_guess": mode_guess},
                         p_val_threshold=allowed_p_val,
+                        use_log_pdf=use_log_pdf,
                     )
                     if pars_i["n_sig"] < 100:
                         valid_fit = False
@@ -1497,6 +1504,7 @@ class HPGeCalibration:
         tail_weight=0,
         peak_param="mode",
         n_events=None,
+        use_log_pdf=False,
     ):
         """
         Run the complete HPGe energy calibration pipeline.
@@ -1523,6 +1531,10 @@ class HPGeCalibration:
             ``"mu"``).
         n_events
             Maximum number of events to use; ``None`` uses all.
+        use_log_pdf
+            Build the unbinned fits from the model's log-density
+            (``iminuit`` ``log=True`` mode); see
+            :meth:`hpge_fit_energy_peaks`.
         """
         log.debug("Find peaks and compute calibration curve for %s", self.energy_param)
         log.debug("Guess is %.3f", self.pars[1])
@@ -1537,6 +1549,7 @@ class HPGeCalibration:
             tail_weight=tail_weight,
             peak_param=peak_param,
             n_events=n_events,
+            use_log_pdf=use_log_pdf,
         )
         if len(self.peaks_kev) != len(got_peaks_kev):
             for _i, peak in enumerate(got_peaks_kev):
@@ -1576,6 +1589,7 @@ class HPGeCalibration:
                 tail_weight=tail_weight,
                 peak_param=peak_param,
                 n_events=n_events,
+                use_log_pdf=use_log_pdf,
             )
 
             if self.pars is None:
@@ -1599,7 +1613,7 @@ class HPGeCalibration:
             interp_energy_kev={"Qbb": 2039.0},
         )
 
-    def fit_calibrated_peaks(self, e_uncal, peak_pars):
+    def fit_calibrated_peaks(self, e_uncal, peak_pars, use_log_pdf=False):
         """
         Fit peaks using an existing calibration without updating the polynomial.
 
@@ -1614,10 +1628,19 @@ class HPGeCalibration:
             1-D array of uncalibrated energy values.
         peak_pars
             List of ``(peak_kev, (kev_lo, kev_hi), func)`` tuples.
+        use_log_pdf
+            Build the unbinned fits from the model's log-density
+            (``iminuit`` ``log=True`` mode); see
+            :meth:`hpge_fit_energy_peaks`.
         """
         log.debug("Fitting %s", self.energy_param)
         self.hpge_get_energy_peaks(e_uncal, update_cal_pars=False)
-        self.hpge_fit_energy_peaks(e_uncal, peak_pars=peak_pars, update_cal_pars=False)
+        self.hpge_fit_energy_peaks(
+            e_uncal,
+            peak_pars=peak_pars,
+            update_cal_pars=False,
+            use_log_pdf=use_log_pdf,
+        )
         self.get_energy_res_curve(
             FWHMLinear,
             interp_energy_kev={"Qbb": 2039.0},
@@ -1636,6 +1659,7 @@ class HPGeCalibration:
         tail_weight=0,
         peak_param="mode",
         n_events=None,
+        use_log_pdf=False,
     ):
         """
         Calibrate using a single prominent peak (degree-0 calibration).
@@ -1661,6 +1685,10 @@ class HPGeCalibration:
             Parameter used to extract the peak position.
         n_events
             Maximum number of events to use; ``None`` uses all.
+        use_log_pdf
+            Build the unbinned fits from the model's log-density
+            (``iminuit`` ``log=True`` mode); see
+            :meth:`hpge_fit_energy_peaks`.
         """
         log.debug("Find peaks and compute calibration curve for %s", self.energy_param)
         log.debug("Guess is %.3f", self.pars[1])
@@ -1681,6 +1709,7 @@ class HPGeCalibration:
             tail_weight=tail_weight,
             peak_param=peak_param,
             n_events=n_events,
+            use_log_pdf=use_log_pdf,
         )
         self.hpge_fit_energy_peaks(
             e_uncal,
@@ -1691,6 +1720,7 @@ class HPGeCalibration:
             peak_param=peak_param,
             n_events=n_events,
             update_cal_pars=False,
+            use_log_pdf=use_log_pdf,
         )
         self.get_energy_res_curve(
             FWHMLinear,
@@ -2616,17 +2646,16 @@ def unbinned_staged_energy_fit(
     Unbinned fit to energy. This is different to the default fitting as
     it will try different fitting methods and choose the best. This is necessary for the lower statistics.
 
+    When ``use_log_pdf`` is true the extended unbinned NLL is built from the
+    model's ``log_pdf_ext`` with ``iminuit``'s ``log=True`` mode, which sums
+    the log-density directly instead of sorting per-event log values — much
+    faster on large samples, at the price of a slightly different floating
+    point summation (results can differ at machine-precision level).
     """
 
     if use_log_pdf and not hasattr(func, "log_pdf_ext"):
-        raise ValueError(
-            "use_log_pdf=True requires the model to implement log_pdf_ext(x, *pars)"
-        )
-
-    if fit_range is None:
-        fit_range = (np.nanmin(energy), np.nanmax(energy))
-
-    """
+        msg = "use_log_pdf=True requires the model to implement log_pdf_ext(x, *pars)"
+        raise ValueError(msg)
 
     if fit_range is None:
         fit_range = (np.nanmin(energy), np.nanmax(energy))

--- a/src/pygama/pargen/energy_optimisation.py
+++ b/src/pygama/pargen/energy_optimisation.py
@@ -337,11 +337,18 @@ def fom_fwhm_with_alpha_fit(
     tb_in,
     kwarg_dict,
     ctc_parameter,
-    nsteps=11,
-    idxs=None,
-    frac_max=0.2,
-    use_log_pdf=False,
-    display=0,
+    """
+    Figure-of-merit: FWHM minimised over a sweep of charge-trapping correction values.
+
+    Scans *nsteps* values of the charge-trapping coefficient alpha between
+    0 and 3.5x10^-6, fitting the peak at each step via
+    :func:`get_peak_fwhm_with_dt_corr`.  A degree-4 polynomial is fit to
+    the valid FWHM/max-ratio values to locate the optimal alpha, and the
+    peak is re-fit at that alpha to obtain the final FWHM in keV.  An early
+    termination heuristic stops the sweep when the FWHM curve is clearly
+    rising.  If *use_log_pdf* is ``True``, the underlying staged fits use
+    ``iminuit``'s ``log=True`` mode for faster unbinned NLL evaluation.
+
 ):
     """
     Figure-of-merit: FWHM minimised over a sweep of charge-trapping correction values.

--- a/src/pygama/pargen/energy_optimisation.py
+++ b/src/pygama/pargen/energy_optimisation.py
@@ -577,11 +577,17 @@ def fom_fwhm_no_alpha_sweep(
     kwarg_dict,
     ctc_param=None,
     alpha=0,
-    idxs=None,
-    frac_max=0.5,
-    kev=True,
-    use_log_pdf=False,
-    display=0,
+    """
+    Figure-of-merit: FWHM at a fixed (or pre-computed) alpha, no sweep.
+
+    Applies a single drift-time correction with the given *alpha* and fits
+    the peak, returning a comprehensive set of fit quality metrics.  Used
+    when the optimal alpha is already known (e.g. from a prior
+    :func:`fom_fwhm_with_alpha_fit` call) or when no charge-trapping
+    correction is desired.  If *use_log_pdf* is ``True``, the underlying
+    staged fit uses ``iminuit``'s ``log=True`` mode for faster unbinned NLL
+    evaluation.
+
 ):
     """
     Figure-of-merit: FWHM at a fixed (or pre-computed) alpha, no sweep.

--- a/src/pygama/pargen/energy_optimisation.py
+++ b/src/pygama/pargen/energy_optimisation.py
@@ -126,6 +126,7 @@ def get_peak_fwhm_with_dt_corr(
     frac_max=0.5,
     bin_width=1,
     allow_tail_drop=False,
+    use_log_pdf=False,
     display=0,
 ):
     """
@@ -165,6 +166,11 @@ def get_peak_fwhm_with_dt_corr(
     allow_tail_drop
         Passed through to the staged fit; allows the tail fraction to
         drop to zero.
+    use_log_pdf
+        Passed through to the staged fit; build the extended unbinned NLL
+        from the model's log-density (``iminuit`` ``log=True`` mode).
+        Faster on large samples; results can differ from the standard mode
+        at machine-precision level.
     display
         Verbosity level; values > 0 produce diagnostic plots.
 
@@ -230,6 +236,7 @@ def get_peak_fwhm_with_dt_corr(
             guess=guess,
             allow_tail_drop=allow_tail_drop,
             bin_width=bin_width,
+            use_log_pdf=use_log_pdf,
             display=display,
         )
         if display > 0:
@@ -327,7 +334,14 @@ def get_peak_fwhm_with_dt_corr(
 
 
 def fom_fwhm_with_alpha_fit(
-    tb_in, kwarg_dict, ctc_parameter, nsteps=11, idxs=None, frac_max=0.2, display=0
+    tb_in,
+    kwarg_dict,
+    ctc_parameter,
+    nsteps=11,
+    idxs=None,
+    frac_max=0.2,
+    use_log_pdf=False,
+    display=0,
 ):
     """
     Figure-of-merit: FWHM minimised over a sweep of charge-trapping correction values.
@@ -422,6 +436,7 @@ def fom_fwhm_with_alpha_fit(
                 guess=None,
                 frac_max=0.5,
                 allow_tail_drop=False,
+                use_log_pdf=use_log_pdf,
             )
             if not np.isnan(fwhm_o_max):
                 fwhms = np.append(fwhms, fwhm_o_max)
@@ -517,6 +532,7 @@ def fom_fwhm_with_alpha_fit(
             frac_max=frac_max,
             allow_tail_drop=True,
             bin_width=bin_width,
+            use_log_pdf=use_log_pdf,
             display=display,
         )
         if np.isnan(final_fwhm) or np.isnan(final_err):
@@ -557,6 +573,7 @@ def fom_fwhm_no_alpha_sweep(
     idxs=None,
     frac_max=0.5,
     kev=True,
+    use_log_pdf=False,
     display=0,
 ):
     """
@@ -658,6 +675,7 @@ def fom_fwhm_no_alpha_sweep(
         kev_width=kev_width,
         frac_max=frac_max,
         kev=kev,
+        use_log_pdf=use_log_pdf,
         display=display,
     )
     return {
@@ -698,6 +716,9 @@ def fom_single_peak_alpha_sweep(data, kwarg_dict, display=0) -> dict:
           first entry is used.
         * ``frac_max`` *(optional, default 0.2)* - fraction of the peak  # noqa: RUF002
           maximum used to define the fit range.
+        * ``use_log_pdf`` *(optional, default False)* - use the model's  # noqa: RUF002
+          log-density in the unbinned fits (``iminuit`` ``log=True`` mode);
+          faster on large samples, results differ at machine-precision level.
     display
         Verbosity / plotting level passed through to the underlying fit.
 
@@ -715,12 +736,14 @@ def fom_single_peak_alpha_sweep(data, kwarg_dict, display=0) -> dict:
     ctc_param = kwarg_dict["ctc_param"]
     peak_dicts = kwarg_dict["peak_dicts"]
     frac_max = kwarg_dict.get("frac_max", 0.2)
+    use_log_pdf = kwarg_dict.get("use_log_pdf", False)
     return fom_fwhm_with_alpha_fit(
         data,
         peak_dicts[0],
         ctc_param,
         idxs=idx_list[0],
         frac_max=frac_max,
+        use_log_pdf=use_log_pdf,
         display=display,
     )
 
@@ -756,6 +779,9 @@ def fom_interpolate_energy_res_with_single_peak_alpha_sweep(
           curve model used for the energy-resolution fit.
         * ``frac_max`` *(optional, default 0.2)* - fraction of peak maximum  # noqa: RUF002
           used to define fit range.
+        * ``use_log_pdf`` *(optional, default False)* - use the model's  # noqa: RUF002
+          log-density in the unbinned fits (``iminuit`` ``log=True`` mode);
+          faster on large samples, results differ at machine-precision level.
     display
         Verbosity / plotting level passed through to the underlying fits.
 
@@ -781,6 +807,7 @@ def fom_interpolate_energy_res_with_single_peak_alpha_sweep(
     interp_energy = kwarg_dict.get("interp_energy", {"Qbb": 2039})
     fwhm_func = kwarg_dict.get("fwhm_func", pgc.FWHMLinear)
     frac_max = kwarg_dict.get("frac_max", 0.2)
+    use_log_pdf = kwarg_dict.get("use_log_pdf", False)
 
     out_dict = fom_fwhm_with_alpha_fit(
         data,
@@ -788,6 +815,7 @@ def fom_interpolate_energy_res_with_single_peak_alpha_sweep(
         ctc_param,
         idxs=idx_list[-1],
         frac_max=frac_max,
+        use_log_pdf=use_log_pdf,
         display=display,
     )
     alpha = out_dict["alpha"]
@@ -804,6 +832,7 @@ def fom_interpolate_energy_res_with_single_peak_alpha_sweep(
             alpha=alpha,
             idxs=idx_list[i],
             frac_max=frac_max,
+            use_log_pdf=use_log_pdf,
             display=display,
         )
         fwhms.append(out_peak_dict["fwhm"])

--- a/src/pygama/pargen/energy_optimisation.py
+++ b/src/pygama/pargen/energy_optimisation.py
@@ -337,6 +337,12 @@ def fom_fwhm_with_alpha_fit(
     tb_in,
     kwarg_dict,
     ctc_parameter,
+    nsteps=11,
+    idxs=None,
+    frac_max=0.2,
+    use_log_pdf=False,
+    display=0,
+):
     """
     Figure-of-merit: FWHM minimised over a sweep of charge-trapping correction values.
 
@@ -348,18 +354,6 @@ def fom_fwhm_with_alpha_fit(
     termination heuristic stops the sweep when the FWHM curve is clearly
     rising.  If *use_log_pdf* is ``True``, the underlying staged fits use
     ``iminuit``'s ``log=True`` mode for faster unbinned NLL evaluation.
-
-):
-    """
-    Figure-of-merit: FWHM minimised over a sweep of charge-trapping correction values.
-
-    Scans *nsteps* values of the charge-trapping coefficient alpha between
-    0 and 3.5x10^-6, fitting the peak at each step via
-    :func:`get_peak_fwhm_with_dt_corr`.  A degree-4 polynomial is fit to
-    the valid FWHM/max-ratio values to locate the optimal alpha, and the
-    peak is re-fit at that alpha to obtain the final FWHM in keV.  An early
-    termination heuristic stops the sweep when the FWHM curve is clearly
-    rising.
 
     Parameters
     ----------
@@ -379,6 +373,9 @@ def fom_fwhm_with_alpha_fit(
         events.
     frac_max
         Fractional height used to define the final FWHM.
+    use_log_pdf
+        Passed through to the staged fits; build the extended unbinned NLL
+        from the model's log-density (``iminuit`` ``log=True`` mode).
     display
         Verbosity level; values > 0 produce diagnostic plots.
 
@@ -577,6 +574,12 @@ def fom_fwhm_no_alpha_sweep(
     kwarg_dict,
     ctc_param=None,
     alpha=0,
+    idxs=None,
+    frac_max=0.5,
+    kev=True,
+    use_log_pdf=False,
+    display=0,
+):
     """
     Figure-of-merit: FWHM at a fixed (or pre-computed) alpha, no sweep.
 
@@ -587,16 +590,6 @@ def fom_fwhm_no_alpha_sweep(
     correction is desired.  If *use_log_pdf* is ``True``, the underlying
     staged fit uses ``iminuit``'s ``log=True`` mode for faster unbinned NLL
     evaluation.
-
-):
-    """
-    Figure-of-merit: FWHM at a fixed (or pre-computed) alpha, no sweep.
-
-    Applies a single drift-time correction with the given *alpha* and fits
-    the peak, returning a comprehensive set of fit quality metrics.  Used
-    when the optimal alpha is already known (e.g. from a prior
-    :func:`fom_fwhm_with_alpha_fit` call) or when no charge-trapping
-    correction is desired.
 
     Parameters
     ----------
@@ -619,6 +612,9 @@ def fom_fwhm_no_alpha_sweep(
         Fractional height used to define the FWHM.
     kev
         If ``True``, return the FWHM in keV rather than ADC units.
+    use_log_pdf
+        Passed through to the staged fit; build the extended unbinned NLL
+        from the model's log-density (``iminuit`` ``log=True`` mode).
     display
         Verbosity level; values > 0 produce diagnostic plots.
 

--- a/src/pygama/pargen/energy_optimisation.py
+++ b/src/pygama/pargen/energy_optimisation.py
@@ -126,8 +126,8 @@ def get_peak_fwhm_with_dt_corr(
     frac_max=0.5,
     bin_width=1,
     allow_tail_drop=False,
-    use_log_pdf=False,
     display=0,
+    use_log_pdf=False,
 ):
     """
     Apply a drift-time correction and fit a peak, returning FWHM and fit quality.
@@ -166,13 +166,13 @@ def get_peak_fwhm_with_dt_corr(
     allow_tail_drop
         Passed through to the staged fit; allows the tail fraction to
         drop to zero.
+    display
+        Verbosity level; values > 0 produce diagnostic plots.
     use_log_pdf
         Passed through to the staged fit; build the extended unbinned NLL
         from the model's log-density (``iminuit`` ``log=True`` mode).
         Faster on large samples; results can differ from the standard mode
         at machine-precision level.
-    display
-        Verbosity level; values > 0 produce diagnostic plots.
 
     Returns
     -------
@@ -340,8 +340,8 @@ def fom_fwhm_with_alpha_fit(
     nsteps=11,
     idxs=None,
     frac_max=0.2,
-    use_log_pdf=False,
     display=0,
+    use_log_pdf=False,
 ):
     """
     Figure-of-merit: FWHM minimised over a sweep of charge-trapping correction values.
@@ -373,11 +373,11 @@ def fom_fwhm_with_alpha_fit(
         events.
     frac_max
         Fractional height used to define the final FWHM.
+    display
+        Verbosity level; values > 0 produce diagnostic plots.
     use_log_pdf
         Passed through to the staged fits; build the extended unbinned NLL
         from the model's log-density (``iminuit`` ``log=True`` mode).
-    display
-        Verbosity level; values > 0 produce diagnostic plots.
 
     Returns
     -------
@@ -577,8 +577,8 @@ def fom_fwhm_no_alpha_sweep(
     idxs=None,
     frac_max=0.5,
     kev=True,
-    use_log_pdf=False,
     display=0,
+    use_log_pdf=False,
 ):
     """
     Figure-of-merit: FWHM at a fixed (or pre-computed) alpha, no sweep.
@@ -612,11 +612,11 @@ def fom_fwhm_no_alpha_sweep(
         Fractional height used to define the FWHM.
     kev
         If ``True``, return the FWHM in keV rather than ADC units.
+    display
+        Verbosity level; values > 0 produce diagnostic plots.
     use_log_pdf
         Passed through to the staged fit; build the extended unbinned NLL
         from the model's log-density (``iminuit`` ``log=True`` mode).
-    display
-        Verbosity level; values > 0 produce diagnostic plots.
 
     Returns
     -------

--- a/src/pygama/pargen/lq_cal.py
+++ b/src/pygama/pargen/lq_cal.py
@@ -325,6 +325,7 @@ class LQCal:
         cdf: callable = gaussian,
         selection_string: str = "is_valid_cal&is_not_pulser",
         debug_mode=False,
+        use_log_pdf: bool = False,
     ):
         """
         Parameters
@@ -346,6 +347,11 @@ class LQCal:
         debug_mode
             If ``True``, exceptions are re-raised instead of being caught
             and logged.
+        use_log_pdf
+            Build the survival-fraction unbinned NLL fits from the models'
+            log-densities (``iminuit`` ``log=True`` mode) — faster on large
+            samples, results differ at machine-precision level.  The LQ
+            calibration's own fits are binned and unaffected.
         """
 
         self.cal_dicts = cal_dicts
@@ -355,6 +361,7 @@ class LQCal:
         self.cdf = cdf
         self.selection_string = selection_string
         self.debug_mode = debug_mode
+        self.use_log_pdf = use_log_pdf
 
     def update_cal_dicts(self, update_dict):
         """
@@ -788,6 +795,7 @@ class LQCal:
                         cut_range=(0, 5),
                         n_samples=30,
                         mode="less",
+                        use_log_pdf=self.use_log_pdf,
                     )
                     self.low_side_sf = pd.concat(
                         [

--- a/src/pygama/pargen/survival_fractions.py
+++ b/src/pygama/pargen/survival_fractions.py
@@ -408,6 +408,115 @@ def fail_pdf_hpge(
     )
 
 
+def log_pass_pdf_gos(
+    x,
+    x_lo,
+    x_hi,
+    n_sig,
+    epsilon_sig,
+    n_bkg,
+    epsilon_bkg,
+    mu,
+    sigma,
+    hstep1,
+    hstep2,  # noqa: ARG001
+):
+    """Log-density counterpart of :func:`pass_pdf_gos` for ``iminuit``'s
+    ``log=True`` mode; same explicit signature (``iminuit`` introspects it)."""
+    return gauss_on_step.log_pdf_ext(
+        x, x_lo, x_hi, n_sig * epsilon_sig, mu, sigma, n_bkg * epsilon_bkg, hstep1
+    )
+
+
+def log_fail_pdf_gos(
+    x,
+    x_lo,
+    x_hi,
+    n_sig,
+    epsilon_sig,
+    n_bkg,
+    epsilon_bkg,
+    mu,
+    sigma,
+    hstep1,  # noqa: ARG001
+    hstep2,
+):
+    """Log-density counterpart of :func:`fail_pdf_gos` for ``iminuit``'s
+    ``log=True`` mode; same explicit signature (``iminuit`` introspects it)."""
+    return gauss_on_step.log_pdf_ext(
+        x,
+        x_lo,
+        x_hi,
+        n_sig * (1 - epsilon_sig),
+        mu,
+        sigma,
+        n_bkg * (1 - epsilon_bkg),
+        hstep2,
+    )
+
+
+def log_pass_pdf_hpge(
+    x,
+    x_lo,
+    x_hi,
+    n_sig,
+    epsilon_sig,
+    n_bkg,
+    epsilon_bkg,
+    mu,
+    sigma,
+    htail,
+    tau,
+    hstep1,
+    hstep2,  # noqa: ARG001
+):
+    """Log-density counterpart of :func:`pass_pdf_hpge` for ``iminuit``'s
+    ``log=True`` mode; same explicit signature (``iminuit`` introspects it)."""
+    return hpge_peak.log_pdf_ext(
+        x,
+        x_lo,
+        x_hi,
+        n_sig * epsilon_sig,
+        mu,
+        sigma,
+        htail,
+        tau,
+        n_bkg * epsilon_bkg,
+        hstep1,
+    )
+
+
+def log_fail_pdf_hpge(
+    x,
+    x_lo,
+    x_hi,
+    n_sig,
+    epsilon_sig,
+    n_bkg,
+    epsilon_bkg,
+    mu,
+    sigma,
+    htail,
+    tau,
+    hstep1,  # noqa: ARG001
+    hstep2,
+):
+    """Log-density counterpart of :func:`fail_pdf_hpge` for ``iminuit``'s
+    ``log=True`` mode; same explicit signature (``iminuit`` introspects it)."""
+    return hpge_peak.log_pdf_ext(
+        x,
+        x_lo,
+        x_hi,
+        n_sig * (1 - epsilon_sig),
+        mu,
+        sigma,
+        htail,
+        tau,
+        n_bkg * (1 - epsilon_bkg),
+        hstep2,
+    )
+
+
 def update_guess(func, parguess, energies):
     """
     Update the signal and background event-count guesses from data.
@@ -475,11 +584,15 @@ def get_survival_fraction(
     mode: str = "greater",
     func=hpge_peak,
     fix_step=True,
+    use_log_pdf=False,
     display=0,
 ):
     """
     Function for calculating the survival fraction of a cut
     using a fit to the surviving and failing energy distributions.
+    When *use_log_pdf* is true the unbinned NLL costs are built from the
+    models' log-densities (``iminuit`` ``log=True`` mode) — faster on large
+    samples, results differ at machine-precision level.
 
     Parameters
     ----------
@@ -569,6 +682,7 @@ def get_survival_fraction(
             bounds_func=get_bounds,
             guess_kwargs={"peak": peak, "eres": eres_pars},
             fit_range=fit_range,
+            use_log_pdf=use_log_pdf,
         )
 
     guess_pars_surv = copy.deepcopy(pars)
@@ -604,13 +718,27 @@ def get_survival_fraction(
         parguess.update({"htail": pars["htail"], "tau": pars["tau"]})
 
     if func == hpge_peak:
+        pass_pdf, fail_pdf = (
+            (log_pass_pdf_hpge, log_fail_pdf_hpge)
+            if use_log_pdf
+            else (pass_pdf_hpge, fail_pdf_hpge)
+        )
         lh = cost.ExtendedUnbinnedNLL(
-            energy[(~nan_idxs) & (pass_idxs)], pass_pdf_hpge
-        ) + cost.ExtendedUnbinnedNLL(energy[(~nan_idxs) & (fail_idxs)], fail_pdf_hpge)
+            energy[(~nan_idxs) & (pass_idxs)], pass_pdf, log=use_log_pdf
+        ) + cost.ExtendedUnbinnedNLL(
+            energy[(~nan_idxs) & (fail_idxs)], fail_pdf, log=use_log_pdf
+        )
     elif func == gauss_on_step:
+        pass_pdf, fail_pdf = (
+            (log_pass_pdf_gos, log_fail_pdf_gos)
+            if use_log_pdf
+            else (pass_pdf_gos, fail_pdf_gos)
+        )
         lh = cost.ExtendedUnbinnedNLL(
-            energy[(~nan_idxs) & (pass_idxs)], pass_pdf_gos
-        ) + cost.ExtendedUnbinnedNLL(energy[(~nan_idxs) & (fail_idxs)], fail_pdf_gos)
+            energy[(~nan_idxs) & (pass_idxs)], pass_pdf, log=use_log_pdf
+        ) + cost.ExtendedUnbinnedNLL(
+            energy[(~nan_idxs) & (fail_idxs)], fail_pdf, log=use_log_pdf
+        )
 
     else:
         msg = (
@@ -667,10 +795,13 @@ def get_sf_sweep(
     mode="greater",
     fit_range=None,
     debug_mode=False,
+    use_log_pdf=False,
 ) -> tuple[pd.DataFrame, float, float]:
     """
     Function sweeping through cut values and calculating the survival fraction for each value
     using a fit to the surviving and failing enegry distributions.
+    When *use_log_pdf* is true the unbinned NLL costs are built from the
+    models' log-densities (``iminuit`` ``log=True`` mode).
 
     Parameters
     ----------
@@ -730,6 +861,7 @@ def get_sf_sweep(
         bounds_func=get_bounds,
         guess_kwargs={"peak": peak, "eres": eres_pars},
         fit_range=fit_range,
+        use_log_pdf=use_log_pdf,
     )
 
     for cut_val in cut_vals:
@@ -745,6 +877,7 @@ def get_sf_sweep(
                 mode=mode,
                 pars=pars,
                 func=func,
+                use_log_pdf=use_log_pdf,
             )
             out_df = pd.concat(
                 [out_df, pd.DataFrame([{"cut_val": cut_val, "sf": sf, "sf_err": err}])]
@@ -771,6 +904,7 @@ def get_sf_sweep(
             mode=mode,
             pars=pars,
             func=func,
+            use_log_pdf=use_log_pdf,
         )
     else:
         sf = None

--- a/src/pygama/pargen/survival_fractions.py
+++ b/src/pygama/pargen/survival_fractions.py
@@ -584,8 +584,8 @@ def get_survival_fraction(
     mode: str = "greater",
     func=hpge_peak,
     fix_step=True,
-    use_log_pdf=False,
     display=0,
+    use_log_pdf=False,
 ):
     """
     Function for calculating the survival fraction of a cut
@@ -799,7 +799,7 @@ def get_sf_sweep(
 ) -> tuple[pd.DataFrame, float, float]:
     """
     Function sweeping through cut values and calculating the survival fraction for each value
-    using a fit to the surviving and failing enegry distributions.
+    using a fit to the surviving and failing energy distributions.
     When *use_log_pdf* is true the unbinned NLL costs are built from the
     models' log-densities (``iminuit`` ``log=True`` mode).
 

--- a/tests/math/test_sum_dists_dispatch.py
+++ b/tests/math/test_sum_dists_dispatch.py
@@ -1,0 +1,99 @@
+"""Regression tests for the cached signature-wrapper dispatch of SumDists.
+
+The wrappers returned by attribute access are cached per instance; these tests
+pin down that the cache changes neither the values produced, the advertised
+signatures, nor runtime-state handling (``components``), and that the norm
+computed with an explicit subtraction matches the previous ``np.diff`` form.
+"""
+
+from __future__ import annotations
+
+import copy
+import inspect
+
+import numpy as np
+
+from pygama.math.distributions import gauss_on_step, hpge_peak
+from pygama.math.functions.sum_dists import get_areas_fracs
+
+X = np.linspace(13000.0, 13140.0, 501)
+# x_lo, x_hi, n_sig, mu, sigma, htail, tau, n_bkg, hstep
+HPGE_PARS = (13000.0, 13140.0, 900.0, 13072.0, 17.5, 0.1, 40.0, 100.0, 0.01)
+# x_lo, x_hi, n_sig, mu, sigma, n_bkg, hstep
+STEP_PARS = (13000.0, 13140.0, 900.0, 13072.0, 17.5, 100.0, 0.01)
+
+
+def test_wrapper_forwards_exactly():
+    for dist, pars in ((hpge_peak, HPGE_PARS), (gauss_on_step, STEP_PARS)):
+        for method in ("get_pdf", "get_cdf", "pdf_norm", "cdf_norm"):
+            wrapped = getattr(dist, method)
+            plain = object.__getattribute__(dist, method)
+            assert np.array_equal(wrapped(X, *pars), plain(X, *pars))
+        sig_w, probs_w = dist.pdf_ext(X, *pars)
+        sig_p, probs_p = object.__getattribute__(dist, "pdf_ext")(X, *pars)
+        assert sig_w == sig_p
+        assert np.array_equal(probs_w, probs_p)
+
+
+def test_wrapper_is_cached_and_signature_preserved():
+    assert hpge_peak.get_pdf is hpge_peak.get_pdf
+    assert hpge_peak.pdf_ext is hpge_peak.pdf_ext
+    assert hpge_peak.get_pdf is not hpge_peak.get_cdf
+
+    assert list(inspect.signature(hpge_peak.get_pdf).parameters) == list(
+        hpge_peak.x_shapes
+    )
+    assert list(inspect.signature(hpge_peak.pdf_ext).parameters) == list(
+        hpge_peak.extended_shapes
+    )
+
+
+def test_norm_matches_np_diff_reference():
+    params = np.array(HPGE_PARS)
+    fracs, areas = get_areas_fracs(
+        params,
+        hpge_peak.area_frac_idxs,
+        hpge_peak.frac_flag,
+        hpge_peak.area_flag,
+        hpge_peak.one_area_flag,
+    )
+    support = np.array([HPGE_PARS[0], HPGE_PARS[1]])
+    ref_sig = (
+        areas[0]
+        * fracs[0]
+        * np.diff(hpge_peak.dists[0].get_cdf(support, *params[hpge_peak.par_idxs[0]]))[
+            0
+        ]
+        + areas[1]
+        * fracs[1]
+        * np.diff(hpge_peak.dists[1].get_cdf(support, *params[hpge_peak.par_idxs[1]]))[
+            0
+        ]
+    )
+    sig, _ = hpge_peak.pdf_ext(X, *HPGE_PARS)
+    assert sig == ref_sig
+
+    ref_norm = np.diff(hpge_peak.get_cdf(support, *HPGE_PARS))
+    ref_pdf_norm = hpge_peak.get_pdf(X, *HPGE_PARS) / ref_norm
+    assert np.array_equal(hpge_peak.pdf_norm(X, *HPGE_PARS), ref_pdf_norm)
+    ref_cdf_norm = hpge_peak.get_cdf(X, *HPGE_PARS) / ref_norm
+    assert np.array_equal(hpge_peak.cdf_norm(X, *HPGE_PARS), ref_cdf_norm)
+
+
+def test_components_toggle_still_honoured():
+    sig, probs = hpge_peak.pdf_ext(X, *HPGE_PARS)
+    hpge_peak.components = True
+    try:
+        sig_c, comp_1, comp_2 = hpge_peak.pdf_ext(X, *HPGE_PARS)
+    finally:
+        hpge_peak.components = False
+    assert sig_c == sig
+    assert np.array_equal(comp_1 + comp_2, probs)
+
+
+def test_deepcopy_gets_independent_cache():
+    dist = copy.deepcopy(gauss_on_step)
+    assert dist.get_pdf is not gauss_on_step.get_pdf
+    assert np.array_equal(
+        dist.get_pdf(X, *STEP_PARS), gauss_on_step.get_pdf(X, *STEP_PARS)
+    )

--- a/tests/pargen/test_aoe_log_mode.py
+++ b/tests/pargen/test_aoe_log_mode.py
@@ -7,15 +7,14 @@ import numpy as np
 from pygama.pargen.AoE_cal import unbinned_aoe_fit
 from pygama.pargen.survival_fractions import get_survival_fraction
 
-RNG = np.random.default_rng(2718)
-
 
 def test_unbinned_aoe_fit_log_mode_agrees():
+    rng = np.random.default_rng(2718)
     n = 20000
     aoe = np.concatenate(
         [
-            RNG.normal(0.0, 0.01, int(n * 0.9)),
-            -RNG.exponential(0.03, int(n * 0.1)),
+            rng.normal(0.0, 0.01, int(n * 0.9)),
+            -rng.exponential(0.03, int(n * 0.1)),
         ]
     )
 
@@ -41,19 +40,20 @@ def test_unbinned_aoe_fit_log_mode_agrees():
 
 
 def test_get_survival_fraction_log_mode_agrees():
+    rng = np.random.default_rng(31415)
     n_sig, n_bkg = 5000, 1000
     mu, sigma = 1592.5, 1.2
     energy = np.concatenate(
         [
-            RNG.normal(mu, sigma, n_sig),
-            RNG.uniform(mu - 30, mu + 30, n_bkg),
+            rng.normal(mu, sigma, n_sig),
+            rng.uniform(mu - 30, mu + 30, n_bkg),
         ]
     )
     # cut parameter correlated with nothing: signal survives ~90%, bkg ~50%
     cut_param = np.concatenate(
         [
-            RNG.normal(2.0, 1.0, n_sig),
-            RNG.normal(0.0, 1.0, n_bkg),
+            rng.normal(2.0, 1.0, n_sig),
+            rng.normal(0.0, 1.0, n_bkg),
         ]
     )
 

--- a/tests/pargen/test_aoe_log_mode.py
+++ b/tests/pargen/test_aoe_log_mode.py
@@ -1,0 +1,76 @@
+"""Tests for the ``use_log_pdf`` mode of the A/E and survival-fraction fits."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from pygama.pargen.AoE_cal import unbinned_aoe_fit
+from pygama.pargen.survival_fractions import get_survival_fraction
+
+RNG = np.random.default_rng(2718)
+
+
+def test_unbinned_aoe_fit_log_mode_agrees():
+    n = 20000
+    aoe = np.concatenate(
+        [
+            RNG.normal(0.0, 0.01, int(n * 0.9)),
+            -RNG.exponential(0.03, int(n * 0.1)),
+        ]
+    )
+
+    res = {}
+    for use_log in (False, True):
+        pars, errs, _cov, (_, _, _, _, _, _, valid, _m) = unbinned_aoe_fit(
+            aoe, use_log_pdf=use_log
+        )
+        assert valid
+        res[use_log] = (np.array(pars), np.array(errs))
+
+    pars_std, errs_std = res[False]
+    pars_log, errs_log = res[True]
+    # mu / sigma are the physically used outputs
+    names = ["x_lo", "x_hi", "n_sig", "mu", "sigma", "n_bkg", "tau"]
+    mu_i, sigma_i = names.index("mu"), names.index("sigma")
+    # mu sits near zero for normalised A/E, so measure its shift in units of
+    # the peak width rather than relative to itself
+    assert abs(pars_log[mu_i] - pars_std[mu_i]) < 1e-4 * pars_std[sigma_i]
+    assert np.isclose(pars_log[sigma_i], pars_std[sigma_i], rtol=1e-4)
+    assert np.allclose(pars_log, pars_std, rtol=5e-3, atol=1e-12)
+    assert np.allclose(errs_log, errs_std, rtol=5e-2, atol=1e-12)
+
+
+def test_get_survival_fraction_log_mode_agrees():
+    n_sig, n_bkg = 5000, 1000
+    mu, sigma = 1592.5, 1.2
+    energy = np.concatenate(
+        [
+            RNG.normal(mu, sigma, n_sig),
+            RNG.uniform(mu - 30, mu + 30, n_bkg),
+        ]
+    )
+    # cut parameter correlated with nothing: signal survives ~90%, bkg ~50%
+    cut_param = np.concatenate(
+        [
+            RNG.normal(2.0, 1.0, n_sig),
+            RNG.normal(0.0, 1.0, n_bkg),
+        ]
+    )
+
+    res = {}
+    for use_log in (False, True):
+        sf, sf_err, _, _ = get_survival_fraction(
+            energy,
+            cut_param,
+            0.0,
+            mu,
+            2.355 * sigma,
+            fit_range=(mu - 30, mu + 30),
+            mode="greater",
+            use_log_pdf=use_log,
+        )
+        assert np.isfinite(sf)
+        res[use_log] = (sf, sf_err)
+
+    assert np.isclose(res[True][0], res[False][0], rtol=1e-3)
+    assert np.isclose(res[True][1], res[False][1], rtol=5e-2)

--- a/tests/pargen/test_dplms.py
+++ b/tests/pargen/test_dplms.py
@@ -1,0 +1,98 @@
+"""Tests for the DPLMS helpers in ``pygama.pargen.dplms_ge_dict``."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from pygama.pargen.dplms_ge_dict import is_not_pile_up, signal_selection
+
+
+def _reference_is_not_pile_up(peak_pos, peak_pos_neg, thr, lim, size):
+    """Verbatim copy of the pre-vectorisation per-event loop."""
+    bin_edges = np.linspace(size / 2 - lim, size / 2 + lim, 2 * lim)
+    hist, bin_edges = np.histogram(peak_pos, bins=bin_edges)
+
+    thr = thr * hist.max() / 100
+    low_thr_idxs = np.where(hist[: hist.argmax()] < thr)[0]
+    upp_thr_idxs = np.where(hist[hist.argmax() :] < thr)[0]
+
+    idx_low = low_thr_idxs[-1] if low_thr_idxs.size > 0 else 0
+    idx_upp = (
+        upp_thr_idxs[0] + hist.argmax() if upp_thr_idxs.size > 0 else len(hist) - 1
+    )
+
+    llow, lupp = bin_edges[idx_low], bin_edges[idx_upp]
+
+    idxs = []
+    for n, nn in zip(peak_pos, peak_pos_neg, strict=False):
+        condition1 = np.count_nonzero(n > 0) == 1
+        condition2 = (
+            np.count_nonzero((n > 0) & ((n < llow) | (n > lupp) & (n < size))) == 0
+        )
+        condition3 = np.count_nonzero(nn > 0) == 0
+        idxs.append(condition1 and condition2 and condition3)
+    return idxs, llow, lupp
+
+
+def test_is_not_pile_up_matches_loop_reference():
+    rng = np.random.default_rng(41)
+    n_events, n_peaks, size, lim, thr = 500, 5, 762, 30, 0.1
+
+    # zero-padded peak-position arrays: one main peak near the centre, with
+    # random extra positive peaks and occasional negative-polarity peaks
+    peak_pos = np.zeros((n_events, n_peaks))
+    peak_pos[:, 0] = rng.normal(size / 2, 3, n_events)
+    extra = rng.integers(0, size + 40, (n_events, n_peaks - 1))
+    has_extra = rng.random((n_events, n_peaks - 1)) < 0.3
+    peak_pos[:, 1:] = np.where(has_extra, extra, 0)
+
+    peak_pos_neg = np.zeros((n_events, n_peaks))
+    neg = rng.integers(0, size, (n_events, n_peaks))
+    peak_pos_neg[:] = np.where(rng.random((n_events, n_peaks)) < 0.05, neg, 0)
+
+    ref_idxs, ref_llow, ref_lupp = _reference_is_not_pile_up(
+        peak_pos, peak_pos_neg, thr, lim, size
+    )
+    idxs, llow, lupp = is_not_pile_up(peak_pos, peak_pos_neg, thr, lim, size)
+
+    assert llow == ref_llow
+    assert lupp == ref_lupp
+    assert np.array_equal(idxs, np.array(ref_idxs))
+    # both selected and rejected events must be present for a meaningful test
+    assert 0 < np.count_nonzero(idxs) < n_events
+
+
+def test_signal_selection_is_deterministic():
+    """signal_selection is pure in its inputs — the caching in dplms_ge_dict
+    relies on this."""
+    rng = np.random.default_rng(7)
+    n_events, size = 200, 762
+
+    class FakeCol:
+        def __init__(self, nda):
+            self.nda = nda
+
+    peak_pos = np.zeros((n_events, 3))
+    peak_pos[:, 0] = rng.normal(size / 2, 3, n_events)
+    dsp_cal = {
+        "peak_pos": FakeCol(peak_pos),
+        "peak_pos_neg": FakeCol(np.zeros((n_events, 3))),
+        "centroid": FakeCol(rng.normal(size / 2, 5, n_events)),
+        "tp_90": FakeCol(rng.uniform(500, 900, n_events)),
+        "tp_10": FakeCol(rng.uniform(100, 400, n_events)),
+    }
+    dplms_dict = {
+        "rt_low": 96,
+        "peak_lim": 30,
+        "wsize": size,
+        "bsize": 1024,
+        "centroid_lim": 20,
+        "dp_def": {"rt": 99, "pt": 0.1},
+    }
+
+    first = signal_selection(dsp_cal, dplms_dict, {})
+    second = signal_selection(dsp_cal, dplms_dict, {"nm": 1, "za": 0})
+
+    assert np.array_equal(first["idxs"], second["idxs"])
+    for key in ("ct_ll", "ct_hh", "pp_ll", "pp_hh", "rt_ll", "rt_hh"):
+        assert first[key] == second[key]

--- a/tests/pargen/test_unbinned_staged_fit_log_mode.py
+++ b/tests/pargen/test_unbinned_staged_fit_log_mode.py
@@ -8,6 +8,7 @@ the standard mode to within float summation noise.
 from __future__ import annotations
 
 import numpy as np
+import pytest
 from lgdo import Array, Table
 
 import pygama.math.distributions as pgf
@@ -62,6 +63,55 @@ def test_staged_fit_log_mode_agrees_with_standard():
     fwhm_std = hpge_peak_fwfm(pars_std[4], pars_std[5], pars_std[6])
     fwhm_log = hpge_peak_fwfm(pars_log[4], pars_log[5], pars_log[6])
     assert np.isclose(fwhm_log, fwhm_std, rtol=1e-4)
+
+
+def test_use_log_pdf_requires_log_pdf_ext():
+    class NoLogPdf:
+        pass
+
+    with pytest.raises(ValueError, match="log_pdf_ext"):
+        unbinned_staged_energy_fit(ENERGY, func=NoLogPdf(), use_log_pdf=True)
+
+
+def test_hpge_calibration_log_mode_agrees(lgnd_test_data):
+    data = lgnd_test_data.get_path(
+        "lh5/prod-ref-l200/generated/tier/dsp/cal/p03/r000/l200-p03-r000-cal-20230311T235840Z-tier_dsp.lh5"
+    )
+    import lh5
+
+    from pygama.pargen import energy_cal
+
+    energy = lh5.read_as("ch1104000/dsp/cuspEmax", data, "np")
+    glines = [860.564, 1592.53, 1620.50, 2103.53, 2614.50]
+    pk_pars = [(line, (20, 20), pgf.hpge_peak) for line in glines]
+
+    res = {}
+    for use_log in (False, True):
+        cal = energy_cal.HPGeCalibration(
+            "cuspEmax",
+            glines,
+            2615 / np.nanpercentile(energy, 99),
+            deg=0,
+            debug_mode=True,
+        )
+        cal.hpge_find_energy_peaks(energy)
+        cal.hpge_get_energy_peaks(energy)
+        cal.hpge_fit_energy_peaks(energy, peak_pars=pk_pars, use_log_pdf=use_log)
+        cal.get_energy_res_curve(
+            energy_cal.FWHMLinear, interp_energy_kev={"Qbb": 2039.0}
+        )
+        fit_results = cal.results["hpge_fit_energy_peaks"]
+        res[use_log] = (
+            np.array(cal.pars),
+            np.array(fit_results["pk_pos"], dtype=float),
+            fit_results["FWHMLinear"]["Qbb_fwhm_in_kev"],
+        )
+
+    pars_std, pos_std, qbb_std = res[False]
+    pars_log, pos_log, qbb_log = res[True]
+    assert np.allclose(pars_log, pars_std, rtol=1e-6)
+    assert np.allclose(pos_log, pos_std, rtol=1e-6)
+    assert np.isclose(qbb_log, qbb_std, rtol=1e-3)
 
 
 def test_fom_wiring_forwards_use_log_pdf():

--- a/tests/pargen/test_unbinned_staged_fit_log_mode.py
+++ b/tests/pargen/test_unbinned_staged_fit_log_mode.py
@@ -1,0 +1,80 @@
+"""Tests for the ``use_log_pdf`` mode of ``unbinned_staged_energy_fit``.
+
+The log mode hands ``iminuit`` the log-density directly (``log=True``), which
+replaces the sorted log-sum with a plain sum.  The fit result must agree with
+the standard mode to within float summation noise.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from lgdo import Array, Table
+
+import pygama.math.distributions as pgf
+from pygama.math.functions.sum_dists import _TINY_FLOAT
+from pygama.math.hpge_peak_fitting import hpge_peak_fwfm
+from pygama.pargen.energy_cal import unbinned_staged_energy_fit
+from pygama.pargen.energy_optimisation import fom_fwhm_no_alpha_sweep
+
+RNG = np.random.default_rng(8175)
+MU, SIGMA = 13072.0, 17.5
+N_SIG, N_TAIL, N_BKG = 3000, 300, 400
+ENERGY = np.concatenate(
+    [
+        RNG.normal(MU, SIGMA, N_SIG),
+        # low-side exponential tail so htail/tau are well constrained
+        MU - RNG.exponential(40.0, N_TAIL) - RNG.normal(0, SIGMA, N_TAIL),
+        RNG.uniform(MU - 250, MU + 250, N_BKG),
+    ]
+)
+FIT_RANGE = (MU - 250, MU + 250)
+
+
+def test_log_pdf_ext_matches_pdf_ext():
+    x = np.linspace(*FIT_RANGE, 1001)
+    pars = (FIT_RANGE[0], FIT_RANGE[1], 900.0, MU, SIGMA, 0.1, 40.0, 100.0, 0.01)
+    sig, probs = pgf.hpge_peak.pdf_ext(x, *pars)
+    sig_log, log_probs = pgf.hpge_peak.log_pdf_ext(x, *pars)
+    assert sig_log == sig
+    assert np.array_equal(log_probs, np.log(probs + _TINY_FLOAT))
+
+
+def test_staged_fit_log_mode_agrees_with_standard():
+    res = {}
+    for use_log in (False, True):
+        pars, errs, _cov, _csqr, _func, _mask, valid, _m = unbinned_staged_energy_fit(
+            ENERGY,
+            func=pgf.hpge_peak,
+            fit_range=FIT_RANGE,
+            use_log_pdf=use_log,
+        )
+        assert valid
+        res[use_log] = (np.array(pars), np.array(errs))
+
+    pars_std, errs_std = res[False]
+    pars_log, errs_log = res[True]
+    assert np.allclose(pars_log, pars_std, rtol=2e-3, atol=1e-10)
+    assert np.allclose(errs_log, errs_std, rtol=2e-2, atol=1e-10)
+
+    # the physical observable must agree much tighter than the (partially
+    # degenerate) shape parameters: pars = (x_lo, x_hi, n_sig, mu, sigma,
+    # htail, tau, n_bkg, hstep)
+    fwhm_std = hpge_peak_fwfm(pars_std[4], pars_std[5], pars_std[6])
+    fwhm_log = hpge_peak_fwfm(pars_log[4], pars_log[5], pars_log[6])
+    assert np.isclose(fwhm_log, fwhm_std, rtol=1e-4)
+
+
+def test_fom_wiring_forwards_use_log_pdf():
+    tb = Table(col_dict={"cuspEmax": Array(ENERGY)})
+    kd = {
+        "parameter": "cuspEmax",
+        "func": pgf.hpge_peak,
+        "peak": 2614.5,
+        "kev_width": (50, 50),
+    }
+    res = {
+        use_log: fom_fwhm_no_alpha_sweep(tb, kd, alpha=0, use_log_pdf=use_log)
+        for use_log in (False, True)
+    }
+    assert np.isfinite(res[True]["fwhm"])
+    assert np.isclose(res[True]["fwhm"], res[False]["fwhm"], rtol=1e-4)


### PR DESCRIPTION
## Motivation

Profiling the LEGEND `par-geds-dsp-eopt` calibration step showed that ~96% of its
runtime is spent in `fom_fwhm_with_alpha_fit` (energy-resolution FOM), and within
that, most of the cost per NLL evaluation is split between the pdf math and
iminuit's `_unbinned_nll`, which **sorts all per-event log values on every
evaluation** for summation accuracy. At production scale (10k events, ±70 keV
window, 2614.5 keV peak) one FOM call takes ~17 s and each eopt pass makes three
of them.

## Changes

**1. `perf(math)`: cache the SumDists signature-wrapper dispatch** *(behavior-preserving)*

`SumDists.__getattribute__` rebuilt `inspect.Parameter` lists, an
`inspect.Signature`, and a fresh closure on *every* access to
`get_pdf`/`pdf_ext`/`get_cdf`/… (~500k accesses per FOM call, doubled by
`hpge_peak` nesting a SumDists inside a SumDists). Wrappers are now built once
per instance and cached in a `WeakKeyDictionary` (instances stay deepcopy-able
and collectable). `np.diff` on 2-element cdf arrays became the identical
subtraction. Outputs are bit-identical — regression-tested, including the
runtime `components` toggle that `AoE_cal` relies on.

**2. `perf(pargen)`: opt-in `use_log_pdf` mode for unbinned energy fits** *(default off)*

- New `SumDists.log_pdf_ext` returning `(integral, log(density + tiny))`, with
  the same zero-protection iminuit applies internally.
- `unbinned_staged_energy_fit(..., use_log_pdf=False)`: when enabled, all
  extended unbinned NLL costs are built with iminuit's `log=True` mode, which
  sums the log-density directly — no per-evaluation sort.
- Wired through the FOM layer (`get_peak_fwhm_with_dt_corr`,
  `fom_fwhm_with_alpha_fit`, `fom_fwhm_no_alpha_sweep`) and readable from the
  `kwarg_dict` of `fom_single_peak_alpha_sweep` /
  `fom_interpolate_energy_res_with_single_peak_alpha_sweep`, so production
  configs can enable it per channel.
- Also threaded through `HPGeCalibration` (`hpge_fit_energy_peaks`,
  `full_calibration`, `fit_calibrated_peaks`, `calibrate_prominent_peak`), so
  the energy-calibration path can opt in as well; `unbinned_staged_energy_fit`
  raises a clear `ValueError` if the model lacks `log_pdf_ext`.

## Benchmark

Production-scale synthetic 2614.5 keV peak (10k events, `kev_width=(70,70)`,
`bin_width=5`), `fom_fwhm_with_alpha_fit`:

| | time | vs baseline |
|---|---|---|
| baseline (sorted log) | 17.1 s | — |
| `use_log_pdf=True` | 10.0 s | **1.71× faster** |

Result deviations with `use_log_pdf=True`: `alpha` bit-identical, `fwhm`
5.5×10⁻¹⁰ relative, `fwhm_err` 6.8×10⁻⁸, `alpha_err` 2.8×10⁻³ relative
(absolute ~10⁻¹¹; it is a bootstrap std of polynomial minima). For LEGEND eopt
this projects to roughly halving the per-channel runtime once enabled in the
dataprod configs.

## Tests

- `tests/math/test_sum_dists_dispatch.py`: exact forwarding equality, wrapper
  caching + signature preservation (what iminuit introspects), exact equality
  against the previous `np.diff` arithmetic, `components` toggle, deepcopy.
- `tests/pargen/test_unbinned_staged_fit_log_mode.py`: definitional identity of
  `log_pdf_ext`, standard-vs-log staged-fit agreement on a realistic hpge peak
  (shape pars to 2×10⁻³ — tail pars are partially degenerate — FWHM to 10⁻⁴),
  FOM-level wiring, the `log_pdf_ext` capability check, and an
  `HPGeCalibration`-level agreement test on the legend-testdata spectrum
  (cal pars / peak positions to 10⁻⁶, interpolated Qbb FWHM to 10⁻³).
- Full `tests/math` + `tests/pargen` suites pass (209).

## Notes

- Unrelated pre-existing issue found while testing: `pickle.dumps(hpge_peak)`
  fails on `main` (`AttributeError: 'SumDists' object has no attribute
  'hpge_get_fwfm'`) — can open a separate issue.
- Disclosure per `AI_POLICY.md`: this contribution was developed with AI
  assistance (Claude) and reviewed by the submitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
