### PR TITLE
Update build_tcm to add a view for each channel to a table of only ev…

### DIFF
--- a/src/pygama/evt/build_tcm.py
+++ b/src/pygama/evt/build_tcm.py
@@ -246,7 +246,7 @@ def build_tcm(
                             np.array(ak.any(table_key == key, axis=-1))
                         )
                         entries += tcm_row
-                        offset += len(old_entries)
+                        new_off = offset + len(old_entries)
                     elif channel_views == "dense":
                         # This builds a 2d array of ranges where our mask is True by identifying
                         # indices where mask changes between True and False
@@ -265,18 +265,18 @@ def build_tcm(
                             (-1, 2),
                         )
                         entries += tcm_row
-                        offset += len(old_entries)
+                        new_off = offset + len(old_entries)
                     elif channel_views == "all":
                         # Build a single 2d array with all entries; overwrite for each iteration
                         if not ak.all(ak.any(table_key == key, axis=-1)):
                             msg = f"channel {key} not found in all events; channel_views='all' failed"
                             raise RuntimeError(msg)
                         entries = np.array([[0, len(table_key) + tcm_row]])
-                        offset = 0
+                        new_off = 0
                     else:
                         msg = f"unknown channel_views mode: {channel_views}"
                         raise ValueError(msg)
-                    view_gps[view] = (entries, offset)
+                    view_gps[view] = (entries, new_off)
 
             # Write to file
             if out_file is not None:

--- a/src/pygama/evt/build_tcm.py
+++ b/src/pygama/evt/build_tcm.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import logging
 import re
-from pathlib import Path
+from copy import deepcopy
+from typing import Literal
 
 import awkward as ak
 import lgdo
 import lh5
+import numpy as np
 from lgdo.types import Struct, Table, VectorOfVectors
 
 from . import tcm as ptcm
