### PR TITLE
perf(pargen): opt-in use_log_pdf mode for A/E and survival-fraction fits

### DIFF
--- a/src/pygama/pargen/AoE_cal.py
+++ b/src/pygama/pargen/AoE_cal.py
@@ -352,6 +352,7 @@ def unbinned_aoe_fit(
     aoe: np.array,
     pdf=aoe_peak,
     display: int = 0,
+    use_log_pdf: bool = False,
 ) -> tuple(np.array, np.array):
     """
     Fitting function for A/E, first fits just a Gaussian before using the full pdf to fit
@@ -365,6 +366,12 @@ def unbinned_aoe_fit(
         PDF to fit to.
     display
         Verbosity level; 0 = silent, >1 = diagnostic plots.
+    use_log_pdf
+        Build the full-pdf extended unbinned NLL from the model's
+        ``log_pdf_ext`` (``iminuit`` ``log=True`` mode) — faster on large
+        samples, results differ at machine-precision level.  Ignored when
+        *pdf* has no ``log_pdf_ext``; the Gaussian/exgauss prefits (a
+        negligible share of the fit time) always use the standard mode.
 
     Returns
     -------
@@ -478,7 +485,12 @@ def unbinned_aoe_fit(
     )
 
     # Full fit using Gaussian signal with Gaussian tail background
-    c = cost.ExtendedUnbinnedNLL(aoe[(aoe < fmax) & (aoe > fmin)], pdf.pdf_ext)
+    if use_log_pdf and hasattr(pdf, "log_pdf_ext"):
+        c = cost.ExtendedUnbinnedNLL(
+            aoe[(aoe < fmax) & (aoe > fmin)], pdf.log_pdf_ext, log=True
+        )
+    else:
+        c = cost.ExtendedUnbinnedNLL(aoe[(aoe < fmax) & (aoe > fmin)], pdf.pdf_ext)
     m = Minuit(c, *x0)
     for arg, val in bounds.items():
         m.limits[arg] = val
@@ -753,6 +765,7 @@ def bimodal_dt_fit(
     pdf,
     debug_mode: bool = False,
     display: int = 0,
+    use_log_pdf: bool = False,
     **_kwargs,
 ) -> tuple[float, dict]:
     """
