### PR TITLE
perf(evt): cut build_evt's per-chunk overhead, and fix first_at/last_at losing values

### DIFF
--- a/src/pygama/evt/aggregators.py
+++ b/src/pygama/evt/aggregators.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 import awkward as ak
 import lh5
 import numpy as np
-import pandas as pd
 from lgdo import types
 
 from . import utils
@@ -61,78 +60,94 @@ def evaluate_to_first_or_last(
     if not isinstance(datainfo, utils.DataInfo):
         datainfo = utils.make_files_config(datainfo)
 
-    sort_df = None
+    # winning value per event, and the sorter value that won it. Both are
+    # indexed by event and assigned positionally: a channel's hits are numbered
+    # 0..n-1 while the events it fired in are arbitrary, and confusing the two
+    # silently drops values for any channel that does not fire in nearly every
+    # event.
+    out = None
+    best = None
 
     for ch in channels:
         table_id = utils.get_tcm_id_by_pattern(datainfo.hit.table_fmt, ch)
         if table_id is None:
             continue
 
+        if ch in channels_skip:
+            continue
+
         # get index list for this channel to be loaded
         _, idx_ch, evt_ids_ch = utils.channel_indices(tcm, table_id)
 
         # evaluate at channel
-        if ch not in channels_skip:
-            res = utils.get_data_at_channel(
-                datainfo=datainfo,
-                ch=ch,
-                tcm=tcm,
-                expr=expr,
-                field_list=field_list,
-                pars_dict=pars_dict,
-            )
+        res = utils.get_data_at_channel(
+            datainfo=datainfo,
+            ch=ch,
+            tcm=tcm,
+            expr=expr,
+            field_list=field_list,
+            pars_dict=pars_dict,
+        )
 
-            if sort_df is None:
-                # define dimension of output array
-                out = utils.make_numpy_full(n_rows, default_value, res.dtype)
-                sort_df = pd.DataFrame({"sort_field": np.zeros(len(out)), "res": out})
+        if out is None:
+            # define dimension of output array
+            out = utils.make_numpy_full(n_rows, default_value, res.dtype)
+            # nothing seen yet, so any real hit must win
+            best = np.full(n_rows, np.inf if is_first else -np.inf)
 
-            # get mask from query
-            limarr = utils.get_mask_from_query(
-                datainfo=datainfo,
-                query=query,
-                length=len(res),
-                ch=ch,
-                idx_ch=idx_ch,
-                cache=getattr(tcm, "cache", None),
-            )
+        # get mask from query
+        limarr = utils.get_mask_from_query(
+            datainfo=datainfo,
+            query=query,
+            length=len(res),
+            ch=ch,
+            idx_ch=idx_ch,
+            cache=getattr(tcm, "cache", None),
+        )
 
-            # find if sorter is in hit or dsp
-            sort_field = lh5.read_as(
-                f"{ch}/{sorter[0]}/{sorter[1]}",
-                (
-                    datainfo.hit.file
-                    if f"{datainfo.hit.group}" == sorter[0]
-                    else datainfo.dsp.file
-                ),
-                idx=idx_ch,
-                library="np",
-            )
+        # find if sorter is in hit or dsp
+        sort_field = lh5.read_as(
+            f"{ch}/{sorter[0]}/{sorter[1]}",
+            (
+                datainfo.hit.file
+                if f"{datainfo.hit.group}" == sorter[0]
+                else datainfo.dsp.file
+            ),
+            idx=idx_ch,
+            library="np",
+        )
 
-            if sort_field.ndim > 1:
-                msg = f"sorter '{sorter[0]}/{sorter[1]}' must be a 1D array"
-                raise ValueError(msg)
+        if sort_field.ndim > 1:
+            msg = f"sorter '{sorter[0]}/{sorter[1]}' must be a 1D array"
+            raise ValueError(msg)
 
-            ch_df = pd.DataFrame({"sort_field": sort_field, "res": res})
+        if is_first:
+            better = (sort_field < best[evt_ids_ch]) & limarr
+        else:
+            better = (sort_field > best[evt_ids_ch]) & limarr
 
-            if is_first:
-                if ch == channels[0]:
-                    sort_df["sort_field"] = np.inf
-                ids = (
-                    ch_df.sort_field.to_numpy()
-                    < sort_df.sort_field[evt_ids_ch].to_numpy()
-                ) & (limarr)
-            else:
-                ids = (
-                    ch_df.sort_field.to_numpy()
-                    > sort_df.sort_field[evt_ids_ch].to_numpy()
-                ) & (limarr)
+        sel = np.nonzero(better)[0]
+        if sel.size == 0:
+            continue
 
-            sort_df.loc[evt_ids_ch[ids], list(sort_df.columns)] = ch_df.loc[
-                ids, list(sort_df.columns)
-            ]
+        # a channel can have several hits in the same event, and fancy-index
+        # assignment keeps the last write: order the writes so the winning hit
+        # is the one that lands last
+        order = np.argsort(sort_field[sel], kind="stable")
+        sel = sel[order[::-1]] if is_first else sel[order]
 
-    return types.Array(nda=sort_df.res.to_numpy())
+        rows = evt_ids_ch[sel]
+        out[rows] = res[sel]
+        best[rows] = sort_field[sel]
+
+    if out is None:
+        msg = (
+            "no channel could be evaluated, so the output dtype is unknown "
+            f"(channels={list(channels)}, skipped={list(channels_skip)})"
+        )
+        raise ValueError(msg)
+
+    return types.Array(nda=out)
 
 
 def evaluate_to_scalar(

--- a/src/pygama/evt/aggregators.py
+++ b/src/pygama/evt/aggregators.py
@@ -69,8 +69,7 @@ def evaluate_to_first_or_last(
             continue
 
         # get index list for this channel to be loaded
-        chan_tcm_indexs = ak.flatten(tcm.table_key) == table_id
-        idx_ch = ak.flatten(tcm.row_in_table)[chan_tcm_indexs].to_numpy()
+        _, idx_ch, evt_ids_ch = utils.channel_indices(tcm, table_id)
 
         # evaluate at channel
         if ch not in channels_skip:
@@ -95,6 +94,7 @@ def evaluate_to_first_or_last(
                 length=len(res),
                 ch=ch,
                 idx_ch=idx_ch,
+                cache=getattr(tcm, "cache", None),
             )
 
             # find if sorter is in hit or dsp
@@ -114,11 +114,6 @@ def evaluate_to_first_or_last(
                 raise ValueError(msg)
 
             ch_df = pd.DataFrame({"sort_field": sort_field, "res": res})
-
-            evt_ids_ch = np.repeat(
-                np.arange(0, len(tcm.table_key)),
-                ak.sum(tcm.table_key == table_id, axis=1),
-            )
 
             if is_first:
                 if ch == channels[0]:
@@ -191,8 +186,7 @@ def evaluate_to_scalar(
             continue
 
         # get index list for this channel to be loaded
-        chan_tcm_indexs = ak.flatten(tcm.table_key) == table_id
-        idx_ch = ak.flatten(tcm.row_in_table)[chan_tcm_indexs].to_numpy()
+        _, idx_ch, evt_ids_ch = utils.channel_indices(tcm, table_id)
 
         if ch not in channels_skip:
             res = utils.get_data_at_channel(
@@ -215,11 +209,7 @@ def evaluate_to_scalar(
                 length=len(res),
                 ch=ch,
                 idx_ch=idx_ch,
-            )
-
-            evt_ids_ch = np.repeat(
-                np.arange(0, len(tcm.table_key)),
-                ak.sum(tcm.table_key == table_id, axis=1),
+                cache=getattr(tcm, "cache", None),
             )
 
             # switch through modes
@@ -283,19 +273,16 @@ def evaluate_at_channel(
 
     out = utils.make_numpy_full(len(ch_comp.nda), default_value, type(default_value))
 
+    hit_tables = utils.table_names(datainfo, "hit", getattr(tcm, "cache", None))
+
     for table_id in np.unique(ch_comp.nda.astype(int)):
         table_name = utils.get_table_name_by_pattern(table_id_fmt, table_id)
         # skip default value
-        if table_name not in lh5.ls(datainfo.hit.file):
+        if table_name not in hit_tables:
             continue
 
         # get index list for this channel to be loaded
-        chan_tcm_indexs = ak.flatten(tcm.table_key) == table_id
-        idx_ch = ak.flatten(tcm.row_in_table)[chan_tcm_indexs].to_numpy()
-
-        evt_ids_ch = np.repeat(
-            np.arange(0, len(tcm.table_key)), ak.sum(tcm.table_key == table_id, axis=1)
-        )
+        _, idx_ch, evt_ids_ch = utils.channel_indices(tcm, table_id)
 
         if (table_name in channels) and (table_name not in channels_skip):
             res = utils.get_data_at_channel(
@@ -362,9 +349,7 @@ def evaluate_at_channel_vov(
     type_name = None
     for table_id in ch_comp_channels:
         table_name = utils.get_table_name_by_pattern(datainfo.hit.table_fmt, table_id)
-        evt_ids_ch = np.repeat(
-            np.arange(0, len(tcm.table_key)), ak.sum(tcm.table_key == table_id, axis=1)
-        )
+        _, _, evt_ids_ch = utils.channel_indices(tcm, table_id)
         if (table_name in channels) and (table_name not in channels_skip):
             res = utils.get_data_at_channel(
                 datainfo=datainfo,
@@ -455,12 +440,7 @@ def evaluate_to_aoesa(
             continue
 
         # get index list for this channel to be loaded
-        chan_tcm_indexs = ak.flatten(tcm.table_key) == table_id
-        idx_ch = ak.flatten(tcm.row_in_table)[chan_tcm_indexs].to_numpy()
-
-        evt_ids_ch = np.repeat(
-            np.arange(0, len(tcm.table_key)), ak.sum(tcm.table_key == table_id, axis=1)
-        )
+        _, idx_ch, evt_ids_ch = utils.channel_indices(tcm, table_id)
 
         if ch not in channels_skip:
             res = utils.get_data_at_channel(
@@ -489,6 +469,7 @@ def evaluate_to_aoesa(
             length=len(res),
             ch=ch,
             idx_ch=idx_ch,
+            cache=getattr(tcm, "cache", None),
         )
 
         out[evt_ids_ch, i] = np.where(limarr, res, out[evt_ids_ch, i])

--- a/src/pygama/evt/build_evt.py
+++ b/src/pygama/evt/build_evt.py
@@ -4,6 +4,7 @@ This module implements routines to build the `evt` tier.
 
 from __future__ import annotations
 
+import contextlib
 import importlib
 import itertools
 import logging
@@ -13,6 +14,7 @@ from pathlib import Path
 from typing import Any
 
 import awkward as ak
+import h5py
 import lh5
 import numpy as np
 from lgdo import Array, ArrayOfEqualSizedArrays, Table, VectorOfVectors
@@ -277,13 +279,53 @@ def build_evt_cols(
     if not isinstance(datainfo, utils.DataInfo):
         datainfo = utils.make_files_config(datainfo)
 
-    evt_tables = []
     if (
         datainfo.evt.file is not None
         and wo_mode == "of"
         and Path(datainfo.evt.file).exists()
     ):
         Path(datainfo.evt.file).unlink()
+
+    # Take ownership of the input files for the whole run. Every lower-tier
+    # read otherwise reopens the file, and there is one such read per
+    # (chunk, operation, channel) -- hundreds of thousands of opens for a
+    # calibration file. lh5.ls/lh5.read accept an open handle directly.
+    stack = contextlib.ExitStack()
+    with stack:
+        datainfo = _open_input_tiers(datainfo, stack)
+        cache = utils.EvtCache()
+        return _build_evt_cols(
+            datainfo, config, channels, wo_mode, buffer_len, channel_mapping, cache
+        )
+
+
+def _open_input_tiers(datainfo, stack):
+    """Replace each per-channel input tier's path with an open HDF5 handle.
+
+    `evt` is the output, and `tcm` is streamed by :class:`lh5.LH5Iterator`,
+    which takes a path — both keep theirs.
+    """
+    opened = {}
+    for name, tier in datainfo._asdict().items():
+        if name in ("evt", "tcm") or tier.file is None:
+            continue
+        if isinstance(tier.file, h5py.Group):  # caller already opened it
+            continue
+        handle = stack.enter_context(h5py.File(str(tier.file), "r"))
+        opened[name] = tier._replace(file=handle)
+    return datainfo._replace(**opened) if opened else datainfo
+
+
+def _build_evt_cols(
+    datainfo,
+    config,
+    channels,
+    wo_mode,
+    buffer_len,
+    channel_mapping,
+    cache,
+) -> None | Table:
+    evt_tables = []
 
     # Pre-compute source attrs for single-field aggregation operations.
     # Done once here because attrs are file-level metadata, not per-chunk data.
@@ -314,9 +356,11 @@ def build_evt_cols(
         field_mask=["table_key", "row_in_table"],
     ):
         # load tcm data from disk
+        cache.new_chunk()
         tcm = utils.TCMData(
             table_key=tcm_lh5.table_key.view_as("ak"),
             row_in_table=tcm_lh5.row_in_table.view_as("ak"),
+            cache=cache,
         )
 
         # get number of events in file (ask the TCM)

--- a/src/pygama/evt/build_tcm.py
+++ b/src/pygama/evt/build_tcm.py
@@ -32,9 +32,10 @@ def readd_attrs(final_table, input_table):
 
 
 def _concat_tables(tbls):
-    out_tbl = tbls[0].view_as("ak")
-    for tbl in tbls[1:]:
-        out_tbl = ak.concatenate([out_tbl, tbl.view_as("ak")], axis=0)
+    # one concatenate over the whole list, not a pairwise fold: the latter
+    # recopies the accumulated result for every chunk, which is quadratic in
+    # the chunk count and doubles peak memory
+    out_tbl = ak.concatenate([tbl.view_as("ak") for tbl in tbls], axis=0)
     out_tbl = Table(col_dict=out_tbl)
     readd_attrs(out_tbl, tbls[0])
     return out_tbl

--- a/src/pygama/evt/utils.py
+++ b/src/pygama/evt/utils.py
@@ -169,10 +169,20 @@ def make_files_config(data: dict):
 
 
 def make_numpy_full(size, fill_value, try_dtype):
-    # turn fill_value into an array (or scalar) so we have a proper dtype
-    if np.can_cast(np.array(fill_value).dtype, try_dtype):
-        return np.full(size, fill_value, dtype=try_dtype)
-    return np.full(size, fill_value)
+    """Allocate an array of *size* filled with *fill_value*, typed to hold both.
+
+    *try_dtype* is the dtype of the data that will later be written into the
+    array, so the result must accommodate *fill_value* **and** *try_dtype*.
+    Promoting is essential rather than cosmetic: an integer ``initial`` value
+    against float32 data cannot be cast to float32, and falling back to the
+    fill value's own dtype would hand back an *integer* accumulator for float
+    data, so that ``out += res`` raises ``UFuncOutputCastingError``.
+
+    *fill_value* is passed through as a scalar, so NEP 50 weak promotion keeps
+    the data's dtype (``0`` with float32 data gives float32, not float64)
+    rather than widening every accumulator.
+    """
+    return np.full(size, fill_value, dtype=np.result_type(fill_value, try_dtype))
 
 
 def copy_lgdo_attrs(obj):

--- a/src/pygama/evt/utils.py
+++ b/src/pygama/evt/utils.py
@@ -19,7 +19,132 @@ H5DataLoc = namedtuple(
 )
 DataInfo = namedtuple("DataInfo", ("raw", "tcm", "evt"), defaults=3 * (None,))
 
-TCMData = namedtuple("TCMData", ("table_key", "row_in_table"))
+TCMData = namedtuple(
+    "TCMData", ("table_key", "row_in_table", "cache"), defaults=(None,)
+)
+
+
+class EvtCache:
+    """Memoises the work that :func:`build_evt_cols` would otherwise repeat.
+
+    An `evt` configuration evaluates many operations over the same channels,
+    and each operation is evaluated again for every TCM chunk. Without
+    memoisation the same HDF5 table is listed, the same lower-tier column is
+    read, and the same per-channel TCM index arrays are rebuilt once per
+    (chunk, operation, channel) — which is why calibration files, holding
+    ~200x more events than physics files and so ~100x more chunks, are so much
+    slower to process.
+
+    Three caches with two different lifetimes:
+
+    `fields`
+        which columns each ``(tier, channel)`` table holds. File-scoped: the
+        input files do not change between chunks.
+    `code`
+        compiled expression objects, keyed by expression string. File-scoped.
+    `cols`, `idx`
+        lower-tier column data and per-channel TCM indices. Chunk-scoped, and
+        must be dropped by :meth:`new_chunk` because both are tied to the rows
+        of the chunk currently being processed.
+    """
+
+    def __init__(self):
+        self.fields = {}
+        self.code = {}
+        self.cols = {}
+        self.idx = {}
+        self._n_hits = 0
+
+    def new_chunk(self) -> None:
+        """Drop everything tied to the previous chunk's rows."""
+        self.cols.clear()
+        self.idx.clear()
+        self._n_hits = 0
+
+    def table_fields(self, datainfo, tier_name: str, ch: str) -> frozenset:
+        """Names of the columns held by ``ch``'s table in tier `tier_name`."""
+        key = (tier_name, ch)
+        if key not in self.fields:
+            tier = datainfo._asdict()[tier_name]
+            self.fields[key] = frozenset(
+                k.split("/")[-1]
+                for k in lh5.ls(tier.file, f"{ch.replace('/', '')}/{tier.group}/")
+            )
+        return self.fields[key]
+
+    def table_names(self, datainfo, tier_name: str = "hit") -> frozenset:
+        """Names of the tables (channels) present in tier `tier_name`."""
+        key = (tier_name, None)
+        if key not in self.fields:
+            tier = datainfo._asdict()[tier_name]
+            self.fields[key] = frozenset(lh5.ls(tier.file))
+        return self.fields[key]
+
+    def compile(self, expr: str):
+        """Compile `expr` once and reuse the code object across channels."""
+        if expr not in self.code:
+            self.code[expr] = compile(expr, "<evt expression>", "eval")
+        return self.code[expr]
+
+    def channel_indices(self, tcm, table_id: int):
+        """``(chan_tcm_indexs, idx_ch, evt_ids_ch)`` for one channel.
+
+        Computed for every channel at once on first use, because the
+        per-channel form is a full jagged reduction over the chunk's TCM and
+        every aggregator needs it for every operation.
+        """
+        if not self.idx:
+            self._build_indices(tcm)
+        entry = self.idx.get(int(table_id))
+        if entry is None:
+            empty_mask = np.zeros(self._n_hits, dtype=bool)
+            empty = np.empty(0, dtype=np.int64)
+            return empty_mask, empty, empty
+        return entry
+
+    def _build_indices(self, tcm) -> None:
+        flat_key = ak.flatten(tcm.table_key).to_numpy()
+        flat_row = ak.flatten(tcm.row_in_table).to_numpy()
+        counts = ak.num(tcm.table_key, axis=1).to_numpy()
+        # event index of every hit, in flattened (event-major) order
+        evt_of_hit = np.repeat(np.arange(len(counts)), counts)
+        self._n_hits = len(flat_key)
+        for table_id in np.unique(flat_key):
+            mask = flat_key == table_id
+            self.idx[int(table_id)] = (mask, flat_row[mask], evt_of_hit[mask])
+
+
+def table_names(datainfo, tier_name="hit", cache=None) -> frozenset:
+    """Names of the tables (channels) present in tier `tier_name`.
+
+    Loop-invariant, so callers should hoist it out of per-channel loops; the
+    `cache` also keeps it to one listing per file.
+    """
+    if cache is not None:
+        return cache.table_names(datainfo, tier_name)
+    return frozenset(lh5.ls(datainfo._asdict()[tier_name].file))
+
+
+def channel_indices(tcm, table_id):
+    """Locate one channel's hits within the current TCM chunk.
+
+    Returns ``(chan_tcm_indexs, idx_ch, evt_ids_ch)``: the mask selecting this
+    channel's entries among the chunk's flattened hits, the rows to read from
+    the channel's lower-tier table, and the event each of those hits belongs
+    to. Served from ``tcm.cache`` when there is one — every aggregator needs
+    these for every operation, and recomputing them is a full jagged reduction
+    over the chunk.
+    """
+    cache = getattr(tcm, "cache", None)
+    if cache is not None:
+        return cache.channel_indices(tcm, table_id)
+
+    chan_tcm_indexs = (ak.flatten(tcm.table_key) == table_id).to_numpy()
+    idx_ch = ak.flatten(tcm.row_in_table)[chan_tcm_indexs].to_numpy()
+    evt_ids_ch = np.repeat(
+        np.arange(0, len(tcm.table_key)), ak.sum(tcm.table_key == table_id, axis=1)
+    )
+    return chan_tcm_indexs, idx_ch, evt_ids_ch
 
 
 def make_files_config(data: dict):
@@ -76,14 +201,23 @@ def get_lgdo_attrs(datainfo, channels, tier_name, field):
     if tier is None or tier.file is None:
         return {}
 
+    # tier.file is an open handle once build_evt_cols has taken ownership of
+    # the input files; only close what we opened ourselves
+    if isinstance(tier.file, h5py.Group):
+        return _first_field_attrs(tier.file, channels, tier.group, field)
+
     with h5py.File(tier.file, "r") as f:
-        for ch in channels:
-            path = f"{ch.replace('/', '')}/{tier.group}/{field}"
-            if path not in f:
-                continue
-            attrs = dict(f[path].attrs)
-            attrs.pop("datatype", None)
-            return attrs
+        return _first_field_attrs(f, channels, tier.group, field)
+
+
+def _first_field_attrs(f, channels, group, field):
+    for ch in channels:
+        path = f"{ch.replace('/', '')}/{group}/{field}"
+        if path not in f:
+            continue
+        attrs = dict(f[path].attrs)
+        attrs.pop("datatype", None)
+        return attrs
     return {}
 
 
@@ -110,6 +244,7 @@ def find_parameters(
     ch,
     idx_ch,
     field_list,
+    cache=None,
 ) -> dict:
     """Finds and returns parameters from non `tcm`, `evt` tiers.
 
@@ -123,6 +258,10 @@ def find_parameters(
        index array of entries to be read from datainfo.
     field_list
        list of tuples ``(tier, field)`` to be found in non `tcm`, `evt` tiers.
+    cache
+       optional :class:`EvtCache`. When given, table listings are looked up
+       instead of read from the file, and each column is read from disk at
+       most once per chunk however many operations reference it.
     """
     if not isinstance(datainfo, DataInfo):
         datainfo = make_files_config(datainfo)
@@ -130,30 +269,62 @@ def find_parameters(
     final_dict = {}
 
     for name, tier in datainfo._asdict().items():
-        if name not in ["tcm", "evt"] and tier.file is not None:  # skip other tables
-            keys = [
+        if name in ("tcm", "evt") or tier.file is None:  # skip other tables
+            continue
+
+        # nothing from this tier is referenced: never touch the file
+        wanted = [e[1] for e in field_list if e[0] == name]
+        if not wanted:
+            continue
+
+        if cache is not None:
+            keys = cache.table_fields(datainfo, name, ch)
+        else:
+            keys = {
                 k.split("/")[-1]
                 for k in lh5.ls(tier.file, f"{ch.replace('/', '')}/{tier.group}/")
-            ]
-            flds = [e[1] for e in field_list if e[0] == name and e[1] in keys]
+            }
+        flds = [f for f in wanted if f in keys]
 
-            if len(flds) > 0:
-                tier_ak = lh5.read_as(
-                    f"{ch.replace('/', '')}/{tier.group}/",
-                    tier.file,
-                    field_mask=flds,
-                    idx=idx_ch,
-                    library="ak",
-                )
+        if not flds:
+            continue
 
-                tier_dict = dict(
-                    zip(
-                        [f"{name}_" + e for e in ak.fields(tier_ak)],
-                        ak.unzip(tier_ak),
-                        strict=False,
-                    )
+        if cache is None:
+            tier_ak = lh5.read_as(
+                f"{ch.replace('/', '')}/{tier.group}/",
+                tier.file,
+                field_mask=flds,
+                idx=idx_ch,
+                library="ak",
+            )
+            final_dict |= dict(
+                zip(
+                    [f"{name}_" + e for e in ak.fields(tier_ak)],
+                    ak.unzip(tier_ak),
+                    strict=False,
                 )
-                final_dict = final_dict | tier_dict
+            )
+            continue
+
+        # read only the columns this chunk has not already loaded
+        missing = list(
+            dict.fromkeys(f for f in flds if (name, ch, f) not in cache.cols)
+        )
+        if missing:
+            tier_ak = lh5.read_as(
+                f"{ch.replace('/', '')}/{tier.group}/",
+                tier.file,
+                field_mask=missing,
+                idx=idx_ch,
+                library="ak",
+            )
+            for fld, col in zip(ak.fields(tier_ak), ak.unzip(tier_ak), strict=False):
+                cache.cols[(name, ch, fld)] = col
+
+        for fld in flds:
+            # a requested column can still be absent if the read dropped it
+            if (name, ch, fld) in cache.cols:
+                final_dict[f"{name}_{fld}"] = cache.cols[(name, ch, fld)]
 
     return final_dict
 
@@ -191,10 +362,10 @@ def get_data_at_channel(
     if not isinstance(datainfo, DataInfo):
         datainfo = make_files_config(datainfo)
     table_id = get_tcm_id_by_pattern(datainfo.hit.table_fmt, ch)
+    cache = getattr(tcm, "cache", None)
 
     # get index list for this channel to be loaded
-    chan_tcm_indexs = (ak.flatten(tcm.table_key) == table_id).to_numpy()
-    idx_ch = ak.flatten(tcm.row_in_table)[chan_tcm_indexs].to_numpy()
+    chan_tcm_indexs, idx_ch, _ = channel_indices(tcm, table_id)
     outsize = len(idx_ch)
 
     if expr == "tcm.table_key":
@@ -209,6 +380,7 @@ def get_data_at_channel(
             ch=ch,
             idx_ch=idx_ch,
             field_list=field_list,
+            cache=cache,
         )
 
         if pars_dict is not None:
@@ -224,8 +396,10 @@ def get_data_at_channel(
             elif name not in ["tcm", "raw"]:
                 new_expr = new_expr.replace(f"{name}.", f"{name}_")
 
+        # compiled once per expression, then reused for every channel
+        code = cache.compile(new_expr) if cache is not None else new_expr
         res = eval(
-            new_expr,
+            code,
             var,
         )
 
@@ -256,6 +430,7 @@ def get_mask_from_query(
     length,
     ch,
     idx_ch,
+    cache=None,
 ) -> NDArray:
     """Evaluates a query expression and returns a mask accordingly.
 
@@ -271,6 +446,8 @@ def get_mask_from_query(
        "rawid" of channel to be evaluated.
     idx_ch
        channel indices to be read.
+    cache
+       optional :class:`EvtCache`, forwarded to :func:`find_parameters`.
     """
     if not isinstance(datainfo, DataInfo):
         datainfo = make_files_config(datainfo)
@@ -285,6 +462,7 @@ def get_mask_from_query(
             ch=ch,
             idx_ch=idx_ch,
             field_list=query_lst,
+            cache=cache,
         )
 
         new_query = query
@@ -292,8 +470,9 @@ def get_mask_from_query(
             if name not in ["tcm", "evt"]:
                 new_query = new_query.replace(f"{name}.", f"{name}_")
 
+        code = cache.compile(new_query) if cache is not None else new_query
         limarr = eval(
-            new_query,
+            code,
             query_var,
         )
 

--- a/src/pygama/evt/utils.py
+++ b/src/pygama/evt/utils.py
@@ -134,7 +134,24 @@ def channel_indices(tcm, table_id):
     to. Served from ``tcm.cache`` when there is one — every aggregator needs
     these for every operation, and recomputing them is a full jagged reduction
     over the chunk.
+
+    Raises
+    ------
+    ValueError
+        If *table_id* is ``None``, i.e. the channel name did not match the
+        table format.  :func:`get_tcm_id_by_pattern` returns ``None`` for those,
+        and callers that mean to skip them must filter on it (as
+        :func:`~pygama.evt.build_evt.build_evt` does) rather than pass the
+        ``None`` through.
     """
+    if table_id is None:
+        msg = (
+            "cannot locate hits for a channel whose name does not match the "
+            "table format (get_tcm_id_by_pattern returned None); filter such "
+            "channels out or correct the channel name in the config"
+        )
+        raise ValueError(msg)
+
     cache = getattr(tcm, "cache", None)
     if cache is not None:
         return cache.channel_indices(tcm, table_id)

--- a/tests/evt/test_build_evt.py
+++ b/tests/evt/test_build_evt.py
@@ -529,3 +529,121 @@ def test_build_evt_independent_of_buffer_len(
         checked += 1
 
     assert checked > 0
+
+
+@pytest.fixture(scope="module")
+def sparse_channel_config(tmp_path_factory):
+    """Two channels, one of which fires only in the last events of the file.
+
+    The real test data has a handful of channels that all fire in nearly every
+    event, which makes a channel's event numbers coincide with its row numbers
+    and hides any confusion between the two. Here ``ch1000001`` fires only in
+    events 40-49, so its rows are 0-9 while its events are 40-49.
+    """
+    d = tmp_path_factory.mktemp("sparse")
+    n_events, first_b = 50, 40
+
+    keys, rows, a_row, b_row = [], [], 0, 0
+    for event in range(n_events):
+        k, r = [1000000], [a_row]
+        a_row += 1
+        if event >= first_b:
+            k.append(1000001)
+            r.append(b_row)
+            b_row += 1
+        keys.append(k)
+        rows.append(r)
+
+    lh5.write(
+        Table(
+            {
+                "table_key": VectorOfVectors(ak.Array(keys)),
+                "row_in_table": VectorOfVectors(ak.Array(rows)),
+            }
+        ),
+        "hardware_tcm_1",
+        str(d / "tcm.lh5"),
+        wo_mode="of",
+    )
+
+    # ch1000001 always has the smaller sorter value, so wherever it fires it
+    # must win the first_at aggregation
+    # ``neg_tp_0_est`` is the negated sorter, so the same channel wins whether
+    # the aggregation takes the smallest or the largest value
+    lh5.write(
+        Table(
+            {
+                "tp_0_est": Array(np.full(a_row, 100.0)),
+                "neg_tp_0_est": Array(np.full(a_row, -100.0)),
+                "timestamp": Array(np.arange(a_row, dtype=float)),
+            }
+        ),
+        "ch1000000/dsp",
+        str(d / "dsp.lh5"),
+        wo_mode="of",
+    )
+    lh5.write(
+        Table(
+            {
+                "tp_0_est": Array(np.full(b_row, 10.0)),
+                "neg_tp_0_est": Array(np.full(b_row, -10.0)),
+                "timestamp": Array(np.full(b_row, 999.0)),
+            }
+        ),
+        "ch1000001/dsp",
+        str(d / "dsp.lh5"),
+        wo_mode="a",
+    )
+    for i, (ch, n) in enumerate((("ch1000000", a_row), ("ch1000001", b_row))):
+        lh5.write(
+            Table({"e": Array(np.ones(n))}),
+            f"{ch}/hit",
+            str(d / "hit.lh5"),
+            wo_mode="of" if i == 0 else "a",
+        )
+
+    files_config = {
+        "tcm": (str(d / "tcm.lh5"), "hardware_tcm_1"),
+        "dsp": (str(d / "dsp.lh5"), "dsp", "ch{}"),
+        "hit": (str(d / "hit.lh5"), "hit", "ch{}"),
+        "evt": (None, "evt"),
+    }
+    expected = np.concatenate(
+        [np.arange(first_b, dtype=float), np.full(n_events - first_b, 999.0)]
+    )
+    return files_config, expected
+
+
+@pytest.mark.parametrize("buffer_len", [10**6, 7, 1])
+@pytest.mark.parametrize("mode", ["first_at", "last_at"])
+def test_first_last_at_uses_sparse_channel(sparse_channel_config, mode, buffer_len):
+    """first_at/last_at must pick the winning channel however sparse it is.
+
+    Regression test: the aggregator used to finish each channel with a pandas
+    ``.loc`` assignment, which aligns the right-hand side *by index label*. The
+    labels were event numbers and the right-hand index was the channel's hit
+    positions, so for a sparse channel the two disagreed and the values were
+    dropped (silently becoming NaN). It also made the result depend on where
+    the chunk boundaries fell.
+    """
+    files_config, expected = sparse_channel_config
+    # ch1000001 has the smaller sorter value, so it wins first_at; the negated
+    # column makes it the largest, so it wins last_at too and one set of
+    # expectations covers both branches
+    sorter = "dsp.tp_0_est" if mode == "first_at" else "dsp.neg_tp_0_est"
+
+    config = {
+        "channels": {"geds_on": ["ch1000000", "ch1000001"]},
+        "outputs": ["t"],
+        "operations": {
+            "t": {
+                "channels": "geds_on",
+                "aggregation_mode": f"{mode}:{sorter}",
+                "expression": "dsp.timestamp",
+                "initial": -1,
+            }
+        },
+    }
+    got = build_evt(files_config, config=config, buffer_len=buffer_len).t.view_as("np")
+    assert not np.isnan(got).any()
+    assert np.array_equal(got, expected)

--- a/tests/evt/test_build_evt.py
+++ b/tests/evt/test_build_evt.py
@@ -472,3 +472,60 @@ def test_buffered_build_evt(files_config_nowrite):
         files_config_nowrite, config=f"{config_dir}/basic-evt-config.yaml", buffer_len=1
     )
     assert (evt1.energy.flattened_data.nda == evt2.energy.flattened_data.nda).all()
+
+
+# Fields that legitimately -- or at least knowingly -- vary with the chunk
+# size, and so cannot take part in the comparison below.
+#
+# ``keep_at_ch`` results already varied before any caching was added:
+# evaluate_at_channel writes its result at every event in which the channel
+# fired (``out[evt_ids_ch] = res``) rather than only at the events ch_comp
+# selects, so whether a channel is evaluated at all depends on it appearing in
+# the current chunk's ch_comp. No production evt config uses keep_at_ch; they
+# use keep_at_idx, which goes through evaluate_at_channel_vov and does restrict
+# by ch_comp.
+#
+# ``tcm.index`` is by construction an offset into the flattened TCM of the
+# chunk being processed, so its value is chunk-relative. It is consumed by
+# keep_at_idx within the same chunk, which is self-consistent; production
+# configs keep such fields as ``_``-prefixed intermediates and never write
+# them out.
+_KEEP_AT_CH_FIELDS = {"aoe", "is_aoe_rejected", "is_usable_aoe", "is_saturated"}
+_TCM_INDEX_FIELDS = {"energy_idx"}
+_CHUNK_DEPENDENT_FIELDS = _KEEP_AT_CH_FIELDS | _TCM_INDEX_FIELDS
+
+
+@pytest.mark.parametrize("buffer_len", [1, 7, 10**4])
+@pytest.mark.parametrize(
+    "config_file",
+    ["query-test-evt-config.json", "vov-test-evt-config.json"],
+)
+def test_build_evt_independent_of_buffer_len(
+    files_config_nowrite, config_file, buffer_len
+):
+    """Chunking must not be observable in the output.
+
+    Per-chunk state (cached lower-tier columns, cached per-channel TCM
+    indices) is only valid for the chunk it was built from, so a stale entry
+    would show up here as a column that changes with the chunk size. Between
+    them the two configs cover every aggregation mode used by the production
+    evt configs: sum, any, all, first_at, last_at, gather and keep_at_idx.
+    """
+    config = f"{config_dir}/{config_file}"
+    ref = build_evt(files_config_nowrite, config=config, buffer_len=10**6)
+    evt = build_evt(files_config_nowrite, config=config, buffer_len=buffer_len)
+
+    assert sorted(ref.keys()) == sorted(evt.keys())
+    checked = 0
+    for field in ref:
+        if field in _CHUNK_DEPENDENT_FIELDS:
+            continue
+        a = ak.flatten(ref[field].view_as("ak"), axis=None).to_numpy()
+        b = ak.flatten(evt[field].view_as("ak"), axis=None).to_numpy()
+        assert a.dtype == b.dtype, field
+        # NaN is a legitimate value here (unfilled defaults), so it has to
+        # compare equal to itself
+        assert np.array_equal(a, b, equal_nan=a.dtype.kind == "f"), field
+        checked += 1
+
+    assert checked > 0

--- a/tests/evt/test_evt_utils.py
+++ b/tests/evt/test_evt_utils.py
@@ -51,3 +51,32 @@ def test_get_lgdo_attrs(tmp_path):
 
     # unknown tier returns an empty dict rather than raising
     assert utils.get_lgdo_attrs(datainfo, ["ch1000000"], "dsp", "flags") == {}
+
+
+def test_make_numpy_full_promotes_to_hold_both():
+    """The accumulator must hold the fill value *and* the data dtype.
+
+    A config ``initial: 0`` against float32 data cannot be cast to float32;
+    returning an integer accumulator makes the later ``out += res`` raise.
+    """
+    # the regression: integer initial, float32 data
+    out = utils.make_numpy_full(4, 0, np.float32)
+    assert out.dtype == np.float32
+    res = np.array([1.5, 2.5, 3.5, 4.5], dtype=np.float32)
+    out[np.arange(4)] += res  # must not raise UFuncOutputCastingError
+    assert out.tolist() == [1.5, 2.5, 3.5, 4.5]
+
+    # float64 data keeps working exactly as before
+    assert utils.make_numpy_full(3, 0, np.float64).dtype == np.float64
+    # bool initial with bool data stays bool
+    assert utils.make_numpy_full(3, False, bool).dtype == np.bool_
+    # a nan initial forces a float accumulator even against integer data
+    assert np.issubdtype(utils.make_numpy_full(3, np.nan, np.int32).dtype, np.floating)
+    # the value is still the requested one
+    assert np.all(utils.make_numpy_full(3, 7, np.float32) == 7)
+
+
+def test_make_numpy_full_accepts_python_types():
+    """``evaluate_to_first_or_last`` passes ``type(default_value)`` as the dtype."""
+    assert utils.make_numpy_full(2, 0, type(0)).dtype == np.dtype(int)
+    assert utils.make_numpy_full(2, 0.0, type(0.0)).dtype == np.dtype(float)

--- a/tests/evt/test_evt_utils.py
+++ b/tests/evt/test_evt_utils.py
@@ -78,5 +78,5 @@ def test_make_numpy_full_promotes_to_hold_both():
 
 def test_make_numpy_full_accepts_python_types():
     """``evaluate_to_first_or_last`` passes ``type(default_value)`` as the dtype."""
-    assert utils.make_numpy_full(2, 0, type(0)).dtype == np.dtype(int)
-    assert utils.make_numpy_full(2, 0.0, type(0.0)).dtype == np.dtype(float)
+    assert utils.make_numpy_full(2, 0, int).dtype == np.dtype(int)
+    assert utils.make_numpy_full(2, 0.0, float).dtype == np.dtype(float)

--- a/tests/evt/test_evt_utils.py
+++ b/tests/evt/test_evt_utils.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+import types
+
+import awkward as ak
 import lh5
 import numpy as np
+import pytest
 from lgdo import Array
 
 from pygama.evt import utils
@@ -80,3 +84,29 @@ def test_make_numpy_full_accepts_python_types():
     """``evaluate_to_first_or_last`` passes ``type(default_value)`` as the dtype."""
     assert utils.make_numpy_full(2, 0, int).dtype == np.dtype(int)
     assert utils.make_numpy_full(2, 0.0, float).dtype == np.dtype(float)
+
+
+def test_channel_indices_rejects_an_unresolved_table_id():
+    """A channel name that does not match the table format must fail clearly.
+
+    ``get_tcm_id_by_pattern`` returns ``None`` for such names, and both the
+    cached and uncached paths would otherwise die inside awkward with an
+    opaque "None conversion/promotion is disabled" TypeError.
+    """
+    tcm = types.SimpleNamespace(
+        table_key=ak.Array([[1, 2], [3]]),
+        row_in_table=ak.Array([[0, 1], [2]]),
+    )
+
+    # uncached path
+    with pytest.raises(ValueError, match="does not match the table format"):
+        utils.channel_indices(tcm, None)
+
+    # and with a cache attached, so both routes agree
+    tcm.cache = utils.EvtCache()
+    with pytest.raises(ValueError, match="does not match the table format"):
+        utils.channel_indices(tcm, None)
+
+    # a resolvable id still works
+    assert utils.get_tcm_id_by_pattern("ch{}", "ch3") == 3
+    assert utils.get_tcm_id_by_pattern("ch{}", "not-a-channel") is None


### PR DESCRIPTION
Building the `evt`/`pet` tier is slow, and disproportionately so for calibration data. Chasing that turned up a correctness bug as well, so this is two commits: a bit-identical performance pass, and a fix that deliberately changes output.

## Why cal is so much worse

`build_evt`'s cost is dominated by **fixed per-chunk, per-operation, per-channel overhead that does not shrink with the chunk size**. A cal file holds ~1.08 M events against ~5 k for a phy file, so at `buffer_len=10**4` it is split into 108 chunks and pays that cost 108 times, while phy pays it once.

Profiling one production cal file (p16 r000, 1,076,389 events):

| | cumulative | calls |
|---|---|---|
| `utils.find_parameters` | **43 %** | 198,921 |
| `lh5.read_as` | 21 % | 192,065 |
| `lh5.ls` | **21 %** | **1,193,530** |
| `ak.sum` (per-channel TCM reduction) | 7 % | 487,649 |

Every one of those `lh5.ls` calls is a full HDF5 open.

## `perf(evt)` — bit-identical

Four sources of repetition, none of which change what is computed:

- **Every lower-tier read reopened the input file.** `build_evt_cols` now opens `hit`/`dsp`/`ann` once through an `ExitStack` and puts the handles in `datainfo`; `lh5.ls`/`lh5.read` already accept them. `tcm` keeps its path (`LH5Iterator` wants a string) and `evt` is the output.
- **`find_parameters` listed a channel's table on every call**, for every tier, even tiers the expression never mentions. Table layout is a property of the file, so a new `EvtCache` holds it for the run.
- **The same column was read once per operation mentioning it** — the merged cal config needs 21 distinct columns but asked for 47. Now read at most once per chunk.
- **Each aggregator rebuilt a channel's TCM index arrays** with a full jagged reduction, in five places. `channel_indices` does every channel in one vectorised pass per chunk.

Also: compile expressions once instead of `eval()`ing a string per channel; skip channels whose expression references no lower-tier field; and replace the pairwise fold in `_concat_tables` with a single `ak.concatenate` (the fold recopied the accumulated table once per chunk — quadratic in chunk count, and double peak memory).

## `fix(evt)` — first_at/last_at

`evaluate_to_first_or_last` finished each channel with

```python
sort_df.loc[evt_ids_ch[ids], cols] = ch_df.loc[ids, cols]
```

`.loc` with a DataFrame on the right aligns **by index label**. The left labels are event numbers; the right index is the channel's hit positions, numbered from zero. They only coincide for a channel that fires in nearly every event, so for a sparse channel most of the assignment lands on labels the right-hand side does not have and silently becomes NaN. It also made the result depend on where chunk boundaries fell.

The effect on real data is not subtle. In the p16 r000 cal `pet` file:

- `evt/trigger/timestamp` is NaN for **1,045,056 of the 1,072,935 events that have a geds hit (97.4 %)**.
- That field feeds `geds.apply_recovery_cut(timestamps=evt.trigger___timestamp, time_window=0.01)`, and every comparison against NaN is False — so `evt/geds/quality/is_not_bb_like/is_delayed_discharge` was True for **0 of 1,076,389 events**. The delayed-discharge veto had never fired at all.

The fix keeps the running best sorter value and the value that won it in two plain numpy arrays indexed by event, and assigns positionally. Where a channel has several hits in one event, the writes are ordered so the winning hit lands last.

A second defect in the same function goes with it: `sort_field` started at zeros and was only reset to `+inf` for `first_at` (and only on `channels[0]`), so `last_at` could never select anything whose sorter was negative.

## Measurements

Same machine and file, no profiler:

| variant | wall clock | peak RSS |
|---|---|---|
| before | **44 m 00 s** | 1.43 GB |
| after, same `buffer_len=10**4` | **12 m 22 s** | 1.45 GB |
| after, `buffer_len=10**6` | **1 m 34 s** | 1.63 GB |

`lh5.ls` calls: 1,193,530 → 359.

## Verification

Rebuilt real production files and diffed every dataset, dtype and attribute against production's own `pet` output:

- The perf commit alone is **bit-identical** on cal (80 datasets) and on phy (116 datasets — the path covering cross-talk, the SiPM `function` operations and the muon second pass), and matches unmodified pygama at every chunk size tested.
- With the fix, phy stays bit-identical and cal changes in exactly three fields: `trigger/timestamp` (no NaN left where a geds hit exists), `is_delayed_discharge` (0 → 23 events flagged) and `is_bb_like` (−19), the latter two being downstream of the first.

Tests: `tests/evt` and `tests/hit` pass. Two new tests — one asserting the output cannot depend on `buffer_len` across every aggregation mode the production configs use, and one building a synthetic file where a channel fires only in the last ten events so its rows and its events cannot be confused. The second fails on `main` in 5 of 6 parametrisations; the real test data is too small and too dense to expose any of this.

## Note for downstream

Any analysis relying on `trigger___timestamp` or the delayed-discharge veto in **cal** data is affected by the fix — those values were largely NaN, and the veto was inoperative.

A related issue this does **not** fix: `keep_at_ch` is also chunk-dependent (`evaluate_at_channel` writes at every event where the channel fired, rather than only where `ch_comp` selects). No production evt config uses `keep_at_ch` — they use `keep_at_idx`, which goes through `evaluate_at_channel_vov` and restricts correctly — so it is excluded from the new chunk-invariance test with a comment rather than changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)