### PR TITLE
fix(pargen): parameterise suffix-blind LQ plot functions

### DIFF
--- a/src/pygama/pargen/lq_cal.py
+++ b/src/pygama/pargen/lq_cal.py
@@ -900,7 +900,7 @@ class LQCal:
 def plot_lq_mean_time(
     lq_class,
     data,  # noqa: ARG001
-    lq_param="LQ_Timecorr",  # noqa: ARG001
+    lq_param="LQ_Timecorr",
     figsize=(12, 8),
     fontsize=12,
 ) -> plt.figure:
@@ -921,7 +921,7 @@ def plot_lq_mean_time(
         )
 
         grouped_means = [
-            cal_dict["LQ_Timecorr"]["parameters"]["a"]
+            cal_dict[lq_param]["parameters"]["a"]
             for tstamp, cal_dict in lq_class.cal_dicts.items()
         ]
         ax.step(
@@ -1111,7 +1111,13 @@ def plot_survival_fraction_curves(
 
 
 def plot_sf_vs_energy(
-    lq_class, data, xrange=(900, 3000), n_bins=701, figsize=(12, 8), fontsize=12
+    lq_class,
+    data,
+    cut_param="LQ_Cut",
+    xrange=(900, 3000),
+    n_bins=701,
+    figsize=(12, 8),
+    fontsize=12,
 ) -> plt.figure:
     """Plots the survival fraction as a function of energy"""
 
@@ -1122,7 +1128,7 @@ def plot_sf_vs_energy(
     try:
         bins = np.linspace(xrange[0], xrange[1], n_bins)
         counts_pass, bins_pass, _ = pgh.get_hist(
-            data.query(f"{lq_class.selection_string}&LQ_Cut")[
+            data.query(f"{lq_class.selection_string}&{cut_param}")[
                 lq_class.cal_energy_param
             ],
             bins=bins,
@@ -1148,6 +1154,7 @@ def plot_sf_vs_energy(
 def plot_spectra(
     lq_class,
     data,
+    cut_param="LQ_Cut",
     xrange=(900, 3000),
     n_bins=2101,
     xrange_inset=(1580, 1640),
@@ -1178,7 +1185,7 @@ def plot_spectra(
         #     label="after double sided A/E cut",
         # )
         ax.hist(
-            data.query(f"{lq_class.selection_string}&LQ_Cut")[
+            data.query(f"{lq_class.selection_string}&{cut_param}")[
                 lq_class.cal_energy_param
             ],
             bins=bins,
@@ -1186,7 +1193,7 @@ def plot_spectra(
             label="after LQ cut",
         )
         ax.hist(
-            data.query(f"{lq_class.selection_string} & (~LQ_Cut)")[
+            data.query(f"{lq_class.selection_string} & (~{cut_param})")[
                 lq_class.cal_energy_param
             ],
             bins=bins,
@@ -1212,14 +1219,14 @@ def plot_spectra(
         #     histtype="step",
         # )
         axins.hist(
-            select_df.query(f"{lq_class.selection_string}&LQ_Cut")[
+            select_df.query(f"{lq_class.selection_string}&{cut_param}")[
                 lq_class.cal_energy_param
             ],
             bins=bins,
             histtype="step",
         )
         axins.hist(
-            select_df.query(f"{lq_class.selection_string} & (~LQ_Cut)")[
+            select_df.query(f"{lq_class.selection_string} & (~{cut_param})")[
                 lq_class.cal_energy_param
             ],
             bins=bins,

--- a/src/pygama/pargen/lq_cal.py
+++ b/src/pygama/pargen/lq_cal.py
@@ -1113,11 +1113,11 @@ def plot_survival_fraction_curves(
 def plot_sf_vs_energy(
     lq_class,
     data,
-    cut_param="LQ_Cut",
     xrange=(900, 3000),
     n_bins=701,
     figsize=(12, 8),
     fontsize=12,
+    cut_param="LQ_Cut",
 ) -> plt.figure:
     """Plots the survival fraction as a function of energy"""
 
@@ -1154,13 +1154,13 @@ def plot_sf_vs_energy(
 def plot_spectra(
     lq_class,
     data,
-    cut_param="LQ_Cut",
     xrange=(900, 3000),
     n_bins=2101,
     xrange_inset=(1580, 1640),
     n_bins_inset=200,
     figsize=(12, 8),
     fontsize=12,
+    cut_param="LQ_Cut",
 ) -> plt.figure:
     """Plots a 2D histogram of the LQ classifier vs calibrated energy"""
 

--- a/tests/pargen/test_lqcal.py
+++ b/tests/pargen/test_lqcal.py
@@ -86,3 +86,12 @@ def test_lq_cal_suffix(lgnd_test_data):
     assert "LQ_Classifier_alt" in data_df
     assert "LQ_Cut_alt" in data_df
     assert cal_dict["LQ_Cut_alt"]["expression"] == "(LQ_Classifier_alt < a)"
+
+    # the plot helpers must be steerable to the suffixed cut: only the
+    # suffixed columns exist here, so with the default cut_param the queries
+    # fail (swallowed) and the pass/fail histograms never get drawn
+    fig = lq.plot_spectra(lqcal, data_df, cut_param="LQ_Cut_alt")
+    assert len(fig.axes[0].patches) >= 3
+    fig = lq.plot_sf_vs_energy(lqcal, data_df, cut_param="LQ_Cut_alt")
+    assert fig.axes
+    assert len(fig.axes[0].lines) == 1


### PR DESCRIPTION
Follow-up to the `suffix` support in `LQCal.calibrate()` (#707): three LQ plot helpers were still hardwired to the unsuffixed parameter names, so for a suffixed calibration they silently plotted the default parameter's results instead:

- `plot_sf_vs_energy` and `plot_spectra` hardcoded `LQ_Cut` in their queries — both now take a `cut_param="LQ_Cut"` kwarg;
- `plot_lq_mean_time` accepted `lq_param` but ignored it (`noqa: ARG001`), reading the `LQ_Timecorr` cal-dict key directly — it now uses the argument.

Defaults are unchanged, so existing callers are unaffected. `test_lq_cal_suffix` is extended to assert the plots actually draw from the suffixed cut column (with only suffixed columns present, the old hardcoded queries fail and the pass/fail histograms are never drawn, so the artist counts distinguish the two).

Needed by legend-exp/legend-dataflow-config#150, which passes the suffixed names through `plot_options` for the new `lq_amax`/`lq95` calibration entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)