### PR TITLE
perf(pargen): speed up dplms_ge_dict grid search

### DIFF
--- a/src/pygama/pargen/dplms_ge_dict.py
+++ b/src/pygama/pargen/dplms_ge_dict.py
@@ -48,7 +48,10 @@ def dplms_ge_dict(
     par_dsp
         Dictionary with db parameters for dsp processing
     dplms_dict
-        Dictionary with various parameters
+        Dictionary with various parameters.  Optional key ``use_log_pdf``
+        (default False): build the FOM's unbinned fits from the model's
+        log-density (``iminuit`` ``log=True`` mode) — faster on large
+        samples, results differ at machine-precision level.
     fom_func
         Function for peak fits
 
@@ -140,10 +143,29 @@ def dplms_ge_dict(
     coeff_keys = list(dp_coeffs.keys())
     lists = [dp_coeffs[key] for key in dp_coeffs]
 
+    use_log_pdf = dplms_dict.get("use_log_pdf", False)
+
     prod = list(itertools.product(*lists))
     grid_dict = {}
     min_fom = float("inf")
     min_idx = None
+
+    # signal selection and the signal-shape matrices depend only on the rt
+    # (risetime percentile) and pt (pile-up threshold) coefficients, so cache
+    # them: for grids that only vary nm/za/pl/ft they are computed once
+    sel_matrix_cache = {}
+
+    def selection_and_matrices(coeff_values):
+        key = (
+            coeff_values.get("rt", dplms_dict["dp_def"]["rt"]),
+            coeff_values.get("pt", dplms_dict["dp_def"]["pt"]),
+        )
+        if key not in sel_matrix_cache:
+            sel_dict = signal_selection(dsp_cal, dplms_dict, coeff_values)
+            wfs = dsp_cal[wf_field].nda[sel_dict["idxs"], :]
+            matrices = signal_matrices(wfs, dplms_dict["length"], decay_const)
+            sel_matrix_cache[key] = (sel_dict, matrices, len(wfs))
+        return sel_matrix_cache[key]
 
     for i, values in enumerate(prod):
         coeff_values = dict(zip(coeff_keys, values, strict=False))
@@ -154,11 +176,10 @@ def dplms_ge_dict(
 
         grid_dict[i] = coeff_values
 
-        sel_dict = signal_selection(dsp_cal, dplms_dict, coeff_values)
-        wfs = dsp_cal[wf_field].nda[sel_dict["idxs"], :]
-        log.info("... %s signals after signal selection", len(wfs))
+        sel_dict, matrices, n_wfs = selection_and_matrices(coeff_values)
+        log.info("... %s signals after signal selection", n_wfs)
 
-        ref, rmat, pmat, fmat = signal_matrices(wfs, dplms_dict["length"], decay_const)
+        ref, rmat, pmat, fmat = matrices
 
         t_tmp = time.time()
         nm_coeff = coeff_values["nm"]
@@ -192,6 +213,7 @@ def dplms_ge_dict(
                 ctc_par,
                 idxs=np.where(~np.isnan(dsp_opt[ctc_par].nda))[0],
                 frac_max=0.5,
+                use_log_pdf=use_log_pdf,
             )
         except Exception as e:
             log.debug(
@@ -294,10 +316,10 @@ def dplms_ge_dict(
         alpha = 0
 
     # filter synthesis
-    sel_dict = signal_selection(dsp_cal, dplms_dict, best_case_values)
+    sel_dict, matrices, _ = selection_and_matrices(best_case_values)
     idxs = sel_dict["idxs"]
     wfs = dsp_cal[wf_field].nda[idxs, :]
-    ref, rmat, pmat, fmat = signal_matrices(wfs, dplms_dict["length"], decay_const)
+    ref, rmat, pmat, fmat = matrices
 
     x, _y, _refy = filter_synthesis(
         ref,
@@ -496,7 +518,7 @@ def is_not_pile_up(
     Returns
     -------
     idxs
-        Per-event mask; True means the event is pile-up free.
+        Per-event boolean mask; True means the event is pile-up free.
     llow
         Lower boundary of the accepted peak band (samples).
     lupp
@@ -516,14 +538,16 @@ def is_not_pile_up(
 
     llow, lupp = bin_edges[idx_low], bin_edges[idx_upp]
 
-    idxs = []
-    for n, nn in zip(peak_pos, peak_pos_neg, strict=False):
-        condition1 = np.count_nonzero(n > 0) == 1
-        condition2 = (
-            np.count_nonzero((n > 0) & ((n < llow) | (n > lupp) & (n < size))) == 0
+    pos = peak_pos > 0
+    condition1 = np.count_nonzero(pos, axis=1) == 1
+    condition2 = (
+        np.count_nonzero(
+            pos & ((peak_pos < llow) | (peak_pos > lupp) & (peak_pos < size)), axis=1
         )
-        condition3 = np.count_nonzero(nn > 0) == 0
-        idxs.append(condition1 and condition2 and condition3)
+        == 0
+    )
+    condition3 = np.count_nonzero(peak_pos_neg > 0, axis=1) == 0
+    idxs = condition1 & condition2 & condition3
     return idxs, llow, lupp
 
 

--- a/tests/pargen/test_dplms.py
+++ b/tests/pargen/test_dplms.py
@@ -1,0 +1,98 @@
+"""Tests for the DPLMS helpers in ``pygama.pargen.dplms_ge_dict``."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from pygama.pargen.dplms_ge_dict import is_not_pile_up, signal_selection
+
+
+def _reference_is_not_pile_up(peak_pos, peak_pos_neg, thr, lim, size):
+    """Verbatim copy of the pre-vectorisation per-event loop."""
+    bin_edges = np.linspace(size / 2 - lim, size / 2 + lim, 2 * lim)
+    hist, bin_edges = np.histogram(peak_pos, bins=bin_edges)
+
+    thr = thr * hist.max() / 100
+    low_thr_idxs = np.where(hist[: hist.argmax()] < thr)[0]
+    upp_thr_idxs = np.where(hist[hist.argmax() :] < thr)[0]
+
+    idx_low = low_thr_idxs[-1] if low_thr_idxs.size > 0 else 0
+    idx_upp = (
+        upp_thr_idxs[0] + hist.argmax() if upp_thr_idxs.size > 0 else len(hist) - 1
+    )
+
+    llow, lupp = bin_edges[idx_low], bin_edges[idx_upp]
+
+    idxs = []
+    for n, nn in zip(peak_pos, peak_pos_neg, strict=False):
+        condition1 = np.count_nonzero(n > 0) == 1
+        condition2 = (
+            np.count_nonzero((n > 0) & ((n < llow) | (n > lupp) & (n < size))) == 0
+        )
+        condition3 = np.count_nonzero(nn > 0) == 0
+        idxs.append(condition1 and condition2 and condition3)
+    return idxs, llow, lupp
+
+
+def test_is_not_pile_up_matches_loop_reference():
+    rng = np.random.default_rng(41)
+    n_events, n_peaks, size, lim, thr = 500, 5, 762, 30, 0.1
+
+    # zero-padded peak-position arrays: one main peak near the centre, with
+    # random extra positive peaks and occasional negative-polarity peaks
+    peak_pos = np.zeros((n_events, n_peaks))
+    peak_pos[:, 0] = rng.normal(size / 2, 3, n_events)
+    extra = rng.integers(0, size + 40, (n_events, n_peaks - 1))
+    has_extra = rng.random((n_events, n_peaks - 1)) < 0.3
+    peak_pos[:, 1:] = np.where(has_extra, extra, 0)
+
+    peak_pos_neg = np.zeros((n_events, n_peaks))
+    neg = rng.integers(0, size, (n_events, n_peaks))
+    peak_pos_neg[:] = np.where(rng.random((n_events, n_peaks)) < 0.05, neg, 0)
+
+    ref_idxs, ref_llow, ref_lupp = _reference_is_not_pile_up(
+        peak_pos, peak_pos_neg, thr, lim, size
+    )
+    idxs, llow, lupp = is_not_pile_up(peak_pos, peak_pos_neg, thr, lim, size)
+
+    assert llow == ref_llow
+    assert lupp == ref_lupp
+    assert np.array_equal(idxs, np.array(ref_idxs))
+    # both selected and rejected events must be present for a meaningful test
+    assert 0 < np.count_nonzero(idxs) < n_events
+
+
+def test_signal_selection_is_deterministic():
+    """signal_selection is pure in its inputs — the caching in dplms_ge_dict
+    relies on this."""
+    rng = np.random.default_rng(7)
+    n_events, size = 200, 762
+
+    class FakeCol:
+        def __init__(self, nda):
+            self.nda = nda
+
+    peak_pos = np.zeros((n_events, 3))
+    peak_pos[:, 0] = rng.normal(size / 2, 3, n_events)
+    dsp_cal = {
+        "peak_pos": FakeCol(peak_pos),
+        "peak_pos_neg": FakeCol(np.zeros((n_events, 3))),
+        "centroid": FakeCol(rng.normal(size / 2, 5, n_events)),
+        "tp_90": FakeCol(rng.uniform(500, 900, n_events)),
+        "tp_10": FakeCol(rng.uniform(100, 400, n_events)),
+    }
+    dplms_dict = {
+        "rt_low": 96,
+        "peak_lim": 30,
+        "wsize": size,
+        "bsize": 1024,
+        "centroid_lim": 20,
+        "dp_def": {"rt": 99, "pt": 0.1},
+    }
+
+    first = signal_selection(dsp_cal, dplms_dict, {})
+    second = signal_selection(dsp_cal, dplms_dict, {"nm": 1, "za": 0})
+
+    assert np.array_equal(first["idxs"], second["idxs"])
+    for key in ("ct_ll", "ct_hh", "pp_ll", "pp_hh", "rt_ll", "rt_hh"):
+        assert first[key] == second[key]


### PR DESCRIPTION
Stacked on #704 (based on `perf-sumdists-dispatch` so the diff shows only the DPLMS changes).

## Changes

- **Cache `signal_selection` + `signal_matrices` per `(rt, pt)`**: both depend only on the risetime-percentile and pile-up-threshold coefficients, so grids that only vary `nm`/`za`/`pl`/`ft` (the L200 production grid: 12 points with `rt`/`pt` single-valued) compute the selection cuts and signal-shape matrices once instead of at every grid point. Bit-identical — `signal_selection` purity is pinned by a test. The post-loop best-case synthesis reuses the same cache.
- **Vectorize `is_not_pile_up`**: the per-event Python loop (one pass over all cal events per grid point) becomes array operations with exactly the same conditions, including the original `&`-over-`|` operator precedence; equality against a verbatim copy of the old loop is tested. Now returns a boolean array instead of a list.
- **`use_log_pdf` passthrough**: optional `dplms_dict` key (default off) forwarded to `fom_fwhm_with_alpha_fit`, so the grid FOM fits — the dominant per-grid-point cost — can use the log-density NLL mode from #704 (~1.7× on the fits).

## Tests

`tests/pargen/test_dplms.py`: loop-vs-vectorized equality for `is_not_pile_up` on synthetic zero-padded peak arrays (with both selected and rejected events), and `signal_selection` determinism (what the caching relies on). Full `tests/math` + `tests/pargen` suites pass (211).

Disclosure per `AI_POLICY.md`: developed with AI assistance (Claude) and reviewed by the submitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)