### PR TITLE
pargen: suffix support in LQCal for calibrating multiple LQ parameters

### DIFF
--- a/src/pygama/pargen/lq_cal.py
+++ b/src/pygama/pargen/lq_cal.py
@@ -565,7 +565,7 @@ class LQCal:
 
     def drift_time_correction(
         self,
-        df: pd.DataFrame(),
+        df: pd.DataFrame,
         lq_param,
         cal_energy_param: str,  # noqa: ARG002
         display: int = 0,  # noqa: ARG002
@@ -648,7 +648,7 @@ class LQCal:
 
     def get_cut_lq_dep(
         self,
-        df: pd.DataFrame(),
+        df: pd.DataFrame,
         lq_param: str,
         cal_energy_param: str,
         classifier_param: str = "LQ_Classifier",

--- a/src/pygama/pargen/lq_cal.py
+++ b/src/pygama/pargen/lq_cal.py
@@ -569,13 +569,14 @@ class LQCal:
         lq_param,
         cal_energy_param: str,  # noqa: ARG002
         display: int = 0,  # noqa: ARG002
+        out_param: str = "LQ_Corrected",
     ):
         """
         Remove the linear drift-time dependence from the LQ distribution.
 
         Fits a degree-1 polynomial to LQ vs. drift time for DEP events in
         a 6 keV window around 1592.5 keV.  Subtracts the fitted slope and
-        intercept to produce a corrected ``LQ_Corrected`` column centred at
+        intercept to produce a corrected column (*out_param*) centred at
         zero, and writes the calibration expression into :attr:`cal_dicts`.
 
         Parameters
@@ -589,6 +590,8 @@ class LQCal:
             Name of the calibrated energy column.
         display
             Verbosity level (currently unused).
+        out_param
+            Name of the output drift-time-corrected LQ column.
         """
 
         log.info("Starting LQ drift time correction")
@@ -622,7 +625,7 @@ class LQCal:
             )
             self.dt_fit_pars = result
 