@@ -861,7 +874,10 @@ def bimodal_dt_fit(
             )
 
             aoe_pars, aoe_errs, _, _ = unbinned_aoe_fit(
-                final_df.query(aoe_grp1)[aoe_param], pdf=pdf, display=display
+                final_df.query(aoe_grp1)[aoe_param],
+                pdf=pdf,
+                display=display,
+                use_log_pdf=use_log_pdf,
             )
             dt_res_dict["aoe_fit1"] = {
                 "pars": aoe_pars.to_dict(),
@@ -869,7 +885,10 @@ def bimodal_dt_fit(
             }
 
             aoe_pars2, aoe_errs2, _, _ = unbinned_aoe_fit(
-                final_df.query(aoe_grp2)[aoe_param], pdf=pdf, display=display
+                final_df.query(aoe_grp2)[aoe_param],
+                pdf=pdf,
+                display=display,
+                use_log_pdf=use_log_pdf,
             )
             dt_res_dict["aoe_fit2"] = {
                 "pars": aoe_pars2.to_dict(),
@@ -1055,6 +1074,7 @@ class CalAoE:
         sigma_func: Callable = SigmaFit,
         compt_bands_width: float = 20,
         debug_mode: bool = False,
+        use_log_pdf: bool = False,
     ):
         """
         Parameters
@@ -1095,6 +1115,11 @@ class CalAoE:
             Width of the Compton bands in keV used for the energy correction.
         debug_mode
             If ``True``, re-raise exceptions from the A/E calibration steps instead of returning NaN.
+        use_log_pdf
+            Build the unbinned fits (A/E peak fits and survival-fraction
+            energy fits) from the models' log-densities (``iminuit``
+            ``log=True`` mode) — faster on large samples, results differ at
+            machine-precision level.
 
         """
         self.cal_dicts = cal_dicts if cal_dicts is not None else {}
@@ -1119,6 +1144,7 @@ class CalAoE:
         self.sigma_func = sigma_func
         self.compt_bands_width = compt_bands_width
         self.debug_mode = debug_mode
+        self.use_log_pdf = use_log_pdf
 
     def update_cal_dicts(self, update_dict):
         """
@@ -1195,6 +1221,7 @@ class CalAoE:
                             )[aoe_param],
                             pdf=self.pdf,
                             display=display,
+                            use_log_pdf=self.use_log_pdf,
                         )
                         self.timecorr_df = pd.concat(
                             [
@@ -1380,6 +1407,7 @@ class CalAoE:
                         )[aoe_param],
                         pdf=self.pdf,
                         display=display,
+                        use_log_pdf=self.use_log_pdf,
                     )
                     self.timecorr_df = pd.concat(
                         [
@@ -1513,6 +1541,7 @@ class CalAoE:
             pdf=self.pdf,
             debug_mode=self.debug_mode,
             display=display,
+            use_log_pdf=self.use_log_pdf,
         )
 
         data[out_param] = data[aoe_param] * (1 + self.alpha * data[self.dt_param])
@@ -1600,6 +1629,7 @@ class CalAoE:
                         )[aoe_param],
                         pdf=self.pdf,
                         display=display,
+                        use_log_pdf=self.use_log_pdf,
                     )
 
                     mean, mean_err = self.pdf.get_mu(pars, cov)
@@ -1744,6 +1774,7 @@ class CalAoE:
                     )[aoe_param],
                     pdf=self.pdf,
                     display=display,
+                    use_log_pdf=self.use_log_pdf,
                 )
             except Exception as e:
                 if self.debug_mode:
@@ -1884,6 +1915,7 @@ class CalAoE:
                 n_samples=40,
                 mode="greater",
                 debug_mode=self.debug_mode,
+                use_log_pdf=self.use_log_pdf,
             )
 
             valid_fits = self.cut_fits.query(
@@ -2028,6 +2060,7 @@ class CalAoE:
                             else None
                         ),
                         debug_mode=self.debug_mode,
+                        use_log_pdf=self.use_log_pdf,
                     )
 
                     cut_df = cut_df.query(
@@ -2136,6 +2169,7 @@ class CalAoE:
                             if self.dt_cut_param is not None
                             else None
                         ),
+                        use_log_pdf=self.use_log_pdf,
                     )
                     sfs = pd.concat(
                         [

--- a/src/pygama/pargen/lq_cal.py
+++ b/src/pygama/pargen/lq_cal.py
@@ -325,6 +325,7 @@ class LQCal:
         cdf: callable = gaussian,
         selection_string: str = "is_valid_cal&is_not_pulser",
         debug_mode=False,
+        use_log_pdf: bool = False,
     ):
         """
         Parameters
@@ -346,6 +347,11 @@ class LQCal:
         debug_mode
             If ``True``, exceptions are re-raised instead of being caught
             and logged.
+        use_log_pdf
+            Build the survival-fraction unbinned NLL fits from the models'
+            log-densities (``iminuit`` ``log=True`` mode) — faster on large
+            samples, results differ at machine-precision level.  The LQ
+            calibration's own fits are binned and unaffected.
         """
 
         self.cal_dicts = cal_dicts
@@ -355,6 +361,7 @@ class LQCal:
         self.cdf = cdf
         self.selection_string = selection_string
         self.debug_mode = debug_mode
+        self.use_log_pdf = use_log_pdf
 
     def update_cal_dicts(self, update_dict):
         """
@@ -788,6 +795,7 @@ class LQCal:
                         cut_range=(0, 5),
                         n_samples=30,
                         mode="less",
+                        use_log_pdf=self.use_log_pdf,
                     )
                     self.low_side_sf = pd.concat(
                         [

--- a/src/pygama/pargen/survival_fractions.py
+++ b/src/pygama/pargen/survival_fractions.py
@@ -408,6 +408,115 @@ def fail_pdf_hpge(
     )
 
 
+def log_pass_pdf_gos(
+    x,
+    x_lo,
+    x_hi,
+    n_sig,
+    epsilon_sig,
+    n_bkg,
+    epsilon_bkg,
+    mu,
+    sigma,
+    hstep1,
+    hstep2,  # noqa: ARG001
+):
+    """Log-density counterpart of :func:`pass_pdf_gos` for ``iminuit``'s
+    ``log=True`` mode; same explicit signature (``iminuit`` introspects it)."""
+    return gauss_on_step.log_pdf_ext(
+        x, x_lo, x_hi, n_sig * epsilon_sig, mu, sigma, n_bkg * epsilon_bkg, hstep1
+    )
+
+
+def log_fail_pdf_gos(
+    x,
+    x_lo,
+    x_hi,
+    n_sig,
+    epsilon_sig,
+    n_bkg,
+    epsilon_bkg,
+    mu,
+    sigma,
+    hstep1,  # noqa: ARG001
+    hstep2,
+):
+    """Log-density counterpart of :func:`fail_pdf_gos` for ``iminuit``'s
+    ``log=True`` mode; same explicit signature (``iminuit`` introspects it)."""
+    return gauss_on_step.log_pdf_ext(
+        x,
+        x_lo,
+        x_hi,
+        n_sig * (1 - epsilon_sig),
+        mu,
+        sigma,
+        n_bkg * (1 - epsilon_bkg),
+        hstep2,
+    )
+
+
+def log_pass_pdf_hpge(
+    x,
+    x_lo,
+    x_hi,
+    n_sig,
+    epsilon_sig,
+    n_bkg,
+    epsilon_bkg,
+    mu,
+    sigma,
+    htail,
+    tau,
+    hstep1,
+    hstep2,  # noqa: ARG001
+):
+    """Log-density counterpart of :func:`pass_pdf_hpge` for ``iminuit``'s
+    ``log=True`` mode; same explicit signature (``iminuit`` introspects it)."""
+    return hpge_peak.log_pdf_ext(
+        x,
+        x_lo,
+        x_hi,
+        n_sig * epsilon_sig,
+        mu,
+        sigma,
+        htail,
+        tau,
+        n_bkg * epsilon_bkg,
+        hstep1,
+    )
+
+
+def log_fail_pdf_hpge(
+    x,
+    x_lo,
+    x_hi,
+    n_sig,
+    epsilon_sig,
+    n_bkg,
+    epsilon_bkg,
+    mu,
+    sigma,
+    htail,
+    tau,
+    hstep1,  # noqa: ARG001
+    hstep2,
+):
+    """Log-density counterpart of :func:`fail_pdf_hpge` for ``iminuit``'s
+    ``log=True`` mode; same explicit signature (``iminuit`` introspects it)."""
+    return hpge_peak.log_pdf_ext(
+        x,
+        x_lo,
+        x_hi,
+        n_sig * (1 - epsilon_sig),
+        mu,
+        sigma,
+        htail,
+        tau,
+        n_bkg * (1 - epsilon_bkg),
+        hstep2,
+    )
+
+
 def update_guess(func, parguess, energies):
     """
     Update the signal and background event-count guesses from data.
@@ -475,11 +584,15 @@ def get_survival_fraction(
     mode: str = "greater",
     func=hpge_peak,
     fix_step=True,
+    use_log_pdf=False,
     display=0,
 ):
     """
     Function for calculating the survival fraction of a cut
     using a fit to the surviving and failing energy distributions.
+    When *use_log_pdf* is true the unbinned NLL costs are built from the
+    models' log-densities (``iminuit`` ``log=True`` mode) — faster on large
+    samples, results differ at machine-precision level.
 
     Parameters
     ----------
@@ -569,6 +682,7 @@ def get_survival_fraction(
             bounds_func=get_bounds,
             guess_kwargs={"peak": peak, "eres": eres_pars},
             fit_range=fit_range,
+            use_log_pdf=use_log_pdf,
         )
 
     guess_pars_surv = copy.deepcopy(pars)
@@ -604,13 +718,27 @@ def get_survival_fraction(
         parguess.update({"htail": pars["htail"], "tau": pars["tau"]})
 
     if func == hpge_peak:
+        pass_pdf, fail_pdf = (
+            (log_pass_pdf_hpge, log_fail_pdf_hpge)
+            if use_log_pdf
+            else (pass_pdf_hpge, fail_pdf_hpge)
+        )
         lh = cost.ExtendedUnbinnedNLL(
-            energy[(~nan_idxs) & (pass_idxs)], pass_pdf_hpge
-        ) + cost.ExtendedUnbinnedNLL(energy[(~nan_idxs) & (fail_idxs)], fail_pdf_hpge)
+            energy[(~nan_idxs) & (pass_idxs)], pass_pdf, log=use_log_pdf
+        ) + cost.ExtendedUnbinnedNLL(
+            energy[(~nan_idxs) & (fail_idxs)], fail_pdf, log=use_log_pdf
+        )
     elif func == gauss_on_step:
+        pass_pdf, fail_pdf = (
+            (log_pass_pdf_gos, log_fail_pdf_gos)
+            if use_log_pdf
+            else (pass_pdf_gos, fail_pdf_gos)
+        )
         lh = cost.ExtendedUnbinnedNLL(
-            energy[(~nan_idxs) & (pass_idxs)], pass_pdf_gos
-        ) + cost.ExtendedUnbinnedNLL(energy[(~nan_idxs) & (fail_idxs)], fail_pdf_gos)
+            energy[(~nan_idxs) & (pass_idxs)], pass_pdf, log=use_log_pdf
+        ) + cost.ExtendedUnbinnedNLL(
+            energy[(~nan_idxs) & (fail_idxs)], fail_pdf, log=use_log_pdf
+        )
 
     else:
         msg = (
@@ -667,10 +795,13 @@ def get_sf_sweep(
     mode="greater",
     fit_range=None,
     debug_mode=False,
+    use_log_pdf=False,
 ) -> tuple[pd.DataFrame, float, float]:
     """
     Function sweeping through cut values and calculating the survival fraction for each value
     using a fit to the surviving and failing enegry distributions.
+    When *use_log_pdf* is true the unbinned NLL costs are built from the
+    models' log-densities (``iminuit`` ``log=True`` mode).
 
     Parameters
     ----------
@@ -730,6 +861,7 @@ def get_sf_sweep(
         bounds_func=get_bounds,
         guess_kwargs={"peak": peak, "eres": eres_pars},
         fit_range=fit_range,
+        use_log_pdf=use_log_pdf,
     )
 
     for cut_val in cut_vals:
@@ -745,6 +877,7 @@ def get_sf_sweep(
                 mode=mode,
                 pars=pars,
                 func=func,
+                use_log_pdf=use_log_pdf,
             )
             out_df = pd.concat(
                 [out_df, pd.DataFrame([{"cut_val": cut_val, "sf": sf, "sf_err": err}])]
@@ -771,6 +904,7 @@ def get_sf_sweep(
             mode=mode,
             pars=pars,
             func=func,
+            use_log_pdf=use_log_pdf,
         )
     else:
         sf = None

--- a/src/pygama/pargen/survival_fractions.py
+++ b/src/pygama/pargen/survival_fractions.py
@@ -584,8 +584,8 @@ def get_survival_fraction(
     mode: str = "greater",
     func=hpge_peak,
     fix_step=True,
-    use_log_pdf=False,
     display=0,
+    use_log_pdf=False,
 ):
     """
     Function for calculating the survival fraction of a cut
@@ -799,7 +799,7 @@ def get_sf_sweep(
 ) -> tuple[pd.DataFrame, float, float]:
     """
     Function sweeping through cut values and calculating the survival fraction for each value
-    using a fit to the surviving and failing enegry distributions.
+    using a fit to the surviving and failing energy distributions.
     When *use_log_pdf* is true the unbinned NLL costs are built from the
     models' log-densities (``iminuit`` ``log=True`` mode).
 

--- a/tests/pargen/test_aoe_log_mode.py
+++ b/tests/pargen/test_aoe_log_mode.py
@@ -7,15 +7,14 @@ import numpy as np
 from pygama.pargen.AoE_cal import unbinned_aoe_fit
 from pygama.pargen.survival_fractions import get_survival_fraction
 
-RNG = np.random.default_rng(2718)
-
 
 def test_unbinned_aoe_fit_log_mode_agrees():
+    rng = np.random.default_rng(2718)
     n = 20000
     aoe = np.concatenate(
         [
-            RNG.normal(0.0, 0.01, int(n * 0.9)),
-            -RNG.exponential(0.03, int(n * 0.1)),
+            rng.normal(0.0, 0.01, int(n * 0.9)),
+            -rng.exponential(0.03, int(n * 0.1)),
         ]
     )
 
@@ -41,19 +40,20 @@ def test_unbinned_aoe_fit_log_mode_agrees():
 
 
 def test_get_survival_fraction_log_mode_agrees():
+    rng = np.random.default_rng(31415)
     n_sig, n_bkg = 5000, 1000
     mu, sigma = 1592.5, 1.2
     energy = np.concatenate(
         [
-            RNG.normal(mu, sigma, n_sig),
-            RNG.uniform(mu - 30, mu + 30, n_bkg),
+            rng.normal(mu, sigma, n_sig),
+            rng.uniform(mu - 30, mu + 30, n_bkg),
         ]
     )
     # cut parameter correlated with nothing: signal survives ~90%, bkg ~50%
     cut_param = np.concatenate(
         [
-            RNG.normal(2.0, 1.0, n_sig),
-            RNG.normal(0.0, 1.0, n_bkg),
+            rng.normal(2.0, 1.0, n_sig),
+            rng.normal(0.0, 1.0, n_bkg),
         ]
     )
 

--- a/tests/pargen/test_aoe_log_mode.py
+++ b/tests/pargen/test_aoe_log_mode.py
@@ -1,0 +1,76 @@
+"""Tests for the ``use_log_pdf`` mode of the A/E and survival-fraction fits."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from pygama.pargen.AoE_cal import unbinned_aoe_fit
+from pygama.pargen.survival_fractions import get_survival_fraction
+
+RNG = np.random.default_rng(2718)
+
+
+def test_unbinned_aoe_fit_log_mode_agrees():
+    n = 20000
+    aoe = np.concatenate(
+        [
+            RNG.normal(0.0, 0.01, int(n * 0.9)),
+            -RNG.exponential(0.03, int(n * 0.1)),
+        ]
+    )
+
+    res = {}
+    for use_log in (False, True):
+        pars, errs, _cov, (_, _, _, _, _, _, valid, _m) = unbinned_aoe_fit(
+            aoe, use_log_pdf=use_log
+        )
+        assert valid
+        res[use_log] = (np.array(pars), np.array(errs))
+
+    pars_std, errs_std = res[False]
+    pars_log, errs_log = res[True]
+    # mu / sigma are the physically used outputs
+    names = ["x_lo", "x_hi", "n_sig", "mu", "sigma", "n_bkg", "tau"]
+    mu_i, sigma_i = names.index("mu"), names.index("sigma")
+    # mu sits near zero for normalised A/E, so measure its shift in units of
+    # the peak width rather than relative to itself
+    assert abs(pars_log[mu_i] - pars_std[mu_i]) < 1e-4 * pars_std[sigma_i]
+    assert np.isclose(pars_log[sigma_i], pars_std[sigma_i], rtol=1e-4)
+    assert np.allclose(pars_log, pars_std, rtol=5e-3, atol=1e-12)
+    assert np.allclose(errs_log, errs_std, rtol=5e-2, atol=1e-12)
+
+
+def test_get_survival_fraction_log_mode_agrees():
+    n_sig, n_bkg = 5000, 1000
+    mu, sigma = 1592.5, 1.2
+    energy = np.concatenate(
+        [
+            RNG.normal(mu, sigma, n_sig),
+            RNG.uniform(mu - 30, mu + 30, n_bkg),
+        ]
+    )
+    # cut parameter correlated with nothing: signal survives ~90%, bkg ~50%
+    cut_param = np.concatenate(
+        [
+            RNG.normal(2.0, 1.0, n_sig),
+            RNG.normal(0.0, 1.0, n_bkg),
+        ]
+    )
+
+    res = {}
+    for use_log in (False, True):
+        sf, sf_err, _, _ = get_survival_fraction(
+            energy,
+            cut_param,
+            0.0,
+            mu,
+            2.355 * sigma,
+            fit_range=(mu - 30, mu + 30),
+            mode="greater",
+            use_log_pdf=use_log,
+        )
+        assert np.isfinite(sf)
+        res[use_log] = (sf, sf_err)
+
+    assert np.isclose(res[True][0], res[False][0], rtol=1e-3)
+    assert np.isclose(res[True][1], res[False][1], rtol=5e-2)


### PR DESCRIPTION
Stacked on #704 (based on `perf-sumdists-dispatch` so the diff shows only the A/E changes — retarget after #704 merges).

Extends the opt-in `use_log_pdf` log-density NLL mode from #704 to the A/E calibration and the survival-fraction machinery.

## Changes

- **`unbinned_aoe_fit(..., use_log_pdf=False)`**: the full-pdf extended unbinned NLL is built from the model's `log_pdf_ext` with iminuit's `log=True` mode (both fit attempts share the one cost object). The gaussian/exgauss prefits stay in standard mode — profiling shows they are ~1% of the fit time (the full `aoe_peak` fit is 32% pdf + 65% iminuit sorted-log), and their `PygamaContinuous.pdf_ext` has no log counterpart.
- **`CalAoE(..., use_log_pdf=False)`**: forwarded to all six `unbinned_aoe_fit` call sites (time-slice fits, `bimodal_dt_fit` drift-time correction, compton-band energy correction, DEP fit) and to the survival-fraction calls.
- **`survival_fractions`**: `get_survival_fraction` / `get_sf_sweep` gain `use_log_pdf`, passed to their staged energy fits (param from #704); the joint pass/fail efficiency likelihoods — run **once per cut value** in the sweeps — get log-density counterparts of the four custom pdfs (`log_pass_pdf_hpge` etc.) with the same explicit signatures iminuit introspects. `compton_sf` is pure counting and unaffected.
- **`LQCal(..., use_log_pdf=False)`**: forwarded to its `get_sf_sweep` calls (LQ's own fits are binned and unchanged).

## Benchmarks (real LEGEND p16 skim fixture, full console scripts)

| script | off | on | speedup |
|---|---|---|---|
| `par-geds-hit-aoe` | 22.0 s | 15.2 s | **1.45×** |
| `par-geds-hit-lq` | 11.3 s | 6.0 s | **1.88×** |

Result agreement: lq results agree to <10⁻⁶ (one `sf_err` at 5×10⁻⁶); aoe fitted quantities agree at machine precision, but the derived low-side cut — `round()` of a grid-crossing of the fitted sigmoid — moved one 0.01 step on this low-statistics 2-channel sample, shifting the DEP survival fraction by 0.2 pp. That amplification at the cut boundary is exactly why the flag defaults to off and needs physics validation before production use.

## Tests

`tests/pargen/test_aoe_log_mode.py`: standard-vs-log agreement for `unbinned_aoe_fit` on a synthetic A/E sample (mu shift measured in units of sigma since mu≈0; sigma to 1e-4) and for `get_survival_fraction` on a synthetic peak with a pass/fail split (sf to 1e-3). Full `tests/math` + `tests/pargen`: 211 passed.

Disclosure per `AI_POLICY.md`: developed with AI assistance (Claude) and reviewed by the submitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)