@@ -49,10 +51,12 @@ def build_tcm(
     window_refs: str | list[str] = "last",
     out_file: str | None = None,
     out_name: str = "tcm",
+    channel_views: Literal["sparse", "dense", "all"] | None = None,
+    view_group: str = "ch{key}",
     wo_mode: str = "write_safe",
     buffer_len: int | None = None,
     out_fields: str | list[str] | None = None,
-) -> lgdo.Table | None:
+) -> lgdo.Table | tuple[lgdo.Table, dict[str, np.ndarray]] | None:
     r"""Build a Time Coincidence Map (TCM).
 
     Given a list of input tables, create an output table containing an entry
@@ -85,6 +89,20 @@ def build_tcm(
         written; the TCM will just be returned in memory.
     out_name
         name for the TCM table in the output file.
+    channel_views
+        mode for creating View of TCM for each channel, with only events
+        containing that channel. Options:
+        - ``"sparse"``: use in sparse trigger mode; a minority of events contain each channel
+        - ``"dense"``: use in global trigger mode; (almost) all events contain (almost) all channels
+        - ``"all"``: use in global trigger mode; assume all events are contained in all channels;
+            if this is not the case, a RunTimeError will be raised!
+        - ``"none"`` or ``None``: no channel views
+    view_group
+        format string for name of group containing view for each channel. View will
+        be named ``out_name``. Can include the format specifiers:
+        - ``key``: the index or hash integer of the channel
+        - ``table``: the name of the input table
+        Default: ``"ch{key}"`` (e.g. ``ch12345678/tcm``)
     wo_mode
         mode to send to :meth:`~lh5.io.store.LH5Store.write`.
 
@@ -94,10 +112,11 @@ def build_tcm(
 
     Returns
     -------
-    lgdo.Table or None
-        If ``out_file`` is ``None`` the resulting TCM is returned as a
-        :class:`lgdo.Table`. Otherwise ``None`` is returned after writing the
-        table to ``out_file``.
+    ``(lgdo.Table, dict[str, np.ndarray])`` or ``lgdo.Table`` or ``None``
+        If we are outputting to a file, return ``None``. Otherwise,
+        if ``out_file`` is ``None`` the resulting TCM is returned as a
+        :class:`lgdo.Table`; if ``channel_views`` is additionally enabled,
+        also return a ``dict`` from ``channel_name`` to entry list.
 
     See Also
     --------
@@ -137,6 +156,7 @@ def build_tcm(
     iterators = []
     table_keys = []
     all_tables = []
+    view_gps = {}
 
     # determine buffer length automatically
     if buffer_len is None:
@@ -195,6 +215,7 @@ def build_tcm(
                 )
             )
             table_keys.append(table_key)
+            view_gps[view_group.format(key=table_key, table=table)] = ([], 0)
 
     coin_windows = [
         ptcm.coin_groups(n, w, r)
@@ -204,31 +225,84 @@ def build_tcm(
     tcm_gen = ptcm.generate_tcm_cols(
         iterators, coin_windows=coin_windows, table_keys=table_keys, fields=out_fields
     )
-    tcm = []
-    # clear existing output files
-    if out_file is not None and wo_mode == "of" and Path(out_file).exists():
-        Path(out_file).unlink()
 
-    wrote_first = False
-    while True:
-        try:
-            out_tbl = tcm_gen.__next__()
+    tcm = None
+    tcm_row = 0
+    channel_views = channel_views.strip().lower() if channel_views is not None else None
+    with lh5.LH5Store(keep_open=True, default_mode=wo_mode) as st:
+        for out_tbl in tcm_gen:
             out_tbl.attrs.update(
                 {"tables": str(all_tables), "hash_func": str(hash_func)}
             )
+
+            # build entry list for each channel
+            if channel_views not in ("none", None):
+                for key, (view, (old_entries, offset)) in zip(table_keys, view_gps.items(), strict=True):
+                    table_key = out_tbl.table_key.view_as("ak")
+                    if channel_views == "sparse":
+                        entries = np.flatnonzero(np.array(ak.any(table_key == key, axis=-1)))
+                        entries += tcm_row
+                        offset += len(old_entries)
+                    elif channel_views == "dense":
+                        # This builds a 2d array of ranges where our mask is True by identifying
+                        # indices where mask changes between True and False
+                        entries = np.reshape(np.flatnonzero(np.diff(
+                            np.concatenate([[0], np.array(ak.any(table_key == key, axis=-1)), [0]])
+                        )), (-1, 2))
+                        entries += tcm_row
+                        offset += len(old_entries)
+                    elif channel_views == "all":
+                        # Build a single 2d array with all entries; overwrite for each iteration
+                        if not ak.all(ak.any(table_key == key, axis=-1)):
+                            msg = f"channel {key} not found in all events; channel_views='all' failed"
+                            raise RuntimeError(msg)
+                        entries = np.array([[0, len(table_key) + tcm_row]])
+                        offset = 0
+                    else:
+                        msg = f"unknown channel_views mode: {channel_views}"
+                        raise ValueError(msg)
+                    view_gps[view] = (entries, offset)
+
+            # Write to file
             if out_file is not None:
-                lh5.write(
+                st.write(
                     out_tbl,
                     out_name,
                     out_file,
-                    wo_mode=wo_mode if not wrote_first else "a",
+                    write_start=tcm_row,
                 )
-                wrote_first = True
+
+                if channel_views not in ("none", None):
+                    for view, (entries, offset) in view_gps.items():
+                        st.write_view(
+                            out_name,
+                            entries,
+                            out_name,
+                            out_file,
+                            group=view,
+                            link_type="hard",
+                            write_start=offset,
+                            wo_mode=None if channel_views!="all" else "o",
+                        )
+
+            # build up the table in memory
+            elif tcm is None:
+                tcm = deepcopy(out_tbl)
+                channel_entries = {k:v[0] for k, v in view_gps.items()}
             else:
                 tcm.append(out_tbl)
-        except StopIteration:
-            break
+                if channel_views not in ("none", None):
+                    for ch_name, (new_entries, _) in view_gps.items():
+                        if channel_views == "all":
+                            channel_entries[ch_name] = new_entries
+                        else:
+                            channel_entries[ch_name] = np.append(channel_entries[ch_name], new_entries, axis=0)
 
-    if out_file is None:
-        return _concat_tables(tcm)
-    return None
+            tcm_row += len(out_tbl)
+
+    if tcm is None:
+        return None
+    elif channel_views in ("none", None):
+        return tcm
+    else:
+        return tcm, channel_entries

--- a/src/pygama/evt/build_tcm.py
+++ b/src/pygama/evt/build_tcm.py
@@ -237,18 +237,33 @@ def build_tcm(
 
             # build entry list for each channel
             if channel_views not in ("none", None):
-                for key, (view, (old_entries, offset)) in zip(table_keys, view_gps.items(), strict=True):
+                for key, (view, (old_entries, offset)) in zip(
+                    table_keys, view_gps.items(), strict=True
+                ):
                     table_key = out_tbl.table_key.view_as("ak")
                     if channel_views == "sparse":
-                        entries = np.flatnonzero(np.array(ak.any(table_key == key, axis=-1)))
+                        entries = np.flatnonzero(
+                            np.array(ak.any(table_key == key, axis=-1))
+                        )
                         entries += tcm_row
                         offset += len(old_entries)
                     elif channel_views == "dense":
                         # This builds a 2d array of ranges where our mask is True by identifying
                         # indices where mask changes between True and False
-                        entries = np.reshape(np.flatnonzero(np.diff(
-                            np.concatenate([[0], np.array(ak.any(table_key == key, axis=-1)), [0]])
-                        )), (-1, 2))
+                        entries = np.reshape(
+                            np.flatnonzero(
+                                np.diff(
+                                    np.concatenate(
+                                        [
+                                            [0],
+                                            np.array(ak.any(table_key == key, axis=-1)),
+                                            [0],
+                                        ]
+                                    )
+                                )
+                            ),
+                            (-1, 2),
+                        )
                         entries += tcm_row
                         offset += len(old_entries)
                     elif channel_views == "all":
@@ -282,13 +297,13 @@ def build_tcm(
                             group=view,
                             link_type="hard",
                             write_start=offset,
-                            wo_mode=None if channel_views!="all" else "o",
+                            wo_mode=None if channel_views != "all" else "o",
                         )
 
             # build up the table in memory
             elif tcm is None:
                 tcm = deepcopy(out_tbl)
-                channel_entries = {k:v[0] for k, v in view_gps.items()}
+                channel_entries = {k: v[0] for k, v in view_gps.items()}
             else:
                 tcm.append(out_tbl)
                 if channel_views not in ("none", None):
@@ -296,13 +311,14 @@ def build_tcm(
                         if channel_views == "all":
                             channel_entries[ch_name] = new_entries
                         else:
-                            channel_entries[ch_name] = np.append(channel_entries[ch_name], new_entries, axis=0)
+                            channel_entries[ch_name] = np.append(
+                                channel_entries[ch_name], new_entries, axis=0
+                            )
 
             tcm_row += len(out_tbl)
 
     if tcm is None:
         return None
-    elif channel_views in ("none", None):
+    if channel_views in ("none", None):
         return tcm
-    else:
-        return tcm, channel_entries
+    return tcm, channel_entries

--- a/tests/evt/test_build_tcm.py
+++ b/tests/evt/test_build_tcm.py
@@ -205,7 +205,7 @@ def test_generate_tcm_cols(lgnd_test_data):
     assert tcm_cols.table_key == exp_keys
     assert set(chan_list) == set(chan_tcms.keys())
     for entries in chan_tcms.values():
-        entries = np.array([0])
+        assert (entries == np.array([0])).all()
 
 
 def test_build_tcm_multiple_cols(lgnd_test_data):

--- a/tests/evt/test_build_tcm.py
+++ b/tests/evt/test_build_tcm.py
@@ -17,10 +17,12 @@ def test_generate_tcm_cols(lgnd_test_data):
         "lh5/prod-ref-l200/generated/tier/raw/cal/p03/r001/l200-p03-r001-cal-20230318T012144Z-tier_raw.lh5"
     )
 
+    chan_list = lh5.ls(f_raw)
     tcm_cols = evt.build_tcm(
-        [(f_raw, [f"{chan}/raw" for chan in lh5.ls(f_raw)])],
+        [(f_raw, [f"{chan}/raw" for chan in chan_list])],
         "timestamp",
         buffer_len=100,
+        channel_views=None,
     )
 
     assert isinstance(tcm_cols, Table)
@@ -37,87 +39,106 @@ def test_generate_tcm_cols(lgnd_test_data):
     }
 
     # fmt: off
-    assert np.array_equal(
-        tcm_cols.table_key.cumulative_length.nda,
-        [
-            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 14, 15, 16, 17, 18, 19, 20,
-            21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
-        ],
+    exp_keys = VectorOfVectors(
+        cumulative_length = np.array(
+            [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+              21, 22, 23, 24, 25, 26, 27, 28, 29, 30, ],
+        ),
+        flattened_data = np.array(
+            [ 1084804, 1084803, 1121600, 1084804, 1121600, 1084804, 1121600,
+              1084804, 1084804, 1084804, 1084803, 1084804, 1084804, 1121600,
+              1121600, 1084804, 1121600, 1084804, 1121600, 1084803, 1084803,
+              1121600, 1121600, 1121600, 1084803, 1084803, 1084803, 1084803,
+              1084803, 1084803, ]            
+        )
     )
-    assert np.array_equal(
-        tcm_cols.table_key.flattened_data.nda,
-        [
-            1084804, 1084803, 1121600, 1084804, 1121600, 1084804, 1121600,
-            1084804, 1084804, 1084804, 1084803, 1084804, 1084804, 1121600,
-            1121600, 1084804, 1121600, 1084804, 1121600, 1084803, 1084803,
-            1121600, 1121600, 1121600, 1084803, 1084803, 1084803, 1084803,
-            1084803, 1084803,
-        ],
-    )
-    assert np.array_equal(
-        tcm_cols.row_in_table.flattened_data.nda,
-        [
-            0, 0, 0, 1, 1, 2, 2, 3, 4, 5, 1, 6, 7, 3, 4, 8, 5, 9, 6, 2, 3, 7,
-            8, 9, 4, 5, 6, 7, 8, 9,
-        ],
+    exp_rows = VectorOfVectors(
+        cumulative_length = np.array(
+            [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+              21, 22, 23, 24, 25, 26, 27, 28, 29, 30, ],
+        ),
+        flattened_data = np.array(
+            [ 0, 0, 0, 1, 1, 2, 2, 3, 4, 5, 1, 6, 7, 3, 4, 8, 5, 9, 6, 2, 3, 7,
+              8, 9, 4, 5, 6, 7, 8, 9, ]
+        )
     )
 
     # fmt: on
+    assert tcm_cols.table_key == exp_keys
+    assert tcm_cols.row_in_table == exp_rows
+
+
+    # Test with sparse views enabled
+    (tcm_cols2, chan_tcms) = evt.build_tcm(
+        [(f_raw, "ch*/raw")],
+        "timestamp",
+        buffer_len=100,
+        channel_views="sparse",
+    )
+
+    assert tcm_cols2.table_key == exp_keys
+    assert tcm_cols2.row_in_table == exp_rows
+
+    assert set(chan_list) == set(chan_tcms.keys())
+    assert all(np.issubdtype(v.dtype, np.integer) for v in chan_tcms.values())
+    for chan_name, entries in chan_tcms.items():
+        chan_id = int(chan_name[2:])
+        assert np.all(entries == np.flatnonzero(np.any(tcm_cols2.table_key.view_as('ak') == chan_id, axis=-1)))
+
     # test with small buffer len
     tcm_cols = evt.build_tcm(
         [(f_raw, [f"{chan}/raw" for chan in lh5.ls(f_raw)])],
         "timestamp",
         buffer_len=1,
+        channel_views=None,
     )
 
-    assert isinstance(tcm_cols, Table)
-    assert isinstance(tcm_cols.table_key, VectorOfVectors)
-    assert isinstance(tcm_cols.row_in_table, VectorOfVectors)
-    for v in tcm_cols.values():
-        assert np.issubdtype(v.flattened_data.nda.dtype, np.integer)
-    # fmt: off
-    assert np.array_equal(
-        tcm_cols.table_key.cumulative_length.nda,
-        [
-            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 14, 15, 16, 17, 18, 19, 20,
-            21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
-        ],
-    )
-    assert np.array_equal(
-        tcm_cols.table_key.flattened_data.nda,
-        [
-            1084804, 1084803, 1121600, 1084804, 1121600, 1084804, 1121600,
-            1084804, 1084804, 1084804, 1084803, 1084804, 1084804, 1121600,
-            1121600, 1084804, 1121600, 1084804, 1121600, 1084803, 1084803,
-            1121600, 1121600, 1121600, 1084803, 1084803, 1084803, 1084803,
-            1084803, 1084803,
-        ],
-    )
-    assert np.array_equal(
-        tcm_cols.row_in_table.flattened_data.nda,
-        [
-            0, 0, 0, 1, 1, 2, 2, 3, 4, 5, 1, 6, 7, 3, 4, 8, 5, 9, 6, 2, 3, 7,
-            8, 9, 4, 5, 6, 7, 8, 9,
-        ],
-    )
-    # fmt: on
+    assert tcm_cols.table_key == exp_keys
+    assert tcm_cols.row_in_table == exp_rows
+
     # test with None hash_func
     tcm_cols = evt.build_tcm(
         [(f_raw, [f"{chan}/raw" for chan in lh5.ls(f_raw)])],
         "timestamp",
         hash_func=None,
         buffer_len=1,
+        channel_views=None,
     )
     # fmt: off
-    assert np.array_equal(
-        tcm_cols.table_key.flattened_data.nda,
-        [
-            1, 0, 2, 1, 2, 1, 2, 1, 1, 1, 0,
-            1, 1, 2, 2, 1, 2, 1, 2, 0, 0, 2,
-            2, 2, 0, 0, 0, 0, 0, 0,
-        ],
+    exp_idxs = VectorOfVectors(
+        cumulative_length = np.array(
+            [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+              21, 22, 23, 24, 25, 26, 27, 28, 29, 30, ],
+        ),
+        flattened_data = np.array(
+            [ 1, 0, 2, 1, 2, 1, 2, 1, 1, 1, 0,
+              1, 1, 2, 2, 1, 2, 1, 2, 0, 0, 2,
+              2, 2, 0, 0, 0, 0, 0, 0, ],
+        )
     )
     # fmt: on
+    assert tcm_cols.table_key == exp_idxs
+    assert tcm_cols.row_in_table == exp_rows
+
+    # test with None hash_func, and with channel_views
+    (tcm_cols2, chan_tcms) = evt.build_tcm(
+        [(f_raw, [f"{chan}/raw" for chan in lh5.ls(f_raw)])],
+        "timestamp",
+        hash_func=None,
+        buffer_len=1,
+        channel_views="sparse",
+    )
+
+    assert tcm_cols2.table_key == exp_idxs
+    assert tcm_cols2.row_in_table == exp_rows
+
+    assert { f"ch{i}" for i in range(3) } == set(chan_tcms.keys())
+    assert all(np.issubdtype(v.dtype, np.integer) for v in chan_tcms.values())
+    for chan_name, entries in chan_tcms.items():
+        chan_id = int(chan_name[2:])
+        assert np.all(entries == np.flatnonzero(np.any(tcm_cols2.table_key.view_as('ak') == chan_id, axis=-1)))
+
+
     # test invalid hash func
     with pytest.raises(NotImplementedError):
         evt.build_tcm(
@@ -139,6 +160,7 @@ def test_generate_tcm_cols(lgnd_test_data):
         [(f_raw, [f"{chan}/raw" for chan in lh5.ls(f_raw)])],
         "timestamp",
         out_fields="timestamp",
+        channel_views=None,
     )
     assert "timestamp" in tcm_cols
 
@@ -148,23 +170,34 @@ def test_generate_tcm_cols(lgnd_test_data):
         "timestamp",
         buffer_len=100,
         coin_windows=1,
-    )
-    assert np.array_equal(
-        tcm_cols.table_key.cumulative_length.nda,
-        [30],
+        channel_views=None,
     )
     # fmt: off
-    assert np.array_equal(
-        tcm_cols.table_key.flattened_data.nda,
-        [
-            1084804, 1084803, 1121600, 1084804, 1121600, 1084804,
-            1121600, 1084804, 1084804, 1084804, 1084803, 1084804,
-            1084804, 1121600, 1121600, 1084804, 1121600, 1084804,
-            1121600, 1084803, 1084803, 1121600, 1121600, 1121600,
-            1084803, 1084803, 1084803, 1084803, 1084803, 1084803,
-        ],
+    exp_keys = VectorOfVectors(
+        flattened_data=np.array(
+            [ 1084804, 1084803, 1121600, 1084804, 1121600, 1084804,
+              1121600, 1084804, 1084804, 1084804, 1084803, 1084804,
+              1084804, 1121600, 1121600, 1084804, 1121600, 1084804,
+              1121600, 1084803, 1084803, 1121600, 1121600, 1121600,
+              1084803, 1084803, 1084803, 1084803, 1084803, 1084803, ]
+        ),
+        cumulative_length=np.array([30])
     )
     # fmt: on
+    assert tcm_cols.table_key == exp_keys
+
+    # test channel appearing multiple times in single entry
+    tcm_cols, chan_tcms = evt.build_tcm(
+        [(f_raw, [f"{chan}/raw" for chan in lh5.ls(f_raw)])],
+        "timestamp",
+        buffer_len=100,
+        coin_windows=1,
+        channel_views="sparse",
+    )
+    assert tcm_cols.table_key == exp_keys
+    assert set(chan_list) == set(chan_tcms.keys())
+    for entries in chan_tcms.values():
+        entries = np.array([0])
 
 
 def test_build_tcm_multiple_cols(lgnd_test_data):
@@ -220,12 +253,14 @@ def test_build_tcm_write(lgnd_test_data, tmp_dir):
         "lh5/prod-ref-l200/generated/tier/raw/cal/p03/r001/l200-p03-r001-cal-20230318T012144Z-tier_raw.lh5"
     )
     out_file = f"{tmp_dir}/pygama-test-tcm.lh5"
+    channels = ["ch1084803", "ch1084804", "ch1121600"]
     evt.build_tcm(
-        [(f_raw, ["ch1084803/raw", "ch1084804/raw", "ch1121600/raw"])],
+        [(f_raw, [f"{ch}/raw" for ch in channels])],
         "timestamp",
         out_file=out_file,
         out_name="hardware_tcm",
         wo_mode="of",
+        channel_views=None,
     )
 
     assert Path(out_file).exists()
@@ -233,123 +268,112 @@ def test_build_tcm_write(lgnd_test_data, tmp_dir):
     assert isinstance(tcm_cols, lgdo.Struct)
     assert sorted(tcm_cols.keys()) == ["row_in_table", "table_key"]
     # fmt: off
-    assert np.array_equal(
-        tcm_cols.table_key.cumulative_length.nda,
-        [
-            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 14, 15, 16, 17, 18, 19, 20,
-            21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
-        ],
+    exp_keys = VectorOfVectors(
+        cumulative_length = np.array(
+            [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+              21, 22, 23, 24, 25, 26, 27, 28, 29, 30, ],
+        ),
+        flattened_data = np.array(
+            [ 1084804, 1084803, 1121600, 1084804, 1121600, 1084804, 1121600,
+              1084804, 1084804, 1084804, 1084803, 1084804, 1084804, 1121600,
+              1121600, 1084804, 1121600, 1084804, 1121600, 1084803, 1084803,
+              1121600, 1121600, 1121600, 1084803, 1084803, 1084803, 1084803,
+              1084803, 1084803, ]            
+        )
     )
-    assert np.array_equal(
-        tcm_cols.table_key.flattened_data.nda,
-        [
-            1084804, 1084803, 1121600, 1084804, 1121600, 1084804, 1121600,
-            1084804, 1084804, 1084804, 1084803, 1084804, 1084804, 1121600,
-            1121600, 1084804, 1121600, 1084804, 1121600, 1084803, 1084803,
-            1121600, 1121600, 1121600, 1084803, 1084803, 1084803, 1084803,
-            1084803, 1084803,
-        ],
-    )
-    assert np.array_equal(
-        tcm_cols.row_in_table.flattened_data.nda,
-        [
-            0, 0, 0, 1, 1, 2, 2, 3, 4, 5, 1, 6, 7, 3, 4, 8, 5, 9, 6, 2, 3, 7,
-            8, 9, 4, 5, 6, 7, 8, 9,
-        ],
+    exp_rows = VectorOfVectors(
+        cumulative_length = np.array(
+            [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+              21, 22, 23, 24, 25, 26, 27, 28, 29, 30, ],
+        ),
+        flattened_data = np.array(
+            [ 0, 0, 0, 1, 1, 2, 2, 3, 4, 5, 1, 6, 7, 3, 4, 8, 5, 9, 6, 2, 3, 7,
+              8, 9, 4, 5, 6, 7, 8, 9, ]
+        )
     )
     # fmt: on
-    # test also with small buffers
+
+    assert tcm_cols.table_key == exp_keys
+    assert tcm_cols.row_in_table == exp_rows
+
+    # test with views also written
     evt.build_tcm(
-        [(f_raw, ["ch1084803/raw", "ch1084804/raw", "ch1121600/raw"])],
+        [(f_raw, [f"{ch}/raw" for ch in channels])],
         "timestamp",
         out_file=out_file,
         out_name="hardware_tcm",
         wo_mode="of",
-        buffer_len=1,
+        channel_views="sparse",
     )
     assert Path(out_file).exists()
     tcm_cols = lh5.read("hardware_tcm", out_file)
     assert isinstance(tcm_cols, lgdo.Struct)
     assert sorted(tcm_cols.keys()) == ["row_in_table", "table_key"]
-    # fmt: off
-    assert np.array_equal(
-        tcm_cols.table_key.cumulative_length.nda,
-        [
-            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 14, 15, 16, 17, 18, 19, 20,
-            21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
-        ],
-    )
-    assert np.array_equal(
-        tcm_cols.table_key.flattened_data.nda,
-        [
-            1084804, 1084803, 1121600, 1084804, 1121600, 1084804, 1121600,
-            1084804, 1084804, 1084804, 1084803, 1084804, 1084804, 1121600,
-            1121600, 1084804, 1121600, 1084804, 1121600, 1084803, 1084803,
-            1121600, 1121600, 1121600, 1084803, 1084803, 1084803, 1084803,
-            1084803, 1084803,
-        ],
-    )
-    assert np.array_equal(
-        tcm_cols.row_in_table.flattened_data.nda,
-        [
-            0, 0, 0, 1, 1, 2, 2, 3, 4, 5, 1, 6, 7, 3, 4, 8, 5, 9, 6, 2, 3, 7,
-            8, 9, 4, 5, 6, 7, 8, 9,
-        ],
-    )
-    # fmt: on
-    # test also with small buffers
+    assert tcm_cols.table_key == exp_keys
+    assert tcm_cols.row_in_table == exp_rows
+
+    for ch in channels:
+        ch_tcm = lh5.read(f"{ch}/hardware_tcm", out_file)
+        ch_id = int(ch[2:])
+        mask = ak.any(tcm_cols.table_key.view_as('ak') == ch_id, axis=-1)
+        assert ch_tcm == tcm_cols[mask]
+
+    # Test both view modes with small buffers in a fresh output file.
+    small_out_file = f"{tmp_dir}/pygama-test-tcm-small-buffer.lh5"
     evt.build_tcm(
-        [(f_raw, ["ch1084803/raw", "ch1084804/raw", "ch1121600/raw"])],
+        [(f_raw, [f"{ch}/raw" for ch in channels])],
         "timestamp",
-        out_file=out_file,
+        out_file=small_out_file,
         out_name="hardware_tcm",
         wo_mode="of",
         buffer_len=1,
+        channel_views=None,
     )
-    assert Path(out_file).exists()
-    tcm_cols = lh5.read("hardware_tcm", out_file)
+    assert Path(small_out_file).exists()
+    tcm_cols = lh5.read("hardware_tcm", small_out_file)
     assert isinstance(tcm_cols, lgdo.Struct)
     assert sorted(tcm_cols.keys()) == ["row_in_table", "table_key"]
-    # fmt: off
-    assert np.array_equal(
-        tcm_cols.table_key.cumulative_length.nda,
-        [
-            1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 13, 14, 15, 16, 17, 18, 19, 20,
-            21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
-        ],
+
+    assert tcm_cols.table_key == exp_keys
+    assert tcm_cols.row_in_table == exp_rows
+
+    # test with sparse views and small buffers
+    evt.build_tcm(
+        [(f_raw, [f"{ch}/raw" for ch in channels])],
+        "timestamp",
+        out_file=small_out_file,
+        out_name="hardware_tcm",
+        wo_mode="of",
+        buffer_len=1,
+        channel_views="sparse",
     )
-    assert np.array_equal(
-        tcm_cols.table_key.flattened_data.nda,
-        [
-            1084804, 1084803, 1121600, 1084804, 1121600, 1084804, 1121600,
-            1084804, 1084804, 1084804, 1084803, 1084804, 1084804, 1121600,
-            1121600, 1084804, 1121600, 1084804, 1121600, 1084803, 1084803,
-            1121600, 1121600, 1121600, 1084803, 1084803, 1084803, 1084803,
-            1084803, 1084803,
-        ],
-    )
-    assert np.array_equal(
-        tcm_cols.row_in_table.flattened_data.nda,
-        [
-            0, 0, 0, 1, 1, 2, 2, 3, 4, 5, 1, 6, 7, 3, 4, 8, 5, 9, 6, 2, 3, 7,
-            8, 9, 4, 5, 6, 7, 8, 9,
-        ],
-    )
-    # fmt: on
+    assert Path(small_out_file).exists()
+    tcm_cols = lh5.read("hardware_tcm", small_out_file)
+    assert isinstance(tcm_cols, lgdo.Struct)
+    assert sorted(tcm_cols.keys()) == ["row_in_table", "table_key"]
+    assert tcm_cols.table_key == exp_keys
+    assert tcm_cols.row_in_table == exp_rows
+
+    for ch in channels:
+        ch_tcm = lh5.read(f"{ch}/hardware_tcm", small_out_file)
+        ch_id = int(ch[2:])
+        mask = ak.any(tcm_cols.table_key.view_as("ak") == ch_id, axis=-1)
+        assert ch_tcm == tcm_cols[mask]
 
     # test append to input file
     clone = f"{tmp_dir}/test-append-tcm-input.lh5"
     tables = ["ch1084803/raw", "ch1084804/raw", "ch1121600/raw"]
 
-    for table in tables:
-        lh5.write(lh5.read(table, f_raw), table, clone)
+    with lh5.LH5Store(keep_open=True, default_mode='of') as st:
+        for table in tables:
+            st.write(lh5.read(table, f_raw), table, clone)
 
     evt.build_tcm(
         [(clone, tables)],
         "timestamp",
         out_file=clone,
         out_name="/tcm",
-        wo_mode="write_safe",
+        wo_mode="a",
         buffer_len=1,
     )
     assert Path(clone).exists()
@@ -407,3 +431,210 @@ def test_build_tcm_buffer_reuse_copy_regression(lgnd_test_data):
 
     assert tcm_small.fields == tcm_large.fields
     assert all(ak.all(tcm_small[f] == tcm_large[f]) for f in tcm_small.fields)
+
+
+# Test with phy data (non-sparse mode); most important for views in dense/all modes
+def test_build_tcm_phy(lgnd_test_data):
+    f_raw = lgnd_test_data.get_path(
+        "lh5/prod-ref-l200/generated/tier/raw/phy/p03/r001/l200-p03-r001-phy-20230322T160139Z-tier_raw.lh5"
+    )
+    channels = ["ch1084803", "ch1084804", "ch1121600"]
+
+    tcm_cols = evt.build_tcm(
+        [(f_raw, [f"{ch}/raw" for ch in channels])],
+        "timestamp",
+        out_name="tcm",
+        wo_mode="of",
+        channel_views=None,
+    )
+
+    # fmt: off
+    exp_keys = VectorOfVectors(
+        cumulative_length = np.arange(1, 11)*3,
+        flattened_data = np.tile([1084803,1084804,1121600], 10)
+    )
+    exp_rows = VectorOfVectors(
+        cumulative_length = np.arange(1, 11)*3,
+        flattened_data = np.repeat(np.arange(10), 3)
+    )
+    # fmt: on
+
+    assert tcm_cols.table_key == exp_keys
+    assert tcm_cols.row_in_table == exp_rows
+
+    # Now test with views in "all" mode
+    (tcm_cols, chan_tcms) = evt.build_tcm(
+        [(f_raw, [f"{ch}/raw" for ch in channels])],
+        "timestamp",
+        out_name="tcm",
+        wo_mode="of",
+        channel_views="all",
+    )
+
+    assert tcm_cols.table_key == exp_keys
+    assert tcm_cols.row_in_table == exp_rows
+
+    assert set(channels) == set(chan_tcms.keys())
+    assert all(np.issubdtype(v.dtype, np.integer) for v in chan_tcms.values())
+    assert all(np.all(v == np.array([0,10])) for v in chan_tcms.values())
+
+    # Now test with views in "all" mode with short buffer
+    (tcm_cols, chan_tcms) = evt.build_tcm(
+        [(f_raw, [f"{ch}/raw" for ch in channels])],
+        "timestamp",
+        out_name="tcm",
+        wo_mode="of",
+        buffer_len=1,
+        channel_views="all",
+    )
+
+    assert tcm_cols.table_key == exp_keys
+    assert tcm_cols.row_in_table == exp_rows
+
+    assert set(channels) == set(chan_tcms.keys())
+    assert all(np.issubdtype(v.dtype, np.integer) for v in chan_tcms.values())
+    assert all(np.all(v == np.array([0,10])) for v in chan_tcms.values())
+
+    # Now test with views in "dense" mode
+    (tcm_cols, chan_tcms) = evt.build_tcm(
+        [(f_raw, [f"{ch}/raw" for ch in channels])],
+        "timestamp",
+        out_name="tcm",
+        wo_mode="of",
+        channel_views="dense",
+    )
+
+    assert tcm_cols.table_key == exp_keys
+    assert tcm_cols.row_in_table == exp_rows
+
+    assert set(channels) == set(chan_tcms.keys())
+    assert all(np.issubdtype(v.dtype, np.integer) for v in chan_tcms.values())
+    assert all(np.all(v == np.array([0,10])) for v in chan_tcms.values())
+
+    # Now test with views in "dense" mode with short buffer
+    (tcm_cols, chan_tcms) = evt.build_tcm(
+        [(f_raw, [f"{ch}/raw" for ch in channels])],
+        "timestamp",
+        out_name="tcm",
+        wo_mode="of",
+        buffer_len=1,
+        channel_views="dense",
+    )
+    assert tcm_cols.table_key == exp_keys
+    assert tcm_cols.row_in_table == exp_rows
+
+    assert set(channels) == set(chan_tcms.keys())
+    assert all(np.issubdtype(v.dtype, np.integer) for v in chan_tcms.values())
+    assert all(np.all(v == np.stack([np.arange(10), np.arange(1, 11)], axis=1)) for v in chan_tcms.values())
+
+# Test with phy data (non-sparse mode); most important for views in dense/all modes
+def test_build_tcm_write_phy(lgnd_test_data, tmp_dir):
+    f_raw = lgnd_test_data.get_path(
+        "lh5/prod-ref-l200/generated/tier/raw/phy/p03/r001/l200-p03-r001-phy-20230322T160139Z-tier_raw.lh5"
+    )
+    out_file = f"{tmp_dir}/pygama-test-tcm-phy.lh5"
+    channels = ["ch1084803", "ch1084804", "ch1121600"]
+
+    evt.build_tcm(
+        [(f_raw, [f"{ch}/raw" for ch in channels])],
+        "timestamp",
+        out_file=out_file,
+        out_name="tcm",
+        wo_mode="of",
+        channel_views=None,
+    )
+
+    assert Path(out_file).exists()
+    tcm_cols = lh5.read("tcm", out_file)
+
+    # fmt: off
+    exp_keys = VectorOfVectors(
+        cumulative_length = np.arange(1, 11)*3,
+        flattened_data = np.tile([1084803,1084804,1121600], 10)
+    )
+    exp_rows = VectorOfVectors(
+        cumulative_length = np.arange(1, 11)*3,
+        flattened_data = np.repeat(np.arange(10), 3)
+    )
+    # fmt: on
+
+    assert tcm_cols.table_key == exp_keys
+    assert tcm_cols.row_in_table == exp_rows
+
+    # Now test with views in "all" mode
+    evt.build_tcm(
+        [(f_raw, [f"{ch}/raw" for ch in channels])],
+        "timestamp",
+        out_file=out_file,
+        out_name="tcm",
+        wo_mode="of",
+        channel_views="all",
+    )
+    assert Path(out_file).exists()
+    tcm_cols = lh5.read("tcm", out_file)
+    assert tcm_cols.table_key == exp_keys
+    assert tcm_cols.row_in_table == exp_rows
+
+    for ch in channels:
+        ch_tcm = lh5.read(f"{ch}/tcm", out_file)
+        assert ch_tcm.table_key == exp_keys
+        assert ch_tcm.row_in_table == exp_rows
+
+    # Now test with views in "all" mode with short buffer
+    evt.build_tcm(
+        [(f_raw, [f"{ch}/raw" for ch in channels])],
+        "timestamp",
+        out_file=out_file,
+        out_name="tcm",
+        wo_mode="of",
+        buffer_len=1,
+        channel_views="all",
+    )
+    assert Path(out_file).exists()
+    tcm_cols = lh5.read("tcm", out_file)
+    assert tcm_cols.table_key == exp_keys
+    assert tcm_cols.row_in_table == exp_rows
+
+    for ch in channels:
+        ch_tcm = lh5.read(f"{ch}/tcm", out_file)
+        assert ch_tcm.table_key == exp_keys
+        assert ch_tcm.row_in_table == exp_rows
+
+    # Now test with views in "dense" mode
+    evt.build_tcm(
+        [(f_raw, [f"{ch}/raw" for ch in channels])],
+        "timestamp",
+        out_file=out_file,
+        out_name="tcm",
+        wo_mode="of",
+        channel_views="dense",
+    )
+    assert Path(out_file).exists()
+    tcm_cols = lh5.read("tcm", out_file)
+    assert tcm_cols.table_key == exp_keys
+    assert tcm_cols.row_in_table == exp_rows
+
+    for ch in channels:
+        ch_tcm = lh5.read(f"{ch}/tcm", out_file)
+        assert ch_tcm.table_key == exp_keys
+        assert ch_tcm.row_in_table == exp_rows
+
+    # Now test with views in "dense" mode with short buffer
+    evt.build_tcm(
+        [(f_raw, [f"{ch}/raw" for ch in channels])],
+        "timestamp",
+        out_file=out_file,
+        out_name="tcm",
+        wo_mode="of",
+        buffer_len=1,
+        channel_views="dense",
+    )
+    assert Path(out_file).exists()
+    tcm_cols = lh5.read("tcm", out_file)
+    assert tcm_cols.table_key == exp_keys
+    assert tcm_cols.row_in_table == exp_rows
+
+    for ch in channels:
+        ch_tcm = lh5.read(f"{ch}/tcm", out_file)
+        assert ch_tcm.table_key == exp_keys
+        assert ch_tcm.row_in_table == exp_rows

--- a/tests/evt/test_build_tcm.py
+++ b/tests/evt/test_build_tcm.py
@@ -49,7 +49,7 @@ def test_generate_tcm_cols(lgnd_test_data):
               1084804, 1084804, 1084804, 1084803, 1084804, 1084804, 1121600,
               1121600, 1084804, 1121600, 1084804, 1121600, 1084803, 1084803,
               1121600, 1121600, 1121600, 1084803, 1084803, 1084803, 1084803,
-              1084803, 1084803, ]            
+              1084803, 1084803, ]
         )
     )
     exp_rows = VectorOfVectors(
@@ -67,7 +67,6 @@ def test_generate_tcm_cols(lgnd_test_data):
     assert tcm_cols.table_key == exp_keys
     assert tcm_cols.row_in_table == exp_rows
 
-
     # Test with sparse views enabled
     (tcm_cols2, chan_tcms) = evt.build_tcm(
         [(f_raw, "ch*/raw")],
@@ -83,7 +82,12 @@ def test_generate_tcm_cols(lgnd_test_data):
     assert all(np.issubdtype(v.dtype, np.integer) for v in chan_tcms.values())
     for chan_name, entries in chan_tcms.items():
         chan_id = int(chan_name[2:])
-        assert np.all(entries == np.flatnonzero(np.any(tcm_cols2.table_key.view_as('ak') == chan_id, axis=-1)))
+        assert np.all(
+            entries
+            == np.flatnonzero(
+                np.any(tcm_cols2.table_key.view_as("ak") == chan_id, axis=-1)
+            )
+        )
 
     # test with small buffer len
     tcm_cols = evt.build_tcm(
@@ -132,12 +136,16 @@ def test_generate_tcm_cols(lgnd_test_data):
     assert tcm_cols2.table_key == exp_idxs
     assert tcm_cols2.row_in_table == exp_rows
 
-    assert { f"ch{i}" for i in range(3) } == set(chan_tcms.keys())
+    assert {f"ch{i}" for i in range(3)} == set(chan_tcms.keys())
     assert all(np.issubdtype(v.dtype, np.integer) for v in chan_tcms.values())
     for chan_name, entries in chan_tcms.items():
         chan_id = int(chan_name[2:])
-        assert np.all(entries == np.flatnonzero(np.any(tcm_cols2.table_key.view_as('ak') == chan_id, axis=-1)))
-
+        assert np.all(
+            entries
+            == np.flatnonzero(
+                np.any(tcm_cols2.table_key.view_as("ak") == chan_id, axis=-1)
+            )
+        )
 
     # test invalid hash func
     with pytest.raises(NotImplementedError):
@@ -278,7 +286,7 @@ def test_build_tcm_write(lgnd_test_data, tmp_dir):
               1084804, 1084804, 1084804, 1084803, 1084804, 1084804, 1121600,
               1121600, 1084804, 1121600, 1084804, 1121600, 1084803, 1084803,
               1121600, 1121600, 1121600, 1084803, 1084803, 1084803, 1084803,
-              1084803, 1084803, ]            
+              1084803, 1084803, ]
         )
     )
     exp_rows = VectorOfVectors(
@@ -315,7 +323,7 @@ def test_build_tcm_write(lgnd_test_data, tmp_dir):
     for ch in channels:
         ch_tcm = lh5.read(f"{ch}/hardware_tcm", out_file)
         ch_id = int(ch[2:])
-        mask = ak.any(tcm_cols.table_key.view_as('ak') == ch_id, axis=-1)
+        mask = ak.any(tcm_cols.table_key.view_as("ak") == ch_id, axis=-1)
         assert ch_tcm == tcm_cols[mask]
 
     # Test both view modes with small buffers in a fresh output file.
@@ -364,7 +372,7 @@ def test_build_tcm_write(lgnd_test_data, tmp_dir):
     clone = f"{tmp_dir}/test-append-tcm-input.lh5"
     tables = ["ch1084803/raw", "ch1084804/raw", "ch1121600/raw"]
 
-    with lh5.LH5Store(keep_open=True, default_mode='of') as st:
+    with lh5.LH5Store(keep_open=True, default_mode="of") as st:
         for table in tables:
             st.write(lh5.read(table, f_raw), table, clone)
 
@@ -476,7 +484,7 @@ def test_build_tcm_phy(lgnd_test_data):
 
     assert set(channels) == set(chan_tcms.keys())
     assert all(np.issubdtype(v.dtype, np.integer) for v in chan_tcms.values())
-    assert all(np.all(v == np.array([0,10])) for v in chan_tcms.values())
+    assert all(np.all(v == np.array([0, 10])) for v in chan_tcms.values())
 
     # Now test with views in "all" mode with short buffer
     (tcm_cols, chan_tcms) = evt.build_tcm(
@@ -493,7 +501,7 @@ def test_build_tcm_phy(lgnd_test_data):
 
     assert set(channels) == set(chan_tcms.keys())
     assert all(np.issubdtype(v.dtype, np.integer) for v in chan_tcms.values())
-    assert all(np.all(v == np.array([0,10])) for v in chan_tcms.values())
+    assert all(np.all(v == np.array([0, 10])) for v in chan_tcms.values())
 
     # Now test with views in "dense" mode
     (tcm_cols, chan_tcms) = evt.build_tcm(
@@ -509,7 +517,7 @@ def test_build_tcm_phy(lgnd_test_data):
 
     assert set(channels) == set(chan_tcms.keys())
     assert all(np.issubdtype(v.dtype, np.integer) for v in chan_tcms.values())
-    assert all(np.all(v == np.array([0,10])) for v in chan_tcms.values())
+    assert all(np.all(v == np.array([0, 10])) for v in chan_tcms.values())
 
     # Now test with views in "dense" mode with short buffer
     (tcm_cols, chan_tcms) = evt.build_tcm(
@@ -525,7 +533,11 @@ def test_build_tcm_phy(lgnd_test_data):
 
     assert set(channels) == set(chan_tcms.keys())
     assert all(np.issubdtype(v.dtype, np.integer) for v in chan_tcms.values())
-    assert all(np.all(v == np.stack([np.arange(10), np.arange(1, 11)], axis=1)) for v in chan_tcms.values())
+    assert all(
+        np.all(v == np.stack([np.arange(10), np.arange(1, 11)], axis=1))
+        for v in chan_tcms.values()
+    )
+
 
 # Test with phy data (non-sparse mode); most important for views in dense/all modes
 def test_build_tcm_write_phy(lgnd_test_data, tmp_dir):


### PR DESCRIPTION
This is a work in progress.

Added to build_tcm the ability to write Views (https://legend-exp.github.io/legend-data-format-specs/dev/hdf5/#Views) to tcm files. A channel view will be called something like `ch#/tcm`, and will contain only the events that contain that channel. This table can then be directly joined to tables from other tiers, even in cases like cal data. Example:
<img width="930" height="887" alt="image" src="https://github.com/user-attachments/assets/0336817e-dab7-4674-9f96-b0bcdd2d37d3" />

When creating the views, there are four options:
1) (default) do not create the views (this is the default to maintain previous behavior)
2) "sparse" view that encodes the view using a list of entries; use this for data taken in sparse mode
3) "dense" view that encodes the view using lists of ranges
4) "all" view that uses a single range covering the full tcm table; use this for non-sparse mode

Tests were added for all of these modes, and with/without writing of files.

Other changes to TCM:
1) Use LH5Store to avoid opening and closing files over and over again during writes
2) Use Table.append to build up the table rather than concatenating at the end

This pull request depends on https://github.com/legend-exp/legend-lh5io/pull/47 and https://github.com/legend-exp/legend-lh5io/pull/48

Next steps: add views to build_evt. This is simple; we can just copy the entry lists over to create new views without having to recalculate