-            df["LQ_Corrected"] = (
+            df[out_param] = (
                 df[lq_param]
                 - df[self.dt_param] * self.dt_fit_pars[0]
                 - self.dt_fit_pars[1]
@@ -636,21 +639,28 @@ class LQCal:
 
         self.update_cal_dicts(
             {
-                "LQ_Corrected": {
-                    "expression": f"{lq_param} - dt_eff*a - b",
+                out_param: {
+                    "expression": f"{lq_param} - {self.dt_param}*a - b",
                     "parameters": {"a": self.dt_fit_pars[0], "b": self.dt_fit_pars[1]},
                 }
             }
         )
 
-    def get_cut_lq_dep(self, df: pd.DataFrame(), lq_param: str, cal_energy_param: str):
+    def get_cut_lq_dep(
+        self,
+        df: pd.DataFrame(),
+        lq_param: str,
+        cal_energy_param: str,
+        classifier_param: str = "LQ_Classifier",
+        cut_param: str = "LQ_Cut",
+    ):
         """
         Determine the LQ cut value from the DEP distribution.
 
         Fits a Gaussian to the sideband-subtracted LQ distribution at the
         DEP (1592.5 keV).  The LQ values are normalised by the fitted σ to
-        produce ``LQ_Classifier``, and a fixed cut at 3 σ is applied
-        (``LQ_Cut``).  Both columns are added to *df* and the corresponding
+        produce *classifier_param*, and a fixed cut at 3 σ is applied
+        (*cut_param*).  Both columns are added to *df* and the corresponding
         calibration expressions are written into :attr:`cal_dicts`.
 
         Parameters
@@ -662,6 +672,10 @@ class LQCal:
             Name of the (drift-time-corrected) LQ parameter column.
         cal_energy_param
             Name of the calibrated energy column.
+        classifier_param
+            Name of the output normalised LQ classifier column.
+        cut_param
+            Name of the output boolean cut column.
         """  # noqa: RUF002
 
         log.info("Starting LQ Cut calculation")
@@ -675,8 +689,8 @@ class LQCal:
             self.fit_hist = (hist, bins)
             self.cut_val = 3
 
-            df["LQ_Classifier"] = np.divide(df[lq_param].to_numpy(), pars[1])
-            df["LQ_Cut"] = df["LQ_Classifier"] < self.cut_val
+            df[classifier_param] = np.divide(df[lq_param].to_numpy(), pars[1])
+            df[cut_param] = df[classifier_param] < self.cut_val
 
         except Exception as e:
             if self.debug_mode:
@@ -689,18 +703,18 @@ class LQCal:
 
         self.update_cal_dicts(
             {
-                "LQ_Classifier": {
+                classifier_param: {
                     "expression": f"({lq_param} / a)",
                     "parameters": {"a": pars[1]},
                 },
-                "LQ_Cut": {
-                    "expression": "(LQ_Classifier < a)",
+                cut_param: {
+                    "expression": f"({classifier_param} < a)",
                     "parameters": {"a": self.cut_val},
                 },
             }
         )
 
-    def calibrate(self, df, initial_lq_param):
+    def calibrate(self, df, initial_lq_param, suffix: str | None = None):
         """
         Run the full LQ calibration pipeline.
 
@@ -724,22 +738,41 @@ class LQCal:
             :attr:`dt_param`, and :attr:`selection_string`.
         initial_lq_param
             Name of the raw LQ parameter column in *df*.
+        suffix
+            Optional suffix appended to all output parameter names, separated
+            by an underscore (e.g. ``suffix="foo"`` produces
+            ``"LQ_Timecorr_foo"``, ``"LQ_Classifier_foo"``, etc.).  When
+            ``None`` (the default) the original names are used unchanged.
         """
 
-        self.lq_timecorr(df, initial_lq_param)
+        _n = (lambda base: f"{base}_{suffix}") if suffix else (lambda base: base)
+
+        timecorr_name = _n("LQ_Timecorr")
+        corrected_name = _n("LQ_Corrected")
+        classifier_name = _n("LQ_Classifier")
+        cut_name = _n("LQ_Cut")
+
+        self.lq_timecorr(df, initial_lq_param, output_name=timecorr_name)
         log.info("Finished LQ Time Correction")
 
         self.drift_time_correction(
-            df, lq_param="LQ_Timecorr", cal_energy_param=self.cal_energy_param
+            df,
+            lq_param=timecorr_name,
+            cal_energy_param=self.cal_energy_param,
+            out_param=corrected_name,
         )
         log.info("Finished LQ Drift Time Correction")
 
         self.get_cut_lq_dep(
-            df, lq_param="LQ_Corrected", cal_energy_param=self.cal_energy_param
+            df,
+            lq_param=corrected_name,
+            cal_energy_param=self.cal_energy_param,
+            classifier_param=classifier_name,
+            cut_param=cut_name,
         )
         log.info("Finished Calculating the LQ Cut Value")
 
-        final_lq_param = "LQ_Classifier"
+        final_lq_param = classifier_name
         peaks_of_interest = [1592.5, 2039, 2103.53, 2614.50]
         self.low_side_sf = pd.DataFrame()
         fit_widths = [(40, 25), (0, 0), (25, 40), (50, 50)]

--- a/tests/pargen/test_lqcal.py
+++ b/tests/pargen/test_lqcal.py
@@ -45,3 +45,44 @@ def test_lq_cal(lgnd_test_data):
     assert (~np.isnan(lqcal.low_side_sf.loc[1592.50]["sf"])) & (
         lqcal.low_side_sf.loc[1592.50]["sf"] > 95
     )
+
+
+def test_lq_cal_suffix(lgnd_test_data):
+    # calibrating with a suffix must produce the suffixed output columns and
+    # calibration expressions, leaving the unsuffixed names untouched
+    data = lgnd_test_data.get_path(
+        "lh5/prod-ref-l200/generated/tier/dsp/cal/p03/r000/l200-p03-r000-cal-20230311T235840Z-tier_dsp.lh5"
+    )
+
+    data_df = lh5.read_as("ch1104000/dsp", data, "pd")
+
+    data_df["cuspEmax_cal"] = data_df["cuspEmax"] * 0.155
+
+    cal_dict = {
+        "LQ_Ecorr_alt": {
+            "expression": "lq80/cuspEmax",
+            "parameters": {},
+        }
+    }
+
+    lqcal = lq.LQCal(
+        cal_dict,
+        "cuspEmax_cal",
+        "dt_eff",
+        lambda x: np.sqrt(1.5 + 0.1 * x),
+        selection_string="index==index",
+        cdf=gaussian,
+        debug_mode=True,
+    )
+
+    data_df["LQ_Ecorr_alt"] = np.divide(data_df["lq80"], data_df["cuspEmax"])
+
+    lqcal.calibrate(data_df, "LQ_Ecorr_alt", suffix="alt")
+    assert (lqcal.cut_val > 0) & (~np.isnan(lqcal.cut_val))
+
+    for name in ("LQ_Timecorr", "LQ_Corrected", "LQ_Classifier", "LQ_Cut"):
+        assert f"{name}_alt" in cal_dict
+        assert name not in cal_dict
+    assert "LQ_Classifier_alt" in data_df
+    assert "LQ_Cut_alt" in data_df
+    assert cal_dict["LQ_Cut_alt"]["expression"] == "(LQ_Classifier_alt < a)"


### PR DESCRIPTION
## Summary

Adds a `suffix` argument to `LQCal.calibrate`, mirroring the `CalAoE` suffix support on the `aoe` branch: with `suffix="foo"` all output parameters become `LQ_Timecorr_foo`, `LQ_Corrected_foo`, `LQ_Classifier_foo`, `LQ_Cut_foo`, so several LQ parameters can be calibrated side by side without their hit-level operations colliding. `drift_time_correction` and `get_cut_lq_dep` gained output-name arguments to support this; behaviour without `suffix` is unchanged.

One deliberate behaviour fix: the drift-time cal-dict expression now uses `self.dt_param` instead of a hardcoded `dt_eff`, matching the in-memory computation (identical output for all production configs, which set `dt_param: dt_eff`).

Companion PRs in legend-dataflow-scripts / legend-dataflow consume this via a multi-parameter `params` config schema for the LQ calibration scripts.

## Test plan

- `tests/pargen/test_lqcal.py`: existing test unchanged and passing; new `test_lq_cal_suffix` asserts the suffixed columns/cal-dict expressions are produced and the unsuffixed names are untouched.
- Full hit-chain integration tests in legend-dataflow-scripts (skimmed real data, suffixed + unsuffixed entries) pass against this branch.

Per `AI_POLICY.md`: developed with AI assistance (Claude); reviewed by the submitter